### PR TITLE
Add $refs.collection property derived from $refs.docSet

### DIFF
--- a/src/lib/data/store-types.js
+++ b/src/lib/data/store-types.js
@@ -36,6 +36,7 @@ export const referenceStore = () => {
     const external = derived(internal, ($internal) => ({
         reference: `${$internal.b} ${$internal.c}${$internal.n ? '' : ':' + $internal.n}`,
         docSet: $internal.ds,
+        collection: $internal.ds.split('_')[1],
         book: $internal.b,
         chapter: $internal.c,
         chapterVerses: `${$internal.c}:1-${$internal.n}`,


### PR DESCRIPTION
The collection id can be derived from $refs.docSet so add a property to $refs for it.

I see places in code for another PR where they are doing:

```
const colId = $refs.docSet.split('_')[1];
```

And then using the colId to look in config.  This should be part of $refs.