### PR TITLE
active tab

### DIFF
--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -192,7 +192,6 @@ The navbar component.
                         visible: showChapterSelector && showVerseSelector
                     }
                 }}
-                active={b}
                 on:menuaction={navigateReference}
             />
         </div>

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -143,7 +143,6 @@ The navbar component.
                             }
                         }}
                         cols="5"
-                        active={c}
                         on:menuaction={navigateReference}
                     />
                 </div>

--- a/src/lib/components/TabsMenu.svelte
+++ b/src/lib/components/TabsMenu.svelte
@@ -8,7 +8,7 @@ A component to display tabbed menus.
 
     export let options: App.TabMenuOptions = { '': { component: '', props: {}, visible: true } };
     export let cols = 6;
-    export let active = '';
+    export let active = Object.keys(options).filter((x) => options[x].visible)[0];
     const dispatch = createEventDispatcher();
     const hasTabs = Object.keys(options).filter((x) => options[x].visible).length > 1;
 


### PR DESCRIPTION
It is not necessary for components to pass in a hardcoded active tab attribute. Neither Book or Chapter selector make use of it, and it makes things complicated for CollectionSelector. If the active tab is set to 'Single Pane' but the 'Single Pane menu is disabled, it will still display the contents since all tabs are being passed to the tab menu despite their visibility:

`showSinglePane: false, showSideBySide: true, showVerseByVerse: true`

<img width="523" alt="Screenshot 2023-06-28 at 3 45 21 PM" src="https://github.com/sillsdev/appbuilder-pwa/assets/78440533/5d158c27-0ecc-431b-8bd5-4539d5686620">

It is possible to set the active tab prop to be the 'default layout option' value but Scripture App Builder allows the user to select a disabled layout option as the default. 

![Screenshot 2023-06-28 at 3 48 44 PM](https://github.com/sillsdev/appbuilder-pwa/assets/78440533/19979a3d-2757-49a5-8917-8647dfbc570b)

Instead, have the tab component menu initialize the active tab to the first available visible tab. 