### PR TITLE
Fix hover state on mobile

### DIFF
--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -4,3 +4,12 @@
 
 @layer base {
 }
+
+/* https://github.com/saadeghi/daisyui/issues/1450 */
+/* When tapping on the appbar buttons, the hover state sticks sometimes */
+@media (hover: none) {
+    .btn.btn-outline:hover {
+        background-color: transparent;
+        color: inherit;
+    }
+}


### PR DESCRIPTION
When tapping on buttons on mobile, the button's hover state was sticking and looked like the button still had focus.