### PR TITLE
#290 Feature: Layout Menu on First Launch

### DIFF
--- a/src/lib/components/TextAppearanceSelector.svelte
+++ b/src/lib/components/TextAppearanceSelector.svelte
@@ -2,7 +2,6 @@
 @component
 The navbar component. We have sliders that update reactively to both font size and line height.
 3 buttons to change the style from normal, sepia and dark.
-TODO
 -->
 <script>
     import Modal from './Modal.svelte';

--- a/src/lib/data/stores/view.js
+++ b/src/lib/data/stores/view.js
@@ -8,6 +8,9 @@ export const NAVBAR_HEIGHT = '4rem';
 /**a group of writable stores to store the top visible verse in a group*/
 export const scrolls = groupStore(writable, 'title');
 /**the current view/layout mode*/
+setDefaultStorage('firstLaunch', true);
+export const firstLaunch = writable(localStorage.firstLaunch === 'true');
+firstLaunch.subscribe((bool) => (localStorage.firstLaunch = bool));
 export const LAYOUT_SINGLE = 'single';
 export const LAYOUT_TWO = 'two';
 export const LAYOUT_VERSE_BY_VERSE = 'verse-by-verse';

--- a/src/lib/data/stores/view.js
+++ b/src/lib/data/stores/view.js
@@ -5,12 +5,14 @@ import { userSettings } from './setting';
 
 export const NAVBAR_HEIGHT = '4rem';
 
-/**a group of writable stores to store the top visible verse in a group*/
-export const scrolls = groupStore(writable, 'title');
-/**the current view/layout mode*/
+/** a local storage flag that keeps track of if the page is at its very first launch */
 setDefaultStorage('firstLaunch', true);
 export const firstLaunch = writable(localStorage.firstLaunch === 'true');
 firstLaunch.subscribe((bool) => (localStorage.firstLaunch = bool));
+
+/**a group of writable stores to store the top visible verse in a group*/
+export const scrolls = groupStore(writable, 'title');
+/**the current view/layout mode*/
 export const LAYOUT_SINGLE = 'single';
 export const LAYOUT_TWO = 'two';
 export const LAYOUT_VERSE_BY_VERSE = 'verse-by-verse';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,6 +10,7 @@
         bookmarks,
         convertStyle,
         direction,
+        firstLaunch,
         highlights,
         mainScroll,
         audioHighlightElements,
@@ -45,7 +46,7 @@
     import TextSelectionToolbar from '$lib/components/TextSelectionToolbar.svelte';
     import { base } from '$app/paths';
     import { page } from '$app/stores';
-    import { onDestroy } from 'svelte';
+    import { onDestroy, onMount } from 'svelte';
 
     function doSwipe(
         event: CustomEvent<{
@@ -97,9 +98,9 @@
     );
 
     const showSearch = config.mainFeatures['search'];
-    const showCollections =
-        config.bookCollections.length > 1 &&
-        config.mainFeatures['layout-config-change-toolbar-button'];
+    const enoughCollections = config.bookCollections.length > 1;
+    const showCollectionNavbar = config.mainFeatures['layout-config-change-toolbar-button'];
+    const showCollectionsOnFirstLaunch = config.mainFeatures['layout-config-first-launch'];
     const showCollectionViewer = config.mainFeatures['layout-config-change-viewer-button'];
     const showAudio = config.mainFeatures['audio-allow-turn-on-off'];
     $: showBorder = config.traits['has-borders'] && $userSettings['show-border'];
@@ -119,7 +120,7 @@
         proskomma: $page.data?.proskomma
     };
 
-    $: extraIconsExist = showSearch || showCollections; //Note: was trying document.getElementById('extraButtons').childElementCount; but that caused it to hang forever.
+    $: extraIconsExist = showSearch || showCollectionNavbar; //Note: was trying document.getElementById('extraButtons').childElementCount; but that caused it to hang forever.
     let showOverlowMenu = false; //Controls the visibility of the extraButtons div on mobile
     function handleMenuClick(event) {
         showOverlowMenu = false;
@@ -219,6 +220,13 @@
     $: updateHighlight($audioHighlightElements, highlightColor);
     $: updateAudioPlayer($refs);
     const navBarHeight = NAVBAR_HEIGHT;
+    onMount(() => {
+        if ($firstLaunch && showCollectionsOnFirstLaunch && enoughCollections) {
+            console.log('open on first launch');
+            modal.open(MODAL_COLLECTION);
+            $firstLaunch = false;
+        }
+    });
 </script>
 
 <div class="grid grid-rows-[auto,1fr,auto]" style="height:100vh;height:100dvh;">
@@ -278,7 +286,7 @@
                     {/if}
 
                     <!-- Collection Selector Button -->
-                    {#if showCollections}
+                    {#if showCollectionNavbar && enoughCollections}
                         <label
                             for="collectionSelector"
                             class="dy-btn dy-btn-ghost p-0.5 dy-no-animation"
@@ -307,7 +315,7 @@
             </div>
         </Navbar>
     </div>
-    {#if showCollectionViewer && showCollections}
+    {#if showCollectionViewer && enoughCollections}
         <!-- svelte-ignore a11y-click-events-have-key-events -->
         <div
             class="absolute dy-badge dy-badge-outline dy-badge-md rounded-sm p-1 end-3 m-1 cursor-pointer"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -221,9 +221,10 @@
     $: updateAudioPlayer($refs);
     const navBarHeight = NAVBAR_HEIGHT;
     onMount(() => {
-        if ($firstLaunch && showCollectionsOnFirstLaunch && enoughCollections) {
-            console.log('open on first launch');
-            modal.open(MODAL_COLLECTION);
+        if ($firstLaunch) {
+            if (showCollectionsOnFirstLaunch && enoughCollections) {
+                modal.open(MODAL_COLLECTION);
+            }
             $firstLaunch = false;
         }
     });


### PR DESCRIPTION
This pull request implements feature #290 by
- Adding a local storage flag that tracks whether or not this launch is the first ever launch
- Displays modal on first launch based on the following conditionals: 
  - `firstLaunch`: a store object that contains a boolean of whether or not this is the first launch ever on a device.
  - `showColllectionsOnFirstLaunch`: a boolean value pulled from SAB of if the user wants to display the menu on first launch
  - `enoughCollections`: a boolean value assigned to true iff there are at least two book collections for the user to choose from. 