### PR TITLE
In convertMedia.ts, images and illustrations are optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@ node_modules
 src/config.js
 data/*
 !data/.empty
-static/sab-stylesheet.css
 static/fonts
 static/images
 static/audio
+static/styles
+static/illustrations

--- a/scripts/convertMedia.ts
+++ b/scripts/convertMedia.ts
@@ -1,13 +1,28 @@
-import { copyFileSync, cpSync } from 'fs';
+import { CopyOptions, cpSync } from 'fs';
 import path from 'path';
 
+function cpSyncOptional(source: string, destination: string, opts?: CopyOptions): void {
+    try {
+        cpSync(source, destination, opts);
+    } catch (e) {
+        // source doesn't exist, ok.
+    }
+}
+
 export function convertMedia(dataDir: string) {
-    // Copy the css stylesheet
-    copyFileSync(path.join(dataDir, 'sab-stylesheet.css'), path.join('static'));
+    // Copy the css stylesheets
+    cpSync(path.join(dataDir, 'styles'), path.join('static', 'styles'), { recursive: true });
 
     // Copy the font files
-    cpSync(path.join(dataDir, 'fonts'), path.join('static'), { recursive: true });
+    cpSync(path.join(dataDir, 'fonts'), path.join('static', 'fonts'), { recursive: true });
 
     // Copy the images
-    cpSync(path.join(dataDir, 'images'), path.join('static'), { recursive: true });
+    cpSyncOptional(path.join(dataDir, 'images'), path.join('static', 'images'), {
+        recursive: true
+    });
+
+    // Copy the illustrations
+    cpSyncOptional(path.join(dataDir, 'illustrations'), path.join('static', 'illustrations'), {
+        recursive: true
+    });
 }


### PR DESCRIPTION
* Before, if there were no images, then the conversion would fail
  with a trackback in the output.
* Add illustrations as optional media files to process