### PR TITLE
Update proskomma-json-tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6537,9 +6537,9 @@
             }
         },
         "node_modules/proskomma-json-tools": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/proskomma-json-tools/-/proskomma-json-tools-0.7.1.tgz",
-            "integrity": "sha512-8a8eKJwbOgvabCe+Kv97zKnp1WAnwo6zU0jc3dPNILFUZojxzeXjH7xu/Jk6tbwC8TBPK57ldJSoQ6S9eTvD3w==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/proskomma-json-tools/-/proskomma-json-tools-0.7.2.tgz",
+            "integrity": "sha512-HPS2VuefQOTb2Wwz4R4YfGKF3d3FXUnu57zfO5nOrWt6WLXbxBR9KUVE9JuVm+ASi2QNM7mmJH/P/bekCndIRw==",
             "dev": true,
             "dependencies": {
                 "@babel/core": "^7.17.10",
@@ -13675,9 +13675,9 @@
             }
         },
         "proskomma-json-tools": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/proskomma-json-tools/-/proskomma-json-tools-0.7.1.tgz",
-            "integrity": "sha512-8a8eKJwbOgvabCe+Kv97zKnp1WAnwo6zU0jc3dPNILFUZojxzeXjH7xu/Jk6tbwC8TBPK57ldJSoQ6S9eTvD3w==",
+            "version": "0.7.2",
+            "resolved": "https://registry.npmjs.org/proskomma-json-tools/-/proskomma-json-tools-0.7.2.tgz",
+            "integrity": "sha512-HPS2VuefQOTb2Wwz4R4YfGKF3d3FXUnu57zfO5nOrWt6WLXbxBR9KUVE9JuVm+ASi2QNM7mmJH/P/bekCndIRw==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.17.10",


### PR DESCRIPTION
* We're seeing 'none' as the verse number when parsing.
* The start verses event was not being called.
* Updating proskomma-json-tools to 0.7.2 seems to have fixed it for the
  moment.