### PR TITLE
Fix issues with margin

### DIFF
--- a/scripts/convertMedia.ts
+++ b/scripts/convertMedia.ts
@@ -36,7 +36,6 @@ export class ConvertMedia extends Task {
     public triggerFiles: string[] = [
         'images',
         'fonts',
-        'styles',
         'illustrations',
         'audio',
         'timings',
@@ -68,7 +67,7 @@ export class ConvertMedia extends Task {
         };
     }
     async convertMedia(dataDir: string, verbose: number, modifiedDirectories: string[]) {
-        const required = ['styles', 'fonts'];
+        const required = ['fonts'];
 
         // FIXME: about 1/5 times the copy fails because of EPERM
         // I suspect this is because of my filesystem. If you also encounter this

--- a/scripts/convertStyles.ts
+++ b/scripts/convertStyles.ts
@@ -1,0 +1,50 @@
+import { existsSync, readFileSync, writeFileSync, readdirSync, mkdirSync } from 'fs';
+import path from 'path';
+import { TaskOutput, Task } from './Task';
+
+export interface StylesTaskOutput extends TaskOutput {
+    taskName: 'ConvertStyles';
+}
+/**
+ * Convert firebase-config.js to module or provide null definition
+ */
+export function convertStyles(dataDir: string, verbose: number) {
+    const srcDir = path.join(dataDir, 'styles');
+    const dstDir = path.join('static', 'styles');
+    mkdirSync(dstDir, { recursive: true });
+
+    readdirSync(srcDir).forEach((file) => {
+        const srcFile = path.join(srcDir, file);
+        const dstFile = path.join(dstDir, file);
+
+        const fileContents = readFileSync(srcFile).toString();
+        const lines = fileContents.split('\n');
+        const updatedFileContents = lines
+            .map((line) => {
+                if (line.indexOf('body') === 0) {
+                    line = line
+                        .replace('body', '#content')
+                        .replace('margin-top', 'padding-top')
+                        .replace('margin-bottom', 'padding-bottom');
+                }
+                return line;
+            })
+            .join('\n');
+        writeFileSync(dstFile, updatedFileContents);
+    });
+}
+
+export class ConvertStyles extends Task {
+    public triggerFiles: string[] = ['styles'];
+
+    constructor(dataDir: string) {
+        super(dataDir);
+    }
+    public async run(verbose: number) {
+        convertStyles(this.dataDir, verbose);
+        return {
+            taskName: this.constructor.name,
+            files: []
+        };
+    }
+}

--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -4,6 +4,7 @@ import { ConvertMedia } from './convertMedia';
 import { ConvertBooks } from './convertBooks';
 import { ConvertAbout } from './convertAbout';
 import { ConvertFirebase } from './convertFirebase';
+import { ConvertStyles } from './convertStyles';
 import { watch } from 'chokidar';
 import { Task, TaskOutput } from './Task';
 import { writeFile } from 'fs';
@@ -39,6 +40,7 @@ const stepClasses: Task[] = [
     ConvertMedia,
     ConvertBooks,
     ConvertFirebase,
+    ConvertStyles,
     ConvertAbout
 ].map((x) => new x(dataDir));
 const allPaths = new Set(

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -1057,9 +1057,11 @@ TODO:
         <LoadingIcon />
     {/if}
     <div
+        id="content"
         bind:this={bookRoot}
         class:hidden={loading}
         style:font-size={fontSize}
         style:line-height={lineHeight}
+        class="single"
     />
 </article>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -256,6 +256,7 @@
         <div
             style={'height:calc(100vh - ' + cs + 'rem);height:calc(100dvh - ' + cs + 'rem);'}
             slot="scrolled-content"
+            class="max-w-screen-md mx-auto"
             use:pinch
             on:pinch={doPinch}
             use:swipe={{ timeframe: 300, minSwipeDistance: 60, touchAction: 'pan-y' }}

--- a/static/override-sab.css
+++ b/static/override-sab.css
@@ -1,9 +1,0 @@
-/* 
- * The body of the HTML in the native apps is just the scripture content area. So the CSS
- * include some default margin at the top and bottom.  The body of the HTML in the PWA includes
- * the top and bottom bars. So we don't want any margin. Otherwise, we get double scrollbars.
- */
-body {
-    margin-top: 0;
-    margin-bottom: 0;
-}


### PR DESCRIPTION
* body and body.* (e.g. body.single) have definitions for margin that were not being used since our app bar and audio toolbar are a part of the body.
* add convertStyles that changes body to #content so that these are picked up.
* add processing of wide pages so that they have max width and centered in page

Fixes #224 