### PR TITLE
Add stores to allow text size and line spacing changes to be viewed

### DIFF
--- a/src/lib/components/ScriptureView.svelte
+++ b/src/lib/components/ScriptureView.svelte
@@ -94,10 +94,10 @@ TODO:
     $: updateHighlight($audioHighlight);
 
     let fontSize = '17px';
-    $: fontSize = $bodyFontSize;
+    $: fontSize = $bodyFontSize + 'px';
 
     let lineHeight = '175%';
-    $: lineHeight = $bodyLineHeight;
+    $: lineHeight = $bodyLineHeight + '%';
 
     onDestroy(unSub);
 

--- a/src/lib/components/ScriptureView.svelte
+++ b/src/lib/components/ScriptureView.svelte
@@ -93,10 +93,8 @@ TODO:
     };
     $: updateHighlight($audioHighlight);
 
-    let fontSize = '17px';
     $: fontSize = $bodyFontSize + 'px';
 
-    let lineHeight = '175%';
     $: lineHeight = $bodyLineHeight + '%';
 
     onDestroy(unSub);

--- a/src/lib/components/ScriptureView.svelte
+++ b/src/lib/components/ScriptureView.svelte
@@ -11,7 +11,15 @@ TODO:
 <script lang="ts">
     import { query } from '../scripts/query';
     import { onDestroy } from 'svelte';
-    import { audioHighlight, refs, scrolls, audioActive, mainScroll } from '$lib/data/stores';
+    import {
+        audioHighlight,
+        refs,
+        scrolls,
+        audioActive,
+        mainScroll,
+        bodyFontSize,
+        bodyLineHeight
+    } from '$lib/data/stores';
     import { renderDoc } from '../scripts/render';
     import { LoadingIcon } from '../icons';
 
@@ -84,6 +92,12 @@ TODO:
             el?.scrollIntoView();
     };
     $: updateHighlight($audioHighlight);
+
+    let fontSize = '17px';
+    $: fontSize = $bodyFontSize;
+
+    let lineHeight = '175%';
+    $: lineHeight = $bodyLineHeight;
 
     onDestroy(unSub);
 
@@ -167,5 +181,10 @@ TODO:
     {#if loading}
         <LoadingIcon />
     {/if}
-    <div bind:this={bookRoot} class:hidden={loading} />
+    <div
+        bind:this={bookRoot}
+        class:hidden={loading}
+        style:font-size={fontSize}
+        style:line-height={lineHeight}
+    />
 </article>

--- a/src/lib/data/stores.js
+++ b/src/lib/data/stores.js
@@ -27,3 +27,7 @@ export const audioHighlight = (() => {
 })();
 /**scrollTop of main window*/
 export const mainScroll = writable({ top: 0, height: 0});
+/**Font size of body elements */
+export const bodyFontSize = writable('17px');
+/**line height of body elements */
+export const bodyLineHeight = writable('175%');

--- a/src/lib/data/stores.js
+++ b/src/lib/data/stores.js
@@ -28,6 +28,6 @@ export const audioHighlight = (() => {
 /**scrollTop of main window*/
 export const mainScroll = writable({ top: 0, height: 0});
 /**Font size of body elements */
-export const bodyFontSize = writable('17px');
+export const bodyFontSize = writable('17');
 /**line height of body elements */
-export const bodyLineHeight = writable('175%');
+export const bodyLineHeight = writable('175');


### PR DESCRIPTION
Adding store variables that will allow the text size and line height to be changed immediately.
ScriptureRender is being rewritten for Sofia at the moment, so where these variables may be used in the final version may differ.  But the store that's affected, and will need to be updated by the text view popup, will be the same so that the team working on that feature can see the text change immediately.

To change the font size or line height from a component:
    import {
        bodyFontSize,
        bodyLineHeight
    } from '$lib/data/stores';


            $bodyFontSize = '30px';
            $bodyLineHeight = '300%';

Still to be done (not in this PR): get initial values from configuration
