### PR TITLE
Implement Text Alignment

### DIFF
--- a/src/lib/components/ColorCard.svelte
+++ b/src/lib/components/ColorCard.svelte
@@ -31,7 +31,7 @@ TODO:
             </a>
         </div>
         <div class="self-center justify-self-end"><CardMenu on:menuaction {actions} /></div>
-        <div class="annotation-item-text col-span-3">
+        <div class="annotation-item-text col-start-2 col-end-3">
             <a
                 style="text-decoration:none;"
                 href="{base}/"

--- a/src/lib/components/IconCard.svelte
+++ b/src/lib/components/IconCard.svelte
@@ -49,7 +49,7 @@ TODO:
         <div class="self-center justify-self-end"><CardMenu on:menuaction {actions} /></div>
 
         <div
-            class="annotation-item-text col-span-3 justify-self-start"
+            class="annotation-item-text col-start-2 col-end-3 justify-self-start"
             class:justify-self-end={justifyEnd}
         >
             <a


### PR DESCRIPTION
Implements proper text alignment of the main body text of the bookmarks, highlights and notes cards so that it starts after the icon and does not go past the three dot dropdown menu. Fixes issue #308