### PR TITLE
Fix issues in Book Selector

### DIFF
--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -81,20 +81,34 @@ The navbar component.
 
     let bookGridGroup = ({ bookLabel = 'abbreviation' }) => {
         const colId = $refs.collection;
-        let groups = config.bookCollections
+        let groups = [];
+        var lastGroup = null;
+
+        config.bookCollections
             .find((x) => x.id === colId)
-            .books.map((x) => x.testament)
-            .reduce((acc, curr) => {
-                if (!acc.includes(curr)) acc.push(curr);
-                return acc;
-            }, []);
-        return groups.map((_, i) => ({
-            header: $t['Book_Group_' + groups[i]],
-            cells: config.bookCollections
-                .find((x) => x.id === colId)
-                .books.filter((x) => x.testament === groups[i])
-                .map((x) => ({ label: x[bookLabel], id: x.id }))
-        }));
+            .books.forEach((book) => {
+                let label = book[bookLabel] || book.name;
+                let cell = { label: label, id: book.id };
+                let group = book.testament || '';
+                if (lastGroup == null || group !== lastGroup) {
+                    // Create new group
+                    groups.push({
+                        header: book.testament
+                            ? $t['Book_Group_' + book.testament]
+                            : lastGroup == null
+                            ? '' // use empty string so that first group doesn't have header (e.g. INT)
+                            : '\u00A0', // use &nbsp; so we have a blank space for additional books at the end
+                        cells: [cell]
+                    });
+                    lastGroup = group;
+                } else {
+                    // Add Book to last group
+                    let cells = groups[groups.length - 1].cells;
+                    groups[groups.length - 1].cells = [...cells, cell];
+                }
+            });
+
+        return groups;
     };
 
     const bookContent = {

--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -18,7 +18,7 @@ The navbar component.
 
     const listView = $userSettings['book-selection'] === 'list';
     const showBookOnly = !config.mainFeatures['show-chapter-selector-after-book'];
-    const showVerseSelector = $userSettings['verse-selection'];
+    const showVerseSelector = $userSettings['verse-selection'] && verseCount(chapter) > 0;
 
     // Translated book, chapter, and verse tab labels
     $: b = $t.Selector_Book;
@@ -37,6 +37,9 @@ The navbar component.
     }
 
     function verseCount(chapter) {
+        if (chapter === 'i') {
+            return 0;
+        }
         let count = Object.keys(chapters[chapter]).length;
         console.log('VERSE COUNT', count);
         return count;
@@ -55,7 +58,7 @@ The navbar component.
                     bookSelector.setActive(c);
                     $nextRef.book = e.detail.text;
                     if (chapterCount($nextRef.book) === 0) {
-                        $nextRef.chapter = 0;
+                        $nextRef.chapter = 'i';
                         completeNavigation();
                     }
                     break;

--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -27,9 +27,20 @@ The navbar component.
 
     let bookSelector;
     $: label = config.bookCollections
-        .find((x) => x.id === $refs.docSet.split('_')[1])
-        .books.find((x) => x.id == book).name;
+        .find((x) => x.id === $refs.collection)
+        .books.find((x) => x.id === book).name;
 
+    function chapterCount(book) {
+        let count = Object.keys(books.find((x) => x.bookCode === book).versesByChapters).length;
+        console.log('CHAPTER COUNT', count);
+        return count;
+    }
+
+    function verseCount(chapter) {
+        let count = Object.keys(chapters[chapter]).length;
+        console.log('VERSE COUNT', count);
+        return count;
+    }
     /**
      * Pushes reference changes to nextRef. Pushes final change to default reference.
      */
@@ -43,13 +54,17 @@ The navbar component.
                 case b:
                     bookSelector.setActive(c);
                     $nextRef.book = e.detail.text;
+                    if (chapterCount($nextRef.book) === 0) {
+                        $nextRef.chapter = 0;
+                        completeNavigation();
+                    }
                     break;
                 case c:
                     $nextRef.chapter = e.detail.text;
-                    if (showVerseSelector) {
-                        bookSelector.setActive(v);
-                    } else {
+                    if (verseCount($nextRef.chapter) === 0 || !showVerseSelector) {
                         completeNavigation();
+                    } else {
+                        bookSelector.setActive(v);
                     }
                     break;
                 case v:
@@ -63,6 +78,7 @@ The navbar component.
     }
 
     function completeNavigation() {
+        console.log('COMPLETE NAV', $nextRef.book, $nextRef.chapter);
         $refs = { book: $nextRef.book, chapter: $nextRef.chapter };
         document.activeElement.blur();
     }

--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -32,16 +32,14 @@ The navbar component.
 
     function chapterCount(book) {
         let count = Object.keys(books.find((x) => x.bookCode === book).versesByChapters).length;
-        console.log('CHAPTER COUNT', count);
         return count;
     }
 
     function verseCount(chapter) {
-        if (chapter === 'i') {
+        if (!chapter || chapter === 'i') {
             return 0;
         }
         let count = Object.keys(chapters[chapter]).length;
-        console.log('VERSE COUNT', count);
         return count;
     }
     /**
@@ -81,7 +79,6 @@ The navbar component.
     }
 
     function completeNavigation() {
-        console.log('COMPLETE NAV', $nextRef.book, $nextRef.chapter);
         $refs = { book: $nextRef.book, chapter: $nextRef.chapter };
         document.activeElement.blur();
     }
@@ -130,6 +127,18 @@ The navbar component.
         return groups;
     };
 
+    let chapterGridGroup = (chapters) => {
+        let hasIntroduction = books.find((x) => x.bookCode === book).hasIntroduction;
+        return [
+            {
+                rows: hasIntroduction
+                    ? [{ label: $t['Chapter_Introduction_Title'], id: 'i' }]
+                    : null,
+                cells: Object.keys(chapters).map((x) => ({ label: x, id: x }))
+            }
+        ];
+    };
+
     const bookContent = {
         component: listView ? SelectList : SelectGrid,
         props: {
@@ -143,7 +152,7 @@ The navbar component.
         return {
             component: SelectGrid,
             props: {
-                options: [{ cells: Object.keys(chapters).map((x) => ({ label: x, id: x })) }]
+                options: chapterGridGroup(chapters)
             }
         };
     }

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -63,6 +63,9 @@ The navbar component.
     }
 
     function verseCount(book, chapter) {
+        if (chapter === 'i') {
+            return 0;
+        }
         let books = catalog.find((d) => d.id === $refs.docSet).documents;
         let chapters = books.find((d) => d.bookCode === book).versesByChapters;
         let count = Object.keys(chapters[chapter]).length;

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -117,7 +117,7 @@ The navbar component.
 
 <!-- Chapter Selector -->
 {#if showSelector && ($nextRef.book === '' || $nextRef.chapter !== '')}
-    <Dropdown on:nav-end={resetNavigation} cols>
+    <Dropdown on:nav-end={resetNavigation} cols="5">
         <svelte:fragment slot="label">
             <div class="normal-case" style={convertStyle($s['ui.selector.chapter'])}>
                 {chapter}
@@ -129,7 +129,6 @@ The navbar component.
         <svelte:fragment slot="content">
             {#if canSelect}
                 <div>
-                    {(console.log('SHOW_VERSE_SELECTOR', showVerseSelector), '')}
                     {#if showVerseSelector}
                         <TabsMenu
                             bind:this={chapterSelector}

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -17,7 +17,7 @@ The navbar component.
     // Needs testing, does updating the book correctly effect what chapters or verses are availible in the next tab?
     $: book = $nextRef.book === '' ? $refs.book : $nextRef.book;
     $: chapter = $nextRef.chapter === '' ? $refs.chapter : $nextRef.chapter;
-    $: showVerseSelector = $userSettings['verse-selection'];
+    $: showVerseSelector = $userSettings['verse-selection'] && verseCount(book, chapter) > 0;
 
     $: c = $t.Selector_Chapter;
     $: v = $t.Selector_Verse;

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -117,7 +117,7 @@ The navbar component.
 
 <!-- Chapter Selector -->
 {#if showSelector && ($nextRef.book === '' || $nextRef.chapter !== '')}
-    <Dropdown on:nav-end={resetNavigation}>
+    <Dropdown on:nav-end={resetNavigation} cols>
         <svelte:fragment slot="label">
             <div class="normal-case" style={convertStyle($s['ui.selector.chapter'])}>
                 {chapter}
@@ -137,6 +137,7 @@ The navbar component.
                                 [c]: chaptersContent(chapters),
                                 [v]: versesContent(chapters, chapter)
                             }}
+                            cols="5"
                             active={c}
                             on:menuaction={navigateReference}
                         />
@@ -146,6 +147,7 @@ The navbar component.
                             options={{
                                 [c]: chaptersContent(chapters)
                             }}
+                            cols="5"
                             active={c}
                             on:menuaction={navigateReference}
                         />

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -11,7 +11,7 @@ The navbar component.
     import { catalog } from '$lib/data/catalog';
     import config from '$lib/data/config';
 
-    const showVerseSelector = $userSettings['verse-selection'];
+    $: showVerseSelector = $userSettings['verse-selection'] && verseCount(book, chapter) > 0;
 
     /**reference to chapter selector so code can use TabsMenu.setActive*/
     let chapterSelector;
@@ -55,11 +55,27 @@ The navbar component.
         nextRef.reset();
     }
 
+    function chapterCount(book) {
+        let books = catalog.find((d) => d.id === $refs.docSet).documents;
+        let count = Object.keys(books.find((x) => x.bookCode === book).versesByChapters).length;
+        console.log('CHAPTER COUNT', count);
+        return count;
+    }
+
+    function verseCount(book, chapter) {
+        let books = catalog.find((d) => d.id === $refs.docSet).documents;
+        let chapters = books.find((d) => d.bookCode === book).versesByChapters;
+        let count = Object.keys(chapters[chapter]).length;
+        console.log('VERSE COUNT', count);
+        return count;
+    }
+
     /**list of books in current docSet*/
     $: books = catalog.find((d) => d.id === $refs.docSet).documents;
     /**list of chapters in current book*/
     $: chapters = books.find((d) => d.bookCode === book).versesByChapters;
-    const showSelector = config.mainFeatures['show-chapter-number-on-app-bar'];
+    const showSelector =
+        config.mainFeatures['show-chapter-number-on-app-bar'] && chapterCount($refs.book) > 0;
     const canSelect = config.mainFeatures['show-chapter-selector'];
 
     function chaptersContent(chapters) {

--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -2,10 +2,10 @@
 @component
 A simple dropdown menu from DaisyUI.
 -->
-<script>
+<script lang="ts">
     import { s, convertStyle } from '$lib/data/stores';
     import { createEventDispatcher } from 'svelte';
-    export let cols = 6;
+    export let cols: number = 6;
     const dispatch = createEventDispatcher();
 </script>
 
@@ -18,8 +18,8 @@ A simple dropdown menu from DaisyUI.
     <div
         tabindex="0"
         class="dy-dropdown-content dy-menu drop-shadow-lg mt-2.5 bg-base-100"
-        class:min-w-[21rem]={cols === 6}
-        class:min-w-[17.25rem]={cols === 5}
+        class:min-w-[21rem]={cols == 6}
+        class:min-w-[17.25rem]={cols == 5}
         style={convertStyle($s['ui.background'])}
         on:blur={() => dispatch('nav-end')}
     >

--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -5,7 +5,7 @@ A simple dropdown menu from DaisyUI.
 <script lang="ts">
     import { s, convertStyle } from '$lib/data/stores';
     import { createEventDispatcher } from 'svelte';
-    export let cols: number = 6;
+    export let cols = 6;
     const dispatch = createEventDispatcher();
 </script>
 

--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -5,7 +5,7 @@ A simple dropdown menu from DaisyUI.
 <script>
     import { s, convertStyle } from '$lib/data/stores';
     import { createEventDispatcher } from 'svelte';
-
+    export let cols = 6;
     const dispatch = createEventDispatcher();
 </script>
 
@@ -17,7 +17,9 @@ A simple dropdown menu from DaisyUI.
     <!-- svelte-ignore a11y-no-noninteractive-tabindex -->
     <div
         tabindex="0"
-        class="dy-dropdown-content dy-menu drop-shadow-lg mt-2.5 bg-base-100 min-w-[21rem]"
+        class="dy-dropdown-content dy-menu drop-shadow-lg mt-2.5 bg-base-100"
+        class:min-w-[21rem]={cols === 6}
+        class:min-w-[17.25rem]={cols === 5}
         style={convertStyle($s['ui.background'])}
         on:blur={() => dispatch('nav-end')}
     >

--- a/src/lib/components/SelectGrid.svelte
+++ b/src/lib/components/SelectGrid.svelte
@@ -57,34 +57,6 @@ A component to display menu options in a grid.
             </span>
         {/each}
     </div>
-    <!-- <table>
-        {#each Array(Math.ceil(group.cells.length / cols)) as _, ri}
-            <tr>
-                {#each Array(cols) as _, ci}
-                    {#if ri * cols + ci < group.cells.length}
-                        <td>
-                            <span
-                                on:click={() => handleClick(group.cells[ri * cols + ci].id)}
-                                class="dy-btn dy-btn-square dy-btn-ghost p-0 normal-case truncate text-clip"
-                                style={convertStyle(
-                                    Object.fromEntries(
-                                        Object.entries($s['ui.button.book-grid']).filter(
-                                            ([key]) => key != 'background-color'
-                                        )
-                                    )
-                                )}
-                                style:background-color={bookCollectionColor(
-                                    group.cells[ri * cols + ci].id
-                                )}
-                            >
-                                {group.cells[ri * cols + ci].label}
-                            </span></td
-                        >
-                    {/if}
-                {/each}
-            </tr>
-        {/each}
-    </table> -->
 {/each}
 
 <style>

--- a/src/lib/components/SelectGrid.svelte
+++ b/src/lib/components/SelectGrid.svelte
@@ -7,6 +7,7 @@ A component to display menu options in a grid.
     import { s, refs, themeBookColors, convertStyle } from '$lib/data/stores';
     import config from '$lib/data/config';
     export let options: App.GridGroup[] = [];
+    export let cols: string = '6';
 
     let cellStyle = convertStyle(
         Object.fromEntries(
@@ -44,13 +45,13 @@ A component to display menu options in a grid.
     {#if group.header}
         <div class="mx-2" style={headerStyle}>{group.header}</div>
     {/if}
-    <div class="grid grid-cols-6 gap-1  m-2">
+    <div class="grid grid-cols-{cols} gap-1 m-2">
         {#if group.rows}
             {#each group.rows as row}
                 <!-- svelte-ignore a11y-click-events-have-key-events -->
                 <span
                     on:click={() => handleClick(row.id)}
-                    class="dy-btn dy-btn-ghost normal-case truncate text-clip col-start-1 col-span-6"
+                    class="dy-btn dy-btn-ghost normal-case truncate text-clip col-start-1 col-span-{cols}"
                     style={rowStyle}
                     style:background-color={bookCollectionColor(row.id, 'ui.button.chapter-intro')}
                 >

--- a/src/lib/components/SelectGrid.svelte
+++ b/src/lib/components/SelectGrid.svelte
@@ -7,7 +7,7 @@ A component to display menu options in a grid.
     import { s, refs, themeBookColors, convertStyle } from '$lib/data/stores';
     import config from '$lib/data/config';
     export let options: App.GridGroup[] = [];
-    export let cols: string = '6';
+    export let cols: number = 6;
 
     let cellStyle = convertStyle(
         Object.fromEntries(
@@ -45,13 +45,19 @@ A component to display menu options in a grid.
     {#if group.header}
         <div class="mx-2" style={headerStyle}>{group.header}</div>
     {/if}
-    <div class="grid grid-cols-{cols} gap-1 m-2">
+    <div
+        class="grid grid-cols-{cols} gap-1 m-2"
+        class:grid-cols-5={cols == 5}
+        class:grid-cols-6={cols == 6}
+    >
         {#if group.rows}
             {#each group.rows as row}
                 <!-- svelte-ignore a11y-click-events-have-key-events -->
                 <span
                     on:click={() => handleClick(row.id)}
-                    class="dy-btn dy-btn-ghost normal-case truncate text-clip col-start-1 col-span-{cols}"
+                    class="dy-btn dy-btn-ghost normal-case truncate text-clip col-start-1"
+                    class:col-span-5={cols == 5}
+                    class:col-span-6={cols == 6}
                     style={rowStyle}
                     style:background-color={bookCollectionColor(row.id, 'ui.button.chapter-intro')}
                 >

--- a/src/lib/components/SelectGrid.svelte
+++ b/src/lib/components/SelectGrid.svelte
@@ -7,17 +7,29 @@ A component to display menu options in a grid.
     import { s, refs, themeBookColors, convertStyle } from '$lib/data/stores';
     import config from '$lib/data/config';
     export let options: App.GridGroup[] = [];
-    export let cols = 6;
 
+    let cellStyle = convertStyle(
+        Object.fromEntries(
+            Object.entries($s['ui.button.book-grid']).filter(([key]) => key != 'background-color')
+        )
+    );
+    let rowStyle = convertStyle(
+        Object.fromEntries(
+            Object.entries($s['ui.button.chapter-intro']).filter(
+                ([key]) => key != 'background-color'
+            )
+        )
+    );
+    let headerStyle = convertStyle($s['ui.text.book-group-title']);
     const dispatch = createEventDispatcher();
 
-    $: bookCollectionColor = (id: string) => {
+    $: bookCollectionColor = (id: string, category: string) => {
         const section = config.bookCollections
             .find((x) => x.id === $refs.collection)
             .books.find((x) => x.id === id)?.section;
         let color = Object.keys($themeBookColors).includes(section)
             ? $themeBookColors[section]
-            : $s['ui.button.book-grid']['background-color'];
+            : $s[category]['background-color'];
         return color;
     };
 
@@ -28,30 +40,31 @@ A component to display menu options in a grid.
     }
 </script>
 
-<!--
-  ri - row index
-  ci - column index
-  see https://svelte.dev/tutorial/each-blocks
--->
-
 {#each options as group}
     {#if group.header}
-        <div style={convertStyle($s['ui.text.book-group-title'])}>{group.header}</div>
+        <div class="mx-2" style={headerStyle}>{group.header}</div>
     {/if}
-    <div class="grid grid-cols-6 gap-1">
+    <div class="grid grid-cols-6 gap-1  m-2">
+        {#if group.rows}
+            {#each group.rows as row}
+                <!-- svelte-ignore a11y-click-events-have-key-events -->
+                <span
+                    on:click={() => handleClick(row.id)}
+                    class="dy-btn dy-btn-ghost normal-case truncate text-clip col-start-1 col-span-6"
+                    style={rowStyle}
+                    style:background-color={bookCollectionColor(row.id, 'ui.button.chapter-intro')}
+                >
+                    {row.label}
+                </span>
+            {/each}
+        {/if}
         {#each group.cells as cell}
             <!-- svelte-ignore a11y-click-events-have-key-events -->
             <span
                 on:click={() => handleClick(cell.id)}
                 class="dy-btn dy-btn-square dy-btn-ghost normal-case truncate text-clip"
-                style={convertStyle(
-                    Object.fromEntries(
-                        Object.entries($s['ui.button.book-grid']).filter(
-                            ([key]) => key != 'background-color'
-                        )
-                    )
-                )}
-                style:background-color={bookCollectionColor(cell.id)}
+                style={cellStyle}
+                style:background-color={bookCollectionColor(cell.id, 'ui.button.book-grid')}
             >
                 {cell.label}
             </span>
@@ -60,31 +73,6 @@ A component to display menu options in a grid.
 {/each}
 
 <style>
-    div {
-        padding: 5px;
-    }
-    table {
-        width: 100%;
-        margin-left: auto;
-        margin-right: auto;
-        padding: 0px;
-        border-collapse: unset;
-        border-spacing: 5px;
-    }
-    tr {
-        width: 100%;
-        margin: 0px;
-        padding: 0px;
-    }
-    td {
-        text-align: center;
-        overflow: hidden;
-        margin: 0px;
-        padding: 0px;
-        position: relative;
-        border: none;
-        border-radius: 0px;
-    }
     span {
         text-overflow: ''; /* Works on Firefox only */
         overflow: hidden;

--- a/src/lib/components/SelectGrid.svelte
+++ b/src/lib/components/SelectGrid.svelte
@@ -38,13 +38,31 @@ A component to display menu options in a grid.
     {#if group.header}
         <div style={convertStyle($s['ui.text.book-group-title'])}>{group.header}</div>
     {/if}
-    <table>
+    <div class="grid grid-cols-6 gap-1">
+        {#each group.cells as cell}
+            <!-- svelte-ignore a11y-click-events-have-key-events -->
+            <span
+                on:click={() => handleClick(cell.id)}
+                class="dy-btn dy-btn-square dy-btn-ghost normal-case truncate text-clip"
+                style={convertStyle(
+                    Object.fromEntries(
+                        Object.entries($s['ui.button.book-grid']).filter(
+                            ([key]) => key != 'background-color'
+                        )
+                    )
+                )}
+                style:background-color={bookCollectionColor(cell.id)}
+            >
+                {cell.label}
+            </span>
+        {/each}
+    </div>
+    <!-- <table>
         {#each Array(Math.ceil(group.cells.length / cols)) as _, ri}
             <tr>
                 {#each Array(cols) as _, ci}
                     {#if ri * cols + ci < group.cells.length}
                         <td>
-                            <!-- svelte-ignore a11y-click-events-have-key-events -->
                             <span
                                 on:click={() => handleClick(group.cells[ri * cols + ci].id)}
                                 class="dy-btn dy-btn-square dy-btn-ghost p-0 normal-case truncate text-clip"
@@ -66,7 +84,7 @@ A component to display menu options in a grid.
                 {/each}
             </tr>
         {/each}
-    </table>
+    </table> -->
 {/each}
 
 <style>

--- a/src/lib/components/SelectGrid.svelte
+++ b/src/lib/components/SelectGrid.svelte
@@ -7,7 +7,7 @@ A component to display menu options in a grid.
     import { s, refs, themeBookColors, convertStyle } from '$lib/data/stores';
     import config from '$lib/data/config';
     export let options: App.GridGroup[] = [];
-    export let cols: number = 6;
+    export let cols = 6;
 
     let cellStyle = convertStyle(
         Object.fromEntries(

--- a/src/lib/components/TabsMenu.svelte
+++ b/src/lib/components/TabsMenu.svelte
@@ -7,7 +7,7 @@ A component to display tabbed menus.
     import { s, convertStyle } from '$lib/data/stores';
 
     export let options: App.TabMenuOptions = { '': { component: '', props: {} } };
-    export let cols: number = 6;
+    export let cols = 6;
     export let active = '';
     const dispatch = createEventDispatcher();
     const hasTabs = Object.keys(options).length > 1;

--- a/src/lib/components/TabsMenu.svelte
+++ b/src/lib/components/TabsMenu.svelte
@@ -7,6 +7,7 @@ A component to display tabbed menus.
     import { s, convertStyle } from '$lib/data/stores';
 
     export let options: App.TabMenuOptions = { '': { component: '', props: {} } };
+    export let cols: number = 6;
     export let active = '';
     const dispatch = createEventDispatcher();
     const hasTabs = Object.keys(options).length > 1;
@@ -53,6 +54,7 @@ A component to display tabbed menus.
 <div class="tabs-content" style={convertStyle($s['ui.background'])} class:p-2={!hasTabs}>
     <svelte:component
         this={options[active].component}
+        {cols}
         on:menuaction={handleMenuaction}
         {...options[active].props}
     />

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -210,7 +210,7 @@ TODO:
             {/if}
             {#if isTextOnImageEnabled}
                 <button class="dy-btn-sm dy-btn-ghost">
-                    <ImageIcon />
+                    <ImageIcon.Image />
                 </button>
             {/if}
             {#if isHighlightEnabled}

--- a/src/lib/data/stores/scripture.js
+++ b/src/lib/data/stores/scripture.js
@@ -4,12 +4,14 @@ import { setDefaultStorage } from './storage';
 import config from '../config';
 
 /** current reference */
+const firstChapter = config.bookCollections[0].books[0].id + "." + config.bookCollections[0].books[0].chaptersN.split("-")[0];
+const startReference = config.mainFeatures['start-at-reference'] || firstChapter;
 const initReference =
     config.bookCollections[0].languageCode +
     '_' +
     config.bookCollections[0].id +
     '.' +
-    config.mainFeatures['start-at-reference'];
+    startReference;
 setDefaultStorage('refs', initReference);
 export const refs = groupStore(referenceStore, localStorage.refs);
 refs.subscribe((value) => {


### PR DESCRIPTION
Issues:

- [x] If there are lest than 6 cells in a group, then they are spaced out evenly instead of being in the first 3 columns
- [x] labels for books without abbreviations wasn't working (need to revert to name)
- [x] books before and after the "testaments" where not displayed in the order in the config.js.
- [x] introductions were not displaying at the top of the chapter selector.
- [x] selecting a book without chapters but had introduction was not navigating to book immediately.

Grid CSS for the win!

Before:

![image](https://user-images.githubusercontent.com/517814/230493978-27c72519-cc42-4134-875b-d3b3292362bb.png)

After:

![image](https://user-images.githubusercontent.com/517814/230493908-767c827e-ba8d-4496-be4f-646e0d7ecac0.png)
