### PR TITLE
Add IndexedDB update stores

### DIFF
--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -103,7 +103,6 @@ TODO:
             await removeBookmark(selectedVerseInBookmarks);
         }
 
-        await bookmarks.sync();
         selectedVerses.reset();
     }
 
@@ -117,7 +116,6 @@ TODO:
             reference: selectedVerses.getReference(0)
         });
 
-        await notes.sync();
         selectedVerses.reset();
     }
 
@@ -128,7 +126,6 @@ TODO:
             await addHighlights(numColor, $selectedVerses);
         }
 
-        await highlights.sync();
         selectedVerses.reset();
     }
 

--- a/src/lib/data/bookmarks.ts
+++ b/src/lib/data/bookmarks.ts
@@ -1,5 +1,6 @@
 import { openDB, type DBSchema } from "idb";
 import config from '$lib/data/config';
+import { writable } from "svelte/store";
 
 export interface BookmarkItem {
     date: number;
@@ -51,6 +52,7 @@ export async function addBookmark(item: {
         .books.findIndex((x) => x.id === item.book);
     const nextItem = {...item, date: date, bookIndex: bookIndex};
     await bookmarks.add("bookmarks", nextItem);
+    notifyUpdated();
 }
 
 export async function findBookmark(item: {
@@ -83,14 +85,22 @@ export async function findBookmarkByChapter(item: {
 export async function removeBookmark(date: number) {
     const bookmarks = await openBookmarks();
     await bookmarks.delete("bookmarks", date);
+    notifyUpdated();
 }
 
 export async function clearBookmarks() {
     const bookmarks = await openBookmarks();
     await bookmarks.clear("bookmarks");
+    notifyUpdated();
 }
 
 export async function getBookmarks() :Promise<BookmarkItem[]> {
     const bookmarks = await openBookmarks();   
     return await bookmarks.getAll("bookmarks");
 }
+
+function notifyUpdated() {
+    bookmarksLastUpdated.set(Date.now());
+}
+
+export const bookmarksLastUpdated = writable(Date.now());

--- a/src/lib/data/highlights.ts
+++ b/src/lib/data/highlights.ts
@@ -1,5 +1,7 @@
 import { openDB, type DBSchema } from "idb";
 import config from '$lib/data/config';
+import { writable } from "svelte/store";
+
 
 export interface HighlightItem {
     date: number;
@@ -63,6 +65,7 @@ export async function addHighlights(numColor: number, selectedVerses) {
         const nextItem = {...selectedVerse, date: date, bookIndex: bookIndex, penColor: numColor};
         await highlights.add("highlights", nextItem);
     }
+    notifyUpdated();
 }
 
 export async function findHighlight(item: {
@@ -105,14 +108,22 @@ export async function removeHighlights(selectedVerses) {
             index = await findHighlight({...selectedVerse});
         }
     }
+    notifyUpdated();
 }
 
 export async function clearHighlights() {
     const highlights = await openHighlights();
     await highlights.clear("highlights");
+    notifyUpdated();
 }
 
 export async function getHighlights() :Promise<HighlightItem[]> {
     const highlights = await openHighlights();   
     return await highlights.getAll("highlights");
 }
+
+function notifyUpdated() {
+    highlightsLastUpdated.set(Date.now());
+}
+
+export const highlightsLastUpdated = writable(Date.now());

--- a/src/lib/data/notes.ts
+++ b/src/lib/data/notes.ts
@@ -1,5 +1,7 @@
 import { openDB, type DBSchema } from "idb";
 import config from '$lib/data/config';
+import { writable } from "svelte/store";
+
 
 export interface NoteItem {
     date: number;
@@ -51,6 +53,7 @@ export async function addNote(item: {
         .books.findIndex((x) => x.id === item.book);
     const nextItem = {...item, date: date, bookIndex: bookIndex};
     await notes.add("notes", nextItem);
+    notifyUpdated();
 }
 
 export async function findNote(item: {
@@ -83,14 +86,22 @@ export async function findNoteByChapter(item: {
 export async function removeNote(date: number) {
     const notes = await openNotes();
     await notes.delete("notes", date);
+    notifyUpdated();
 }
 
 export async function clearNotes() {
     const notes = await openNotes();
     await notes.clear("notes");
+    notifyUpdated();
 }
 
 export async function getNotes() :Promise<NoteItem[]> {
     const notes = await openNotes();   
     return await notes.getAll("notes");
 }
+
+function notifyUpdated() {
+    notesLastUpdated.set(Date.now());
+}
+
+export const notesLastUpdated = writable(Date.now());

--- a/src/lib/data/stores/annotation.js
+++ b/src/lib/data/stores/annotation.js
@@ -1,61 +1,20 @@
-import { writable, get } from "svelte/store";
-import { setDefaultStorage } from "./storage";
+import { writable, get, derived } from "svelte/store";
 import { refs } from "./scripture";
-import { findBookmarkByChapter } from "$lib/data/bookmarks";
-import { findHighlightByChapter } from "$lib/data/highlights";
-import { findNoteByChapter } from "$lib/data/notes";
+import { findBookmarkByChapter, bookmarksLastUpdated } from "$lib/data/bookmarks";
+import { findHighlightByChapter, highlightsLastUpdated } from "$lib/data/highlights";
+import { findNoteByChapter, notesLastUpdated } from "$lib/data/notes";
 
-/* list of bookmarks */
-function createBookmarks() {
-    const {subscribe, set} = writable([]);
-    const fetchData = async (item) => {
-        const foundBookmarks = await findBookmarkByChapter(item);
-        set(foundBookmarks);
-    };
+/* list of bookmarks for the current collection/book/chapter */
+export const bookmarks = derived([refs, bookmarksLastUpdated], ([$refs]) => {
+    return findBookmarkByChapter($refs);
+});
 
-    refs.subscribe(item => {
-        fetchData(item);
-    });
-    
-    return {
-        subscribe, 
-        sync: async () => await fetchData(get(refs))
-    };
-}
-export const bookmarks = createBookmarks();
+/* list of highlights for the current collection/book/chapter */
+export const highlights = derived([refs, highlightsLastUpdated], ([$refs]) => {
+    return findHighlightByChapter($refs);
+});
 
-function createHighlights() {
-    const {subscribe, set} = writable([]);
-    const fetchData = async (item) => {
-        const foundHighlights = await findHighlightByChapter(item);
-        set(foundHighlights);
-    };
-
-    refs.subscribe(item => {
-        fetchData(item);
-    });
-    
-    return {
-        subscribe, 
-        sync: async () => await fetchData(get(refs))
-    };
-}
-export const highlights = createHighlights();
-
-function createNotes() {
-    const {subscribe, set} = writable([]);
-    const fetchData = async (item) => {
-        const foundNotes = await findNoteByChapter(item);
-        set(foundNotes);
-    };
-
-    refs.subscribe(item => {
-        fetchData(item);
-    });
-    
-    return {
-        subscribe, 
-        sync: async () => await fetchData(get(refs))
-    };
-}
-export const notes = createNotes();
+/* list of notes for the current collection/book/chapter */
+export const notes = derived([refs, notesLastUpdated], ([$refs]) => {
+    return findNoteByChapter($refs);
+});


### PR DESCRIPTION
* We have annotation stores (bookmarks, notes, highlights) for the current chapter.  If an annotation is added to the current chapter then these need to be updated but there wasn't a way for these stores to be dependent on the IndexedDB update.
* Introduce a store for when IndexedDB is changes. Greatly simplifies the annotation stores to just use derived().