### PR TITLE
Implement Share All

### DIFF
--- a/src/lib/data/annotation-share.ts
+++ b/src/lib/data/annotation-share.ts
@@ -1,0 +1,34 @@
+import config from '$lib/data/config';
+
+export async function shareAnnotation(annotation: any) {
+    try {
+        await navigator.share({
+            title: config.name,
+            text: annotation.reference + '\n' + annotation.text
+        })
+        console.log('Successfully shared');
+    }
+    catch (error) {
+        console.error('Error sharing: ', error);
+    }
+}
+
+export async function shareAnnotations(annotations: any) {
+    let text = config.name;
+    annotations.forEach((item) => {
+        text += '\n\n' + item.reference + '\n' + item.text;
+    });
+
+    const file = new File([text], 'annotations.txt', { type: 'text/plain' });
+
+    try {
+        await navigator.share({
+            title: config.name,
+            files: [file]
+        })
+        console.log('Successfully shared');
+    }
+    catch (error) {
+        console.error('Error sharing: ', error);
+    }
+}

--- a/src/routes/bookmarks/+page.svelte
+++ b/src/routes/bookmarks/+page.svelte
@@ -2,6 +2,7 @@
     import IconCard from '$lib/components/IconCard.svelte';
     import SortMenu from '$lib/components/SortMenu.svelte';
     import { BookmarkIcon } from '$lib/icons';
+    import ShareIcon from '$lib/icons/ShareIcon.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
     import { refs, t } from '$lib/data/stores';
     import { formatDate } from '$lib/scripts/dateUtils';
@@ -11,7 +12,7 @@
     import { page } from '$app/stores';
     import { base } from '$app/paths';
     import { goto } from '$app/navigation';
-    import config from '$lib/data/config';
+    import { shareAnnotation, shareAnnotations } from '$lib/data/annotation-share';
 
     async function handleMenuAction(event: CustomEvent, bookmark: BookmarkItem) {
         switch (event.detail.text) {
@@ -20,10 +21,7 @@
                 goto(`${base}/`);
                 break;
             case $t['Annotation_Menu_Share']:
-                await navigator.share({
-                    title: config.name,
-                    text: bookmark.reference + '\n' + bookmark.text
-                });
+                shareAnnotation(bookmark);
                 break;
             case $t['Annotation_Menu_Delete']:
                 await removeBookmark(bookmark.date);
@@ -59,9 +57,16 @@
             </label>
 
             <!-- svelte-ignore a11y-label-has-associated-control -->
-            <label slot="right-buttons">
+            <div slot="right-buttons">
+                <button
+                    class="dy-btn dy-btn-ghost dy-btn-circle"
+                    on:click={async () =>
+                        shareAnnotations(toSorted($page.data.bookmarks, sortOrder))}
+                >
+                    <ShareIcon color="white" />
+                </button>
                 <SortMenu on:menuaction={(e) => handleSortAction(e)} {...sortMenu} />
-            </label>
+            </div>
             <!-- <div slot="right-buttons" /> -->
         </Navbar>
     </div>

--- a/src/routes/highlights/+page.svelte
+++ b/src/routes/highlights/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
     import ColorCard from '$lib/components/ColorCard.svelte';
     import SortMenu from '$lib/components/SortMenu.svelte';
+    import ShareIcon from '$lib/icons/ShareIcon.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
-    import { notes, refs, t } from '$lib/data/stores';
+    import { refs, t } from '$lib/data/stores';
     import { formatDate } from '$lib/scripts/dateUtils';
     import { removeHighlight, type HighlightItem } from '$lib/data/highlights';
     import { SORT_COLOR, SORT_DATE, SORT_REFERENCE, toSorted } from '$lib/data/annotation-sort';
@@ -10,7 +11,7 @@
     import { page } from '$app/stores';
     import { base } from '$app/paths';
     import { goto } from '$app/navigation';
-    import config from '$lib/data/config';
+    import { shareAnnotation, shareAnnotations } from '$lib/data/annotation-share';
 
     async function handleMenuaction(event: CustomEvent, highlight: HighlightItem) {
         switch (event.detail.text) {
@@ -19,10 +20,7 @@
                 goto(`${base}/`);
                 break;
             case $t['Annotation_Menu_Share']:
-                await navigator.share({
-                    title: config.name,
-                    text: highlight.text + '\n' + highlight.reference
-                });
+                shareAnnotation(highlight);
                 break;
             case $t['Annotation_Menu_Delete']:
                 await removeHighlight(highlight.date);
@@ -65,9 +63,16 @@
             </label>
 
             <!-- svelte-ignore a11y-label-has-associated-control -->
-            <label slot="right-buttons">
+            <div slot="right-buttons">
+                <button
+                    class="dy-btn dy-btn-ghost dy-btn-circle"
+                    on:click={async () =>
+                        shareAnnotations(toSorted($page.data.highlights, sortOrder))}
+                >
+                    <ShareIcon color="white" />
+                </button>
                 <SortMenu on:menuaction={(e) => handleSortAction(e)} {...sortMenu} />
-            </label>
+            </div>
             <!-- <div slot="right-buttons" /> -->
         </Navbar>
     </div>

--- a/src/routes/notes/+page.svelte
+++ b/src/routes/notes/+page.svelte
@@ -2,6 +2,7 @@
     import IconCard from '$lib/components/IconCard.svelte';
     import SortMenu from '$lib/components/SortMenu.svelte';
     import { NoteIcon } from '$lib/icons';
+    import ShareIcon from '$lib/icons/ShareIcon.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
     import { t, monoIconColor, refs, bookmarks } from '$lib/data/stores';
     import { formatDate } from '$lib/scripts/dateUtils';
@@ -11,7 +12,7 @@
     import { page } from '$app/stores';
     import { base } from '$app/paths';
     import { goto } from '$app/navigation';
-    import config from '$lib/data/config';
+    import { shareAnnotation, shareAnnotations } from '$lib/data/annotation-share';
 
     async function handleMenuaction(event: CustomEvent, note: NoteItem) {
         switch (event.detail.text) {
@@ -23,10 +24,7 @@
                 console.log('Ready to edit: ', note.reference, ' ', note.text);
                 break;
             case $t['Annotation_Menu_Share']:
-                await navigator.share({
-                    title: config.name,
-                    text: note.text + '\n' + note.reference
-                });
+                shareAnnotation(note);
                 break;
             case $t['Annotation_Menu_Delete']:
                 await removeNote(note.date);
@@ -62,9 +60,15 @@
             </label>
 
             <!-- svelte-ignore a11y-label-has-associated-control -->
-            <label slot="right-buttons">
+            <div slot="right-buttons">
+                <button
+                    class="dy-btn dy-btn-ghost dy-btn-circle"
+                    on:click={async () => shareAnnotations(toSorted($page.data.notes, sortOrder))}
+                >
+                    <ShareIcon color="white" />
+                </button>
                 <SortMenu on:menuaction={(e) => handleSortAction(e)} {...sortMenu} />
-            </label>
+            </div>
             <!-- <div slot="right-buttons" /> -->
         </Navbar>
     </div>


### PR DESCRIPTION
This adds the button for and implements the share all functionality for bookmarks, highlights, and notes. It also edits the regular Share functionality by changing it to a function from a separate share file. Has strange error on the bookmarks page which is being investigated. Fixes #358