### PR TITLE
Resolve Layout 'cols' warning

### DIFF
--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -107,6 +107,7 @@ The navbar component.
                             [c]: {
                                 component: SelectGrid,
                                 props: {
+                                    cols: 5,
                                     options: [
                                         {
                                             rows: books.find((x) => x.bookCode === book)
@@ -130,6 +131,7 @@ The navbar component.
                             [v]: {
                                 component: SelectGrid,
                                 props: {
+                                    cols: 5,
                                     options: [
                                         {
                                             cells: Object.keys(chapters[chapter]).map((x) => ({
@@ -142,7 +144,6 @@ The navbar component.
                                 visible: showVerseSelector
                             }
                         }}
-                        cols="5"
                         on:menuaction={navigateReference}
                     />
                 </div>

--- a/src/lib/components/TabsMenu.svelte
+++ b/src/lib/components/TabsMenu.svelte
@@ -9,7 +9,6 @@ A component to display tabbed menus.
     import { s, convertStyle } from '$lib/data/stores';
 
     export let options: App.TabMenuOptions = { '': { component: '', props: {}, visible: true } };
-    export let cols = 6;
     export let active = Object.keys(options).filter((x) => options[x].visible)[0];
     export let scroll = true;
     export let height = '50vh';
@@ -66,7 +65,6 @@ A component to display tabbed menus.
 >
     <svelte:component
         this={options[active].component}
-        {cols}
         on:menuaction={handleMenuaction}
         {...options[active].props}
     />


### PR DESCRIPTION
Tab Menu was passing cols value as prop to its child component. Not all child components use the cols property so cols was moved to the props handler of the tab props object that is passed to the child.