### PR TITLE
Delete old files before copying new files in convertMedia.ts

### DIFF
--- a/scripts/convertMedia.ts
+++ b/scripts/convertMedia.ts
@@ -15,17 +15,15 @@ function cpSyncOptional(source: string, destination: string, opts?: CopyOptions)
  * Copies styles, fonts, images, illustrations, audio, and timings from supplied data folder to static.
  */
 export function convertMedia(dataDir: string, verbose: number) {
-    // Copy the css stylesheets
-    cpSync(path.join(dataDir, 'styles'), path.join('static', 'styles'), { recursive: true });
-    if (verbose)
-        console.log(`copied ${path.join(dataDir, 'styles')} to ${path.join('static', 'styles')}`);
+    const requiredPaths = [
+        'styles',
+        'fonts'
+    ];
+    for(let p of requiredPaths) {
+        copyDirectory(path.join(dataDir, p), path.join('static', p), verbose, false);
+    }
 
-    // Copy the font files
-    cpSync(path.join(dataDir, 'fonts'), path.join('static', 'fonts'), { recursive: true });
-    if (verbose)
-        console.log(`copied ${path.join(dataDir, 'fonts')} to ${path.join('static', 'fonts')}`);
-
-    const paths = [
+    const optionalPaths = [
         'images',
         'illustrations',
         'audio',
@@ -37,15 +35,20 @@ export function convertMedia(dataDir: string, verbose: number) {
         'videos',
         'icons'
     ];
-    for (const p of paths) {
-        doCopyForRoute(path.join(dataDir, p), path.join('static', p), verbose);
+    for (const p of optionalPaths) {
+        copyDirectory(path.join(dataDir, p), path.join('static', p), verbose, true);
     }
 }
 
-function doCopyForRoute(from: string, to: string, verbose: number) {
-    if(cpSyncOptional(from, to, { recursive: true })) {
+function copyDirectory(from: string, to: string, verbose: number, optional: boolean) {
+    if(optional) {
+        if(cpSyncOptional(from, to, { recursive: true })) {
+            if (verbose) console.log(`copied ${from} to ${to}`);
+        } else if (verbose) console.log(`no files found in ${from}`);
+    } else {
+        cpSync(from, to, { recursive: true });
         if (verbose) console.log(`copied ${from} to ${to}`);
-    } else if (verbose) console.log(`no files found in ${from}`);
+    }
 }
 
 export interface MediaTaskOutput extends TaskOutput {

--- a/scripts/convertMedia.ts
+++ b/scripts/convertMedia.ts
@@ -25,35 +25,21 @@ export function convertMedia(dataDir: string, verbose: number) {
     if (verbose)
         console.log(`copied ${path.join(dataDir, 'fonts')} to ${path.join('static', 'fonts')}`);
 
-    // Copy the images
-    doCopyForRoute(path.join(dataDir, 'images'), path.join('static', 'images'), verbose);
-
-    // Copy the illustrations
-    doCopyForRoute(path.join(dataDir, 'illustrations'), path.join('static', 'illustrations'), verbose);
-
-    // Copy local audio files
-    doCopyForRoute(path.join(dataDir, 'audio'), path.join('static', 'audio'), verbose);
-
-    // Copy timing files
-    doCopyForRoute(path.join(dataDir, 'timings'), path.join('static', 'timings'), verbose);
-
-    // Copy backgrounds files
-    doCopyForRoute(path.join(dataDir, 'backgrounds'), path.join('static', 'backgrounds'), verbose);
-
-    // Copy borders files
-    doCopyForRoute(path.join(dataDir, 'borders'), path.join('static', 'borders'), verbose);
-
-    // Copy images files
-    doCopyForRoute(path.join(dataDir, 'images'), path.join('static', 'images'), verbose);
-
-    // Copy clips files
-    doCopyForRoute(path.join(dataDir, 'clips'), path.join('static', 'clips'), verbose);
-
-    // Copy videos files
-    doCopyForRoute(path.join(dataDir, 'videos'), path.join('static', 'videos'), verbose);
-
-    // Copy icons files
-    doCopyForRoute(path.join(dataDir, 'icons'), path.join('static', 'icons'), verbose);
+    const paths = [
+        'images',
+        'illustrations',
+        'audio',
+        'timings',
+        'backgrounds',
+        'borders',
+        'images',
+        'clips',
+        'videos',
+        'icons'
+    ];
+    for (const p of paths) {
+        doCopyForRoute(path.join(dataDir, p), path.join('static', p), verbose);
+    }
 }
 
 function doCopyForRoute(from: string, to: string, verbose: number) {

--- a/scripts/convertMedia.ts
+++ b/scripts/convertMedia.ts
@@ -15,9 +15,9 @@ function cpSyncOptional(source: string, destination: string, opts?: CopyOptions)
 /**
  * Copies a directory from supplied data folder to a target
  */
-function cloneDirectory(from: string, to: string, verbose: number, optional: boolean = false) {
-    if(optional) {
-        if(cpSyncOptional(from, to, { recursive: true })) {
+function cloneDirectory(from: string, to: string, verbose: number, optional = false) {
+    if (optional) {
+        if (cpSyncOptional(from, to, { recursive: true })) {
             if (verbose) console.log(`copied ${from} to ${to}`);
         } else if (verbose) console.log(`no files found in ${from}`);
     } else {
@@ -52,8 +52,12 @@ export class ConvertMedia extends Task {
         super(dataDir);
     }
 
-    public async run(verbose: number, outputs: Map<string, TaskOutput>, modifiedPaths: string[]): Promise<TaskOutput> {
-        let modifiedDirectories = new Set<string>();
+    public async run(
+        verbose: number,
+        outputs: Map<string, TaskOutput>,
+        modifiedPaths: string[]
+    ): Promise<TaskOutput> {
+        const modifiedDirectories = new Set<string>();
         for (const p of modifiedPaths) {
             modifiedDirectories.add(p.split(path.sep)[0]);
         }
@@ -69,13 +73,22 @@ export class ConvertMedia extends Task {
         // FIXME: about 1/5 times the copy fails because of EPERM
         // I suspect this is because of my filesystem. If you also encounter this
         // error there will need to be a delay between the removal and the copy.
-        await Promise.all(modifiedDirectories.map(p => rmDir(path.join('static', p)).then(() => {
-            if (verbose) console.log(`removed ${path.join('static', p)}`);
-            return p;
-        })));
+        await Promise.all(
+            modifiedDirectories.map((p) =>
+                rmDir(path.join('static', p)).then(() => {
+                    if (verbose) console.log(`removed ${path.join('static', p)}`);
+                    return p;
+                })
+            )
+        );
 
         for (const p of modifiedDirectories) {
-            cloneDirectory(path.join(dataDir, p), path.join('static', p), verbose, !required.includes(p));
+            cloneDirectory(
+                path.join(dataDir, p),
+                path.join('static', p),
+                verbose,
+                !required.includes(p)
+            );
         }
     }
 }

--- a/scripts/convertMedia.ts
+++ b/scripts/convertMedia.ts
@@ -26,124 +26,40 @@ export function convertMedia(dataDir: string, verbose: number) {
         console.log(`copied ${path.join(dataDir, 'fonts')} to ${path.join('static', 'fonts')}`);
 
     // Copy the images
-    if (
-        cpSyncOptional(path.join(dataDir, 'images'), path.join('static', 'images'), {
-            recursive: true
-        })
-    ) {
-        if (verbose)
-            console.log(
-                `copied ${path.join(dataDir, 'images')} to ${path.join('static', 'images')}`
-            );
-    } else if (verbose) console.log(`no images found in ${dataDir}`);
+    doCopyForRoute(path.join(dataDir, 'images'), path.join('static', 'images'), verbose);
 
     // Copy the illustrations
-    if (
-        cpSyncOptional(path.join(dataDir, 'illustrations'), path.join('static', 'illustrations'), {
-            recursive: true
-        })
-    ) {
-        if (verbose)
-            console.log(
-                `copied ${path.join(dataDir, 'illustrations')} to ${path.join(
-                    'static',
-                    'illustrations'
-                )}`
-            );
-    } else if (verbose) console.log(`no illustrations found in ${dataDir}`);
+    doCopyForRoute(path.join(dataDir, 'illustrations'), path.join('static', 'illustrations'), verbose);
 
     // Copy local audio files
-    if (
-        cpSyncOptional(path.join(dataDir, 'audio'), path.join('static', 'audio'), {
-            recursive: true
-        })
-    ) {
-        if (verbose)
-            console.log(`copied ${path.join(dataDir, 'audio')} to ${path.join('static', 'audio')}`);
-    } else if (verbose) console.log(`no audio found in ${dataDir}`);
+    doCopyForRoute(path.join(dataDir, 'audio'), path.join('static', 'audio'), verbose);
 
     // Copy timing files
-    if (
-        cpSyncOptional(path.join(dataDir, 'timings'), path.join('static', 'timings'), {
-            recursive: true
-        })
-    ) {
-        if (verbose)
-            console.log(
-                `copied ${path.join(dataDir, 'timings')} to ${path.join('static', 'timings')}`
-            );
-    } else if (verbose) console.log(`no timings found in ${dataDir}`);
+    doCopyForRoute(path.join(dataDir, 'timings'), path.join('static', 'timings'), verbose);
 
     // Copy backgrounds files
-    if (
-        cpSyncOptional(path.join(dataDir, 'backgrounds'), path.join('static', 'backgrounds'), {
-            recursive: true
-        })
-    ) {
-        if (verbose)
-            console.log(
-                `copied ${path.join(dataDir, 'backgrounds')} to ${path.join(
-                    'static',
-                    'backgrounds'
-                )}`
-            );
-    } else if (verbose) console.log(`no backgrounds found in ${dataDir}`);
+    doCopyForRoute(path.join(dataDir, 'backgrounds'), path.join('static', 'backgrounds'), verbose);
 
     // Copy borders files
-    if (
-        cpSyncOptional(path.join(dataDir, 'borders'), path.join('static', 'borders'), {
-            recursive: true
-        })
-    ) {
-        if (verbose)
-            console.log(
-                `copied ${path.join(dataDir, 'borders')} to ${path.join('static', 'borders')}`
-            );
-    } else if (verbose) console.log(`no borders found in ${dataDir}`);
+    doCopyForRoute(path.join(dataDir, 'borders'), path.join('static', 'borders'), verbose);
 
     // Copy images files
-    if (
-        cpSyncOptional(path.join(dataDir, 'images'), path.join('static', 'images'), {
-            recursive: true
-        })
-    ) {
-        if (verbose)
-            console.log(
-                `copied ${path.join(dataDir, 'images')} to ${path.join('static', 'images')}`
-            );
-    } else if (verbose) console.log(`no images found in ${dataDir}`);
+    doCopyForRoute(path.join(dataDir, 'images'), path.join('static', 'images'), verbose);
 
     // Copy clips files
-    if (
-        cpSyncOptional(path.join(dataDir, 'clips'), path.join('static', 'clips'), {
-            recursive: true
-        })
-    ) {
-        if (verbose)
-            console.log(`copied ${path.join(dataDir, 'clips')} to ${path.join('static', 'clips')}`);
-    } else if (verbose) console.log(`no clips found in ${dataDir}`);
+    doCopyForRoute(path.join(dataDir, 'clips'), path.join('static', 'clips'), verbose);
 
     // Copy videos files
-    if (
-        cpSyncOptional(path.join(dataDir, 'videos'), path.join('static', 'videos'), {
-            recursive: true
-        })
-    ) {
-        if (verbose)
-            console.log(
-                `copied ${path.join(dataDir, 'videos')} to ${path.join('static', 'videos')}`
-            );
-    } else if (verbose) console.log(`no videos found in ${dataDir}`);
+    doCopyForRoute(path.join(dataDir, 'videos'), path.join('static', 'videos'), verbose);
 
     // Copy icons files
-    if (
-        cpSyncOptional(path.join(dataDir, 'icons'), path.join('static', 'icons'), {
-            recursive: true
-        })
-    ) {
-        if (verbose)
-            console.log(`copied ${path.join(dataDir, 'icons')} to ${path.join('static', 'icons')}`);
-    } else if (verbose) console.log(`no icons found in ${dataDir}`);
+    doCopyForRoute(path.join(dataDir, 'icons'), path.join('static', 'icons'), verbose);
+}
+
+function doCopyForRoute(from: string, to: string, verbose: number) {
+    if(cpSyncOptional(from, to, { recursive: true })) {
+        if (verbose) console.log(`copied ${from} to ${to}`);
+    } else if (verbose) console.log(`no files found in ${from}`);
 }
 
 export interface MediaTaskOutput extends TaskOutput {


### PR DESCRIPTION
Rewrote most of the `convertMedia.ts` file. Files in `static/{media folders}` are now deleted before they are copied. I also added incremental compilation, so that only modified folders will be copied. 