### PR TITLE
Feature/mobile navbar icons

### DIFF
--- a/src/lib/components/AudioPlaybackSpeed.svelte
+++ b/src/lib/components/AudioPlaybackSpeed.svelte
@@ -12,7 +12,7 @@
     $: iconColor = $s['ui.bar.audio.icon']['color'];
 </script>
 
-<Modal id={modalId}>
+<Modal id={modalId} addCSS="position:absolute; bottom:1rem; right:1rem;">
     <svelte:fragment slot="label">
         <AudioIcon.Speed color={iconColor} />
     </svelte:fragment>
@@ -102,7 +102,7 @@
                 1.6x
             </label>
             <div class="dy-modal-action close-btn">
-                <label for={modalId} class="dy-btn dy-btn-ghost">{$t['Button_Close']}</label>
+                <button class="dy-btn dy-btn-ghost">{$t['Button_Close']}</button>
             </div>
         </div>
     </svelte:fragment>

--- a/src/lib/components/AudioPlaybackSpeed.svelte
+++ b/src/lib/components/AudioPlaybackSpeed.svelte
@@ -12,7 +12,8 @@
     $: iconColor = $s['ui.bar.audio.icon']['color'];
 </script>
 
-<Modal id={modalId} addCSS="position:absolute; bottom:1rem; right:1rem;">
+<Modal id={modalId} addCSS="position:absolute; bottom:1rem; right:1rem;"
+    ><!--addCSS injects CSS into the modal to position it 1rem away from the bottom and right edges of the screen (on mobile it will be centered)-->
     <svelte:fragment slot="label">
         <AudioIcon.Speed color={iconColor} />
     </svelte:fragment>

--- a/src/lib/components/CollectionSelector.svelte
+++ b/src/lib/components/CollectionSelector.svelte
@@ -14,12 +14,13 @@ Book Collection Selector component.
     let modal;
     export function showModal() {
         modal.showModal();
+        console.log('='+vertOffset)
     }
-    export let vertOffset = '0px';
+    export let vertOffset = '1rem';
     $: positioningCSS =
         'position:absolute; top:' +
-        (vertOffset + parseFloat(getComputedStyle(document.documentElement).fontSize)) +
-        'px; right:1rem;';
+        (Number(vertOffset.replace('rem', '')) + 1) +
+        'rem; right:1rem;';
 
     function navigateReference(e) {
         switch (e.detail.tab) {

--- a/src/lib/components/CollectionSelector.svelte
+++ b/src/lib/components/CollectionSelector.svelte
@@ -14,9 +14,10 @@ Book Collection Selector component.
     let modal;
     export function showModal() {
         modal.showModal();
-        console.log('='+vertOffset)
     }
-    export let vertOffset = '1rem';
+
+    export let vertOffset = '1rem'; //Prop that will have the navbar's height (in rem) passed in
+    //The positioningCSS positions the modal 1rem below the navbar and 1rem from the right edge of the screen (on mobile it will be centered)
     $: positioningCSS =
         'position:absolute; top:' +
         (Number(vertOffset.replace('rem', '')) + 1) +
@@ -36,7 +37,9 @@ Book Collection Selector component.
     }
 </script>
 
-<Modal bind:this={modal} id={modalId} useLabel={false} addCSS={positioningCSS}>
+<Modal bind:this={modal} id={modalId} useLabel={false} addCSS={positioningCSS}
+    ><!--addCSS is a prop for injecting CSS into the modal-->
+
     <svelte:fragment slot="content">
         <!-- TODO: Include other layout options -->
         <TabsMenu

--- a/src/lib/components/CollectionSelector.svelte
+++ b/src/lib/components/CollectionSelector.svelte
@@ -11,6 +11,15 @@ Book Collection Selector component.
 
     let modalId = 'collectionSelector';
     let docSet = $refs.docSet;
+    let modal;
+    export function showModal() {
+        modal.showModal();
+    }
+    export let vertOffset = '0px';
+    $: positioningCSS =
+        'position:absolute; top:' +
+        (vertOffset + parseFloat(getComputedStyle(document.documentElement).fontSize)) +
+        'px; right:1rem;';
 
     function navigateReference(e) {
         switch (e.detail.tab) {
@@ -26,10 +35,7 @@ Book Collection Selector component.
     }
 </script>
 
-<Modal id={modalId}>
-    <svelte:fragment slot="label">
-        <BibleIcon color="white" />
-    </svelte:fragment>
+<Modal bind:this={modal} id={modalId} useLabel={false} addCSS={positioningCSS}>
     <svelte:fragment slot="content">
         <!-- TODO: Include other layout options -->
         <TabsMenu
@@ -43,21 +49,23 @@ Book Collection Selector component.
             active="Single Pane"
             on:menuaction={navigateReference}
         />
-        <div style:justify-content="space-between" class="flex w-full">
+        <div style:justify-content="space-between" class="flex w-full dy-modal-action">
             <!-- svelte-ignore a11y-click-events-have-key-events -->
-            <label
-                for={modalId}
+            <button
                 style={convertStyle($s['ui.dialog.button'])}
                 class="dy-btn dy-btn-sm dy-btn-ghost dy-no-animation"
-                on:click={() => (docSet = $refs.docSet)}>Cancel</label
+                on:click={() => (docSet = $refs.docSet)}
             >
+                Cancel
+            </button>
             <!-- svelte-ignore a11y-click-events-have-key-events -->
-            <label
-                for={modalId}
+            <button
                 style={convertStyle($s['ui.dialog.button'])}
                 class="dy-btn dy-btn-sm dy-btn-ghost dy-no-animation"
-                on:click={() => ($refs.docSet = docSet)}>Ok</label
+                on:click={() => ($refs.docSet = docSet)}
             >
+                Ok
+            </button>
         </div>
     </svelte:fragment>
 </Modal>

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -7,15 +7,29 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
 <script>
     import { s, convertStyle } from '$lib/data/stores';
     export let id;
+    let dialog;
+    export let useLabel = true;
+    export function showModal() {
+        dialog.showModal();
+    }
+    export let addCSS = 'position: absolute; top: 1rem;';
 </script>
 
-<!-- The button to open modal -->
-<label for={id} class="dy-btn dy-btn-ghost p-0.5 dy-no-animation"><slot name="label" /></label>
+{#if useLabel}
+    <label for={id} class="dy-btn dy-btn-ghost p-0.5 dy-no-animation" onclick="{id}.showModal()"
+        ><slot name="label" /></label
+    >
+{/if}
 
-<!-- Put this part before </body> tag -->
-<input type="checkbox" {id} class="dy-modal-toggle" />
-<label for={id} class="dy-modal cursor-pointer">
-    <label style={convertStyle($s['ui.dialog'])} class="dy-modal-box relative" for="">
+<dialog bind:this={dialog} {id} class="dy-modal cursor-pointer">
+    <form
+        method="dialog"
+        style={convertStyle($s['ui.dialog']) + addCSS}
+        class="dy-modal-box relative"
+    >
         <slot name="content" />
-    </label>
-</label>
+    </form>
+    <form method="dialog" class="dy-modal-backdrop">
+        <button>close</button>
+    </form>
+</dialog>

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -8,17 +8,20 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
     import { s, convertStyle } from '$lib/data/stores';
     export let id;
     let dialog;
-    export let useLabel = true;
+    export let useLabel = true; //If this is set to false, there will be no button/label with this modal to open it, and the modal may be initialized without filling the label slot.
     export function showModal() {
+        //This exported function allows buttons/labels in other divs to trigger the modal popup (see handleTextAppearanceSelector() and handleCollectionSelector() in +page.svelte).
         dialog.showModal();
     }
-    export let addCSS = 'position: absolute; top: 1rem;';
+    export let addCSS = 'position: absolute; top: 1rem;'; //Here addCSS is a prop for injecting CSS into the modal contents div/form below.
 </script>
 
 {#if useLabel}
-    <label for={id} class="dy-btn dy-btn-ghost p-0.5 dy-no-animation" onclick="{id}.showModal()"
-        ><slot name="label" /></label
-    >
+    <label for={id} class="dy-btn dy-btn-ghost p-0.5 dy-no-animation" onclick="{id}.showModal()">
+        <slot
+            name="label"
+        /><!--Anything passed into this slot will trigger the modal popup when clicked-->
+    </label>
 {/if}
 
 <dialog bind:this={dialog} {id} class="dy-modal cursor-pointer">
@@ -27,9 +30,10 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
         style={convertStyle($s['ui.dialog']) + addCSS}
         class="dy-modal-box relative"
     >
-        <slot name="content" />
+        <slot name="content" /><!--This is the slot for the popup's actual contents-->
     </form>
     <form method="dialog" class="dy-modal-backdrop">
+        <!--This allows the modal to be closed when the user taps outside of the contents div/form-->
         <button>close</button>
     </form>
 </dialog>

--- a/src/lib/components/TextAppearanceSelector.svelte
+++ b/src/lib/components/TextAppearanceSelector.svelte
@@ -24,7 +24,9 @@ TODO
     export function showModal() {
         modal.showModal();
     }
-    export let vertOffset = '1rem';
+
+    export let vertOffset = '1rem'; //Prop that will have the navbar's height (in rem) passed in
+    //The positioningCSS positions the modal 1rem below the navbar and 1rem from the right edge of the screen (on mobile it will be centered)
     $: positioningCSS =
         'position:absolute; top:' +
         (Number(vertOffset.replace('rem', '')) + 1) +
@@ -89,7 +91,8 @@ TODO
 
 <!-- TextAppearanceSelector -->
 {#if showTextAppearence}
-    <Modal bind:this={modal} id={modalId} useLabel={false} addCSS={positioningCSS}>
+    <Modal bind:this={modal} id={modalId} useLabel={false} addCSS={positioningCSS}
+        ><!--addCSS is a prop for injecting CSS into the modal-->
         <svelte:fragment slot="content">
             <!-- Sliders for when text appearence text size is implemented place holder no functionality-->
             {#if showFontSize}

--- a/src/lib/components/TextAppearanceSelector.svelte
+++ b/src/lib/components/TextAppearanceSelector.svelte
@@ -24,11 +24,11 @@ TODO
     export function showModal() {
         modal.showModal();
     }
-    export let vertOffset = '0px';
+    export let vertOffset = '1rem';
     $: positioningCSS =
         'position:absolute; top:' +
-        (vertOffset + parseFloat(getComputedStyle(document.documentElement).fontSize)) +
-        'px; right:1rem;';
+        (Number(vertOffset.replace('rem', '')) + 1) +
+        'rem; right:1rem;';
 
     const showFontSize = config.mainFeatures['text-font-size-slider'];
     const showLineHeight = config.mainFeatures['text-line-height-slider'];

--- a/src/lib/components/TextAppearanceSelector.svelte
+++ b/src/lib/components/TextAppearanceSelector.svelte
@@ -5,7 +5,7 @@ The navbar component. We have sliders that update reactively to both font size a
 TODO
 -->
 <script>
-    import Dropdown from './Dropdown.svelte';
+    import Modal from './Modal.svelte';
     import { TextAppearanceIcon, ImageIcon } from '$lib/icons';
     import {
         language,
@@ -18,6 +18,17 @@ TODO
         direction
     } from '$lib/data/stores';
     import config from '$lib/data/config';
+
+    let modalId = 'textAppearanceSelector';
+    let modal;
+    export function showModal() {
+        modal.showModal();
+    }
+    export let vertOffset = '0px';
+    $: positioningCSS =
+        'position:absolute; top:' +
+        (vertOffset + parseFloat(getComputedStyle(document.documentElement).fontSize)) +
+        'px; right:1rem;';
 
     const showFontSize = config.mainFeatures['text-font-size-slider'];
     const showLineHeight = config.mainFeatures['text-line-height-slider'];
@@ -78,81 +89,72 @@ TODO
 
 <!-- TextAppearanceSelector -->
 {#if showTextAppearence}
-    <div
-        class="dy-dropdown dy-dropdown-bottom {$direction === 'ltr'
-            ? 'dy-dropdown-end'
-            : 'dy-dropdown-right'}"
-    >
-        <Dropdown>
-            <svelte:fragment slot="label">
-                <TextAppearanceIcon color="white" />
-            </svelte:fragment>
-            <svelte:fragment slot="content">
-                <!-- Sliders for when text appearence text size is implemented place holder no functionality-->
-                {#if showFontSize}
-                    <div class="grid gap-4 items-center range-row m-2">
-                        <TextAppearanceIcon color={$monoIconColor} size="1rem" />
-                        <input
-                            type="range"
-                            min={config.mainFeatures['text-size-min']}
-                            max={config.mainFeatures['text-size-max']}
-                            bind:value={$bodyFontSize}
-                            class="dy-range dy-range-xs"
+    <Modal bind:this={modal} id={modalId} useLabel={false} addCSS={positioningCSS}>
+        <svelte:fragment slot="content">
+            <!-- Sliders for when text appearence text size is implemented place holder no functionality-->
+            {#if showFontSize}
+                <div class="grid gap-4 items-center range-row m-2">
+                    <TextAppearanceIcon color={$monoIconColor} size="1rem" />
+                    <input
+                        type="range"
+                        min={config.mainFeatures['text-size-min']}
+                        max={config.mainFeatures['text-size-max']}
+                        bind:value={$bodyFontSize}
+                        class="dy-range dy-range-xs"
+                    />
+                    <div class="text-sm place-self-end">{$bodyFontSize}</div>
+                </div>
+            {/if}
+            {#if showLineHeight}
+                <div class="grid gap-4 items-center range-row m-2">
+                    <ImageIcon.FormatLineSpacing color={$monoIconColor} size="1rem" />
+                    <input
+                        type="range"
+                        min="100"
+                        max="250"
+                        bind:value={$bodyLineHeight}
+                        class="dy-range dy-range-xs"
+                    />
+                    <div class="text-sm place-self-end">
+                        {formatLineHeight($bodyLineHeight)}
+                    </div>
+                </div>
+            {/if}
+            <!-- Theme Selction buttons-->
+            {#if showThemes}
+                <div
+                    class="grid gap-2 m-2"
+                    class:grid-cols-2={themes.length === 2}
+                    class:grid-cols-3={themes.length === 3}
+                >
+                    {#if themes.includes('Normal')}
+                        <button
+                            class="dy-btn-sm"
+                            style:background-color={buttonBackground('Normal')}
+                            style:border={buttonBorder('Normal', $theme)}
+                            on:click={() => ($theme = 'Normal')}
                         />
-                        <div class="text-sm place-self-end">{$bodyFontSize}</div>
-                    </div>
-                {/if}
-                {#if showLineHeight}
-                    <div class="grid gap-4 items-center range-row m-2">
-                        <ImageIcon.FormatLineSpacing color={$monoIconColor} size="1rem" />
-                        <input
-                            type="range"
-                            min="100"
-                            max="250"
-                            bind:value={$bodyLineHeight}
-                            class="dy-range dy-range-xs"
+                    {/if}
+                    {#if themes.includes('Sepia')}
+                        <button
+                            class="dy-btn-sm"
+                            style:background-color={buttonBackground('Sepia')}
+                            style:border={buttonBorder('Sepia', $theme)}
+                            on:click={() => ($theme = 'Sepia')}
                         />
-                        <div class="text-sm place-self-end">
-                            {formatLineHeight($bodyLineHeight)}
-                        </div>
-                    </div>
-                {/if}
-                <!-- Theme Selction buttons-->
-                {#if showThemes}
-                    <div
-                        class="grid gap-2 m-2"
-                        class:grid-cols-2={themes.length === 2}
-                        class:grid-cols-3={themes.length === 3}
-                    >
-                        {#if themes.includes('Normal')}
-                            <button
-                                class="dy-btn-sm"
-                                style:background-color={buttonBackground('Normal')}
-                                style:border={buttonBorder('Normal', $theme)}
-                                on:click={() => ($theme = 'Normal')}
-                            />
-                        {/if}
-                        {#if themes.includes('Sepia')}
-                            <button
-                                class="dy-btn-sm"
-                                style:background-color={buttonBackground('Sepia')}
-                                style:border={buttonBorder('Sepia', $theme)}
-                                on:click={() => ($theme = 'Sepia')}
-                            />
-                        {/if}
-                        {#if themes.includes('Dark')}
-                            <button
-                                class="dy-btn-sm"
-                                style:background-color={buttonBackground('Dark')}
-                                style:border={buttonBorder('Dark', $theme)}
-                                on:click={() => ($theme = 'Dark')}
-                            />
-                        {/if}
-                    </div>
-                {/if}
-            </svelte:fragment>
-        </Dropdown>
-    </div>
+                    {/if}
+                    {#if themes.includes('Dark')}
+                        <button
+                            class="dy-btn-sm"
+                            style:background-color={buttonBackground('Dark')}
+                            style:border={buttonBorder('Dark', $theme)}
+                            on:click={() => ($theme = 'Dark')}
+                        />
+                    {/if}
+                </div>
+            {/if}
+        </svelte:fragment>
+    </Modal>
 {/if}
 
 <style>

--- a/src/lib/icons/TriangleLeftIcon.svelte
+++ b/src/lib/icons/TriangleLeftIcon.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+    // Arrow Left from https://fonts.google.com/icons
+    // Filled = 1
+    // Weight = 400
+    // Grade = 0
+    // Optical size = 24px
+    export let scale = 1.0;
+    export let color = 'black';
+</script>
+
+<svg
+    fill={color}
+    xmlns="http://www.w3.org/2000/svg"
+    height={24 * scale}
+    viewBox="0 -960 960 960"
+    width={24 * scale}
+>
+    <path d="M560-280 360-480l200-200v400Z" />
+</svg>

--- a/src/lib/icons/TriangleRightIcon.svelte
+++ b/src/lib/icons/TriangleRightIcon.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+    // Arrow Right from https://fonts.google.com/icons
+    // Filled = 1
+    // Weight = 400
+    // Grade = 0
+    // Optical size = 24px
+    export let scale = 1.0;
+    export let color = 'black';
+</script>
+
+<svg
+    fill={color}
+    xmlns="http://www.w3.org/2000/svg"
+    height={24 * scale}
+    viewBox="0 -960 960 960"
+    width={24 * scale}
+>
+    <path d="M400-280v-400l200 200-200 200Z" />
+</svg>

--- a/src/lib/icons/index.js
+++ b/src/lib/icons/index.js
@@ -23,6 +23,8 @@ import SideBySideIcon from './SideBySideIcon.svelte';
 import SinglePaneIcon from './SinglePaneIcon.svelte';
 import TextAppearanceIcon from './TextAppearanceIcon.svelte';
 import VerseByVerseIcon from './VerseByVerseIcon.svelte';
+import TriangleLeftIcon from './TriangleLeftIcon.svelte';
+import TriangleRightIcon from './TriangleRightIcon.svelte';
 import { AudioIcon } from './audio';
 import { ImageIcon } from './image';
 
@@ -52,5 +54,7 @@ export {
     SideBySideIcon,
     SinglePaneIcon,
     TextAppearanceIcon,
-    VerseByVerseIcon
+    VerseByVerseIcon,
+    TriangleLeftIcon,
+    TriangleRightIcon
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -110,8 +110,8 @@
         viewShowVerses: $userSettings['verse-numbers']
     };
 
-    $: extraIconsExist = showSearch || showCollections; //was trying document.getElementById('extraButtons').childElementCount; but that caused it to hang forever.
-    let showOverlowMenu = false;
+    $: extraIconsExist = showSearch || showCollections; //Note: was trying document.getElementById('extraButtons').childElementCount; but that caused it to hang forever.
+    let showOverlowMenu = false; //Controls the visibility of the extraButtons div on mobile
     function handleMenuClick(event) {
         showOverlowMenu = false;
     }
@@ -218,18 +218,20 @@
 
     let textAppearanceSelector;
     function handleTextAppearanceSelector() {
-        textAppearanceSelector.showModal();
+        textAppearanceSelector.showModal(); //Uses an exported modal function (see Modal.svelte) to trigger the modal popup
     }
 
     let collectionSelector;
     function handleCollectionSelector() {
-        collectionSelector.showModal();
+        collectionSelector.showModal(); //Uses an exported modal function (see Modal.svelte) to trigger the modal popup
     }
 
     let navBarHeight = '4rem';
 </script>
 
 <div>
+    <!--Div containing the popup modals triggered by the navBar buttons:-->
+
     <!-- Text Appearance Options Menu -->
     <TextAppearanceSelector bind:this={textAppearanceSelector} vertOffset={navBarHeight} />
 
@@ -257,6 +259,7 @@
                           console.log('Clicked in right-buttons but showOverlowMenu = false.');
                       }}
             >
+                <!-- (mobile) handleMenuClick() is called to collpase the extraButtons menu when any button inside right-buttons is clicked. -->
                 <div class="flex">
                     {#if $refs.hasAudio && showAudio}
                         <!-- Mute/Volume Button -->
@@ -275,7 +278,9 @@
                     {/if}
                 </div>
                 <div id="extraButtons" class={showOverlowMenu ? 'flex' : 'hidden md:flex'}>
-                    <!-- Text Appearance Options Menu -->
+                    <!-- An overflow menu containing the other right-buttons. On mobile it expands when overflowMenuButton is clicked and collpases when handleMenuClick() is called, on larger screens these buttons are always visible. -->
+
+                    <!-- Text Appearance Selector Button -->
                     <label
                         for="textAppearanceSelector"
                         class="dy-btn dy-btn-ghost p-0.5 dy-no-animation"
@@ -283,13 +288,14 @@
                         ><TextAppearanceIcon color="white" /></label
                     >
 
+                    <!-- Search Button -->
                     {#if showSearch}
-                        <!-- Search Button -->
                         <a href="{base}/search" class="dy-btn dy-btn-ghost dy-btn-circle">
                             <SearchIcon color="white" />
                         </a>
                     {/if}
 
+                    <!-- Collection Selector Button -->
                     {#if showCollections}
                         <label
                             for="collectionSelector"
@@ -299,7 +305,7 @@
                     {/if}
                 </div>
                 {#if extraIconsExist}
-                    <!-- Overflow Menu Button -->
+                    <!-- overflowMenuButton (on mobile this toggles the visibility of the extraButtons div) -->
                     <button
                         class="md:hidden dy-btn dy-btn-ghost dy-btn-circle"
                         on:click={() => {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -226,7 +226,7 @@
         collectionSelector.showModal();
     }
 
-    let navBarHeight;
+    let navBarHeight = '4rem';
 </script>
 
 <div>
@@ -238,7 +238,7 @@
 </div>
 
 <div class="grid grid-rows-[auto,1fr,auto]" style="height:100vh;height:100dvh;">
-    <div class="navbar h-16" bind:clientHeight={navBarHeight}>
+    <div class="navbar" style="height: {navBarHeight};">
         <Navbar>
             <div
                 slot="left-buttons"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -22,7 +22,14 @@
     } from '$lib/data/stores';
     import { addHistory } from '$lib/data/history';
     import { parseReference } from '$lib/data/stores/store-types';
-    import { AudioIcon, SearchIcon } from '$lib/icons';
+    import {
+        AudioIcon,
+        SearchIcon,
+        TriangleLeftIcon,
+        TriangleRightIcon,
+        BibleIcon,
+        TextAppearanceIcon
+    } from '$lib/icons';
     import Navbar from '$lib/components/Navbar.svelte';
     import TextAppearanceSelector from '$lib/components/TextAppearanceSelector.svelte';
     import config from '$lib/data/config';
@@ -102,6 +109,12 @@
         verseLayout: $userSettings['verse-layout'],
         viewShowVerses: $userSettings['verse-numbers']
     };
+
+    $: extraIconsExist = showSearch || showCollections; //was trying document.getElementById('extraButtons').childElementCount; but that caused it to hang forever.
+    let showOverlowMenu = false;
+    function handleMenuClick(event) {
+        showOverlowMenu = false;
+    }
 
     // Process page parameters
     if ($page.data?.ref) {
@@ -202,45 +215,109 @@
             el?.scrollIntoView();
     };
     $: updateHighlight($audioHighlight, highlightColor, $refs.hasAudio?.timingFile);
+
+    let textAppearanceSelector;
+    function handleTextAppearanceSelector() {
+        textAppearanceSelector.showModal();
+    }
+
+    let collectionSelector;
+    function handleCollectionSelector() {
+        collectionSelector.showModal();
+    }
+
+    let navBarHeight;
 </script>
 
+<div>
+    <!-- Text Appearance Options Menu -->
+    <TextAppearanceSelector bind:this={textAppearanceSelector} vertOffset={navBarHeight} />
+
+    <!-- Collection Selector Menu -->
+    <CollectionSelector bind:this={collectionSelector} vertOffset={navBarHeight} />
+</div>
+
 <div class="grid grid-rows-[auto,1fr,auto]" style="height:100vh;height:100dvh;">
-    <div class="navbar h-16">
+    <div class="navbar h-16" bind:clientHeight={navBarHeight}>
         <Navbar>
-            <div slot="left-buttons">
-                <div class="flex flex-nowrap">
-                    <BookSelector />
-                    <ChapterSelector />
-                </div>
+            <div
+                slot="left-buttons"
+                class={showOverlowMenu ? 'hidden md:flex flex-nowrap' : 'flex flex-nowrap'}
+            >
+                <BookSelector />
+                <ChapterSelector />
             </div>
-            <div slot="right-buttons">
-                {#if $refs.hasAudio && showAudio}
-                    <!-- Mute/Volume Button -->
-                    <button
-                        class="dy-btn dy-btn-ghost dy-btn-circle"
-                        on:click={() => ($audioActive = !$audioActive)}
+            <!-- svelte-ignore a11y-click-events-have-key-events -->
+            <div
+                slot="right-buttons"
+                class="flex flex-nowrap"
+                on:click={showOverlowMenu
+                    ? handleMenuClick
+                    : () => {
+                          console.log('Clicked in right-buttons but showOverlowMenu = false.');
+                      }}
+            >
+                <div class="flex">
+                    {#if $refs.hasAudio && showAudio}
+                        <!-- Mute/Volume Button -->
+                        <button
+                            class="dy-btn dy-btn-ghost dy-btn-circle"
+                            on:click={() => {
+                                $audioActive = !$audioActive;
+                            }}
+                        >
+                            {#if $audioActive}
+                                <AudioIcon.Volume color="white" />
+                            {:else}
+                                <AudioIcon.Mute color="white" />
+                            {/if}
+                        </button>
+                    {/if}
+                </div>
+                <div id="extraButtons" class={showOverlowMenu ? 'flex' : 'hidden md:flex'}>
+                    <!-- Text Appearance Options Menu -->
+                    <label
+                        for="textAppearanceSelector"
+                        class="dy-btn dy-btn-ghost p-0.5 dy-no-animation"
+                        on:click={handleTextAppearanceSelector}
+                        ><TextAppearanceIcon color="white" /></label
                     >
-                        {#if $audioActive}
-                            <AudioIcon.Volume color="white" />
+
+                    {#if showSearch}
+                        <!-- Search Button -->
+                        <a href="{base}/search" class="dy-btn dy-btn-ghost dy-btn-circle">
+                            <SearchIcon color="white" />
+                        </a>
+                    {/if}
+
+                    {#if showCollections}
+                        <label
+                            for="collectionSelector"
+                            class="dy-btn dy-btn-ghost p-0.5 dy-no-animation"
+                            on:click={handleCollectionSelector}><BibleIcon color="white" /></label
+                        >
+                    {/if}
+                </div>
+                {#if extraIconsExist}
+                    <!-- Overflow Menu Button -->
+                    <button
+                        class="md:hidden dy-btn dy-btn-ghost dy-btn-circle"
+                        on:click={() => {
+                            showOverlowMenu = !showOverlowMenu;
+                            event.stopPropagation();
+                        }}
+                    >
+                        {#if showOverlowMenu}
+                            <TriangleRightIcon color="white" scale={1.25} />
                         {:else}
-                            <AudioIcon.Mute color="white" />
+                            <TriangleLeftIcon color="white" scale={1.25} />
                         {/if}
                     </button>
-                {/if}
-                {#if showSearch}
-                    <!-- Search Button -->
-                    <a href="{base}/search" class="dy-btn dy-btn-ghost dy-btn-circle">
-                        <SearchIcon color="white" />
-                    </a>
-                {/if}
-                <!-- Text Appearance Options Menu -->
-                <TextAppearanceSelector />
-                {#if showCollections}
-                    <CollectionSelector />
                 {/if}
             </div>
         </Navbar>
     </div>
+
     <div class:borderimg={showBorder} class="overflow-y-auto">
         <ScrolledContent>
             <div


### PR DESCRIPTION
Resolving issue #208 by:
- Displaying the audio (if there is audio) and text appearance buttons by default on the nav bar.
- Hiding all the rest under a more button.
- When the more button is clicked, it hides the book and chapter and shows all navbar buttons.
- Showing all buttons on screens >= 768px width (implemented via `md:` breakpoint).