### PR TITLE
Back/forward arrows to move between chapters (#225) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ A template for building a Progressive Web App with [Scripture App Builder](https
 
 ## Usage
 
-You will need to have Scripture App Builder 10.3 [PWA build](https://drive.google.com/drive/folders/1EQaBXX-Y3Y2ZD3rgn8EtTfEO6J1Dhd9U?usp=share_link) to use this project without the provided example data.
-
-> Contact [chris_hubbard@sil.org](mailto:chris_hubbard@sil.org) for access to the Google Drive folder.
+You will need to download [Scripture App Builder 10.3.2](https://drive.google.com/drive/folders/1EQaBXX-Y3Y2ZD3rgn8EtTfEO6J1Dhd9U?usp=share_link](https://software.sil.org/scriptureappbuilder/download/)) to use this project without the provided example data.
 
 ### Develop
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A template for building a Progressive Web App with [Scripture App Builder](https
 
 ## Usage
 
-You will need to download [Scripture App Builder 10.3.2](https://drive.google.com/drive/folders/1EQaBXX-Y3Y2ZD3rgn8EtTfEO6J1Dhd9U?usp=share_link](https://software.sil.org/scriptureappbuilder/download/)) to use this project without the provided example data.
+You will need to download [Scripture App Builder 10.3.2](https://software.sil.org/scriptureappbuilder/download/) to use this project without the provided example data.
 
 ### Develop
 

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -1062,6 +1062,5 @@ TODO:
         class:hidden={loading}
         style:font-size={fontSize}
         style:line-height={lineHeight}
-        class="single"
     />
 </article>

--- a/src/lib/components/ScrolledContent.svelte
+++ b/src/lib/components/ScrolledContent.svelte
@@ -16,7 +16,7 @@
     onMount(updateScroll);
 </script>
 
-<div class="p-2 w-full overflow-y-auto " bind:this={main} on:scroll={updateScroll}>
+<div class="p-2 overflow-y-auto " bind:this={main} on:scroll={updateScroll}>
     <main>
         <slot name="scrolled-content" />
     </main>

--- a/src/lib/icons/ChevronLeftIcon.svelte
+++ b/src/lib/icons/ChevronLeftIcon.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+    // Chevron Left from https://fonts.google.com/icons
+    // Filled = 0
+    // Weight = 400
+    // Grade = 0
+    // Optical size = 24px
+    export let color = 'black';
+</script>
+
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+    ><g transform="rotate(180 12 12)"
+        ><path fill={color} d="M10 6L8.59 7.41L13.17 12l-4.58 4.59L10 18l6-6z" /></g
+    ></svg
+>

--- a/src/lib/icons/ChevronRightIcon.svelte
+++ b/src/lib/icons/ChevronRightIcon.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+    // Chevron Right from https://fonts.google.com/icons
+    // Filled = 0
+    // Weight = 400
+    // Grade = 0
+    // Optical size = 24px
+    export let color = 'black';
+</script>
+
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
+    ><path fill={color} d="M10 6L8.59 7.41L13.17 12l-4.58 4.59L10 18l6-6z" /></svg
+>

--- a/src/lib/icons/index.js
+++ b/src/lib/icons/index.js
@@ -7,6 +7,8 @@ import BibleIcon from './BibleIcon.svelte';
 import BookmarkIcon from './BookmarkIcon.svelte';
 import BookmarkOutlineIcon from './BookmarkOutlineIcon.svelte';
 import CopyContentIcon from './CopyContentIcon.svelte';
+import ChevronLeftIcon from './ChevronLeftIcon.svelte';
+import ChevronRightIcon from './ChevronRightIcon.svelte';
 import DeleteSweepIcon from './DeleteSweepIcon.svelte';
 import DropdownIcon from './DropdownIcon.svelte';
 import EditIcon from './EditIcon.svelte';
@@ -37,6 +39,8 @@ export {
     BookmarkIcon,
     BookmarkOutlineIcon,
     CopyContentIcon,
+    ChevronLeftIcon,
+    ChevronRightIcon,
     DeleteSweepIcon,
     DropdownIcon,
     EditIcon,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,7 +21,7 @@
     } from '$lib/data/stores';
     import { addHistory } from '$lib/data/history';
     import { parseReference } from '$lib/data/stores/store-types';
-    import { AudioIcon, SearchIcon } from '$lib/icons';
+    import { AudioIcon, SearchIcon, ChevronLeftIcon, ChevronRightIcon } from '$lib/icons';
     import Navbar from '$lib/components/Navbar.svelte';
     import TextAppearanceSelector from '$lib/components/TextAppearanceSelector.svelte';
     import config from '$lib/data/config';
@@ -252,19 +252,64 @@
     class:borderimg={showBorder}
     style={'height:calc(100vh - ' + bs + 'rem);height:calc(100dvh - ' + bs + 'rem)'}
 >
-    <ScrolledContent>
-        <div
-            style={'height:calc(100vh - ' + cs + 'rem);height:calc(100dvh - ' + cs + 'rem);'}
-            slot="scrolled-content"
-            class="max-w-screen-md mx-auto"
-            use:pinch
-            on:pinch={doPinch}
-            use:swipe={{ timeframe: 300, minSwipeDistance: 60, touchAction: 'pan-y' }}
-            on:swipe={doSwipe}
-        >
-            <ScriptureViewSofria {...viewSettings} />
+    <div class="flex flex-row justify-center space-x-4 ml-4 mr-4">
+        <!-- TODO: we shouldn't show these buttons on smaller screens -->
+        <div class="grow flex flex-column items-center justify-end">
+            <button
+                class="dy-btn dy-btn-ghost dy-btn-circle"
+                disabled={!$refs.prev.book || !$refs.prev.chapter}
+                on:click={() => {
+                    refs.skip(-1);
+                    addHistory({
+                        collection: $refs.collection,
+                        book: $refs.book,
+                        chapter: $refs.chapter,
+                        verse: $refs.verse
+                    });
+                }}
+            >
+                {#if $refs.prev.book && $refs.prev.chapter}
+                    <ChevronLeftIcon color="gray" />
+                {/if}
+            </button>
         </div>
-    </ScrolledContent>
+
+        <!-- div class="flex flex-col justify-center">
+    </div -->
+        <ScrolledContent class="grow-0">
+            <div
+                style={'height:calc(100vh - ' + cs + 'rem);height:calc(100dvh - ' + cs + 'rem);'}
+                slot="scrolled-content"
+                class="max-w-screen-md"
+                use:pinch
+                on:pinch={doPinch}
+                use:swipe={{ timeframe: 300, minSwipeDistance: 60, touchAction: 'pan-y' }}
+                on:swipe={doSwipe}
+            >
+                <ScriptureViewSofria {...viewSettings} />
+            </div>
+        </ScrolledContent>
+        <div class="grow flex flex-column items-center justify-start">
+            <!-- TODO: we shouldn't show these buttons on smaller screens -->
+            <button
+                class="dy-btn dy-btn-ghost dy-btn-circle"
+                disabled={!$refs.next.book || !$refs.next.chapter}
+                on:click={() => {
+                    refs.skip(1);
+                    addHistory({
+                        collection: $refs.collection,
+                        book: $refs.book,
+                        chapter: $refs.chapter,
+                        verse: $refs.verse
+                    });
+                }}
+            >
+                {#if $refs.next.book && $refs.next.chapter}
+                    <ChevronRightIcon color="gray" />
+                {/if}
+            </button>
+        </div>
+    </div>
 </div>
 {#if $selectedVerses.length > 0}
     <div class="left-0 right-0 bottom-0 absolute">
@@ -291,5 +336,11 @@
         border: 30px solid transparent;
         border-image-source: url(/borders/border.png);
         border-image-slice: 100;
+    }
+    button[disabled] {
+        background-color: transparent;
+        &:hover {
+            background-color: transparent;
+        }
     }
 </style>


### PR DESCRIPTION
I think we can consider hiding these buttons on small screens, I've left that as a TODO.

The prev button is hidden for the first chapter, and likewise for the next button for the last chapter of the last book.

Small Screens:
<img width="382" alt="image" src="https://github.com/sillsdev/appbuilder-pwa/assets/32358891/cc0062cc-8bec-4a0d-a8f8-fd67345648a7">

Larger screens:
<img width="928" alt="image" src="https://github.com/sillsdev/appbuilder-pwa/assets/32358891/ce45dc97-d2f7-4b1a-a63b-86ad3c30826b">
