### PR TITLE
fixed bug with prev reference property

### DIFF
--- a/src/lib/data/store-types.js
+++ b/src/lib/data/store-types.js
@@ -66,7 +66,7 @@ export const referenceStore = () => {
             const i = codes.indexOf($internal.b);
             const chapters = Object.keys(books[i].versesByChapters);
             const j = chapters.indexOf($internal.c);
-            if (j - 1 <= 0) {
+            if (j <= 0) {
                 if (i - 1 >= 0) {
                     prevBook = codes[i - 1];
                     const c2 = Object.keys(books[i - 1].versesByChapters);


### PR DESCRIPTION
The prev property of referenceStore had a bug where it would not find the previous chapter if the current chapter was 2.
TL;DR: off by one error.