### PR TITLE
Fix inclusion of tailwind css directives

### DIFF
--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -1,0 +1,6 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+}

--- a/src/lib/components/ScrolledContent.svelte
+++ b/src/lib/components/ScrolledContent.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import '../../tailwind.css';
     import { mainScroll } from '$lib/data/stores';
     import { onMount } from 'svelte';
     let main: HTMLElement;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import Sidebar from '$lib/components/Sidebar.svelte';
+    import '$lib/app.css';
 </script>
 
 <Sidebar>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,6 @@
     import CollectionSelector from '$lib/components/CollectionSelector.svelte';
     import Dropdown from '$lib/components/Dropdown.svelte';
     import ScrolledContent from '$lib/components/ScrolledContent.svelte';
-    import '../tailwind.css';
     import { audioActive } from '$lib/data/stores';
     import { AudioIcon, SearchIcon, TextAppearanceIcon } from '$lib/icons';
     import Navbar from '$lib/components/Navbar.svelte';

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -3,7 +3,6 @@
     // Check kit.svelte.dev docs (Language Forge examples)
     import { onMount } from 'svelte';
     import ScrolledContent from '$lib/components/ScrolledContent.svelte';
-    import '../../tailwind.css';
     import Navbar from '$lib/components/Navbar.svelte';
 
     var partial: string;

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -2,7 +2,6 @@
     // Mark this as prerender?
     // Check kit.svelte.dev docs (Language Forge examples)
     import ScrolledContent from '$lib/components/ScrolledContent.svelte';
-    import '../../tailwind.css';
     import Navbar from '$lib/components/Navbar.svelte';
 </script>
 

--- a/src/routes/bookmarks/+page.svelte
+++ b/src/routes/bookmarks/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import IconCard from '$lib/components/IconCard.svelte';
     import { BookmarkIcon } from '$lib/icons';
-    import '../../tailwind.css';
     import Navbar from '$lib/components/Navbar.svelte';
     import ScrolledContent from '$lib/components/ScrolledContent.svelte';
     let bookmarks = [

--- a/src/routes/highlights/+page.svelte
+++ b/src/routes/highlights/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import ColorCard from '$lib/components/ColorCard.svelte';
-    import '../../tailwind.css';
     import Navbar from '$lib/components/Navbar.svelte';
     import ScrolledContent from '$lib/components/ScrolledContent.svelte';
 

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import HistoryCard from '$lib/components/HistoryCard.svelte';
     import ScrolledContent from '$lib/components/ScrolledContent.svelte';
-    import '../../tailwind.css';
     import Navbar from '$lib/components/Navbar.svelte';
     let history = [
         { book: 'World English Bible', reference: 'Genesis 1', date: 'Today | 14:49' },

--- a/src/routes/notes/+page.svelte
+++ b/src/routes/notes/+page.svelte
@@ -2,7 +2,6 @@
     import IconCard from '$lib/components/IconCard.svelte';
     import { NoteIcon } from '$lib/icons';
     import ScrolledContent from '$lib/components/ScrolledContent.svelte';
-    import '../../tailwind.css';
     import Navbar from '$lib/components/Navbar.svelte';
     let notes = [
         {

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -3,7 +3,6 @@
     import { refs } from '$lib/data/stores';
     import { query } from '$lib/scripts/query';
     import { postQueries, queries } from 'proskomma-tools';
-    import '../../tailwind.css';
     import { SearchIcon } from '$lib/icons';
     import Navbar from '$lib/components/Navbar.svelte';
 

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    import '../../tailwind.css';
     import Navbar from '$lib/components/Navbar.svelte';
     import ScrolledContent from '$lib/components/ScrolledContent.svelte';
     // TODO: link config to settings, make settings actually matter


### PR DESCRIPTION
* match what web-languageforge does:
- next-app/src/lib/app.css
- next-app/src/routes/+layout.svelte