### PR TITLE
Enable text selection toolbar play button functionality

### DIFF
--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -19,7 +19,7 @@ TODO:
     import { prepareAudioPhraseEndChars, parsePhrase } from '$lib/scripts/parsePhrase';
     import { createVideoBlock, addVideoLinks } from '$lib/video';
     import { loadDocSetIfNotLoaded } from '$lib/data/scripture';
-    import { seekToVerse, seekToVerseBasedOnNumberClicked } from '$lib/data/audio';
+    import { seekBasedOnNumber } from '$lib/data/audio';
     import { audioPlayer } from '$lib/data/stores';
 
     export let audioPhraseEndChars: string;
@@ -264,7 +264,7 @@ TODO:
         const element = click.target.textContent;
         const verseSelection = document.querySelector('[data-verse="' + element + '"]');
         const verseId = verseSelection.getAttribute('id');
-        seekToVerseBasedOnNumberClicked(verseId);
+        seekBasedOnNumber(verseId);
     }
     function addNotesDiv(workspace) {
         const fnc = 'abcdefghijklmnopqrstuvwxyz';
@@ -410,9 +410,7 @@ TODO:
             audioClickHandler(e);
         } else {
             if (!$audioPlayer.playing) {
-                const x = onClickText(e, selectedVerses, maxSelections);
-                const tagSelected = x + 'a';
-                seekToVerse(tagSelected);
+                onClickText(e, selectedVerses, maxSelections);
             }
         }
     }

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -417,11 +417,11 @@ TODO:
         if (e.target.getAttribute('class') === 'v') {
             audioClickHandler(e);
         } else {
-            if (!$audioPlayer.playing){
-            const x = onClickText(e, selectedVerses, maxSelections);
-            const tagSelected = x + 'a';
-            seekToVerse(tagSelected);
-        }   
+            if (!$audioPlayer.playing) {
+                const x = onClickText(e, selectedVerses, maxSelections);
+                const tagSelected = x + 'a';
+                seekToVerse(tagSelected);
+            }
         }
     }
 

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -266,14 +266,6 @@ TODO:
         const verseId = verseSelection.getAttribute('id');
         seekToVerseBasedOnNumberClicked(verseId);
     }
-    // function selectionAudioClickHandler(click){
-    //     // const element = click.target.id;
-    //     // console.log(element);
-    //     // const x =element.replace(/[a-z]/g, 'a');
-    //     // const x = onClickText(
-    //     // console.log(x);
-    //     // seekToVerse(x);
-    // }
     function addNotesDiv(workspace) {
         const fnc = 'abcdefghijklmnopqrstuvwxyz';
         const phraseIndex = fnc.charAt(workspace.currentPhraseIndex);

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -19,7 +19,7 @@ TODO:
     import { prepareAudioPhraseEndChars, parsePhrase } from '$lib/scripts/parsePhrase';
     import { createVideoBlock, addVideoLinks } from '$lib/video';
     import { loadDocSetIfNotLoaded } from '$lib/data/scripture';
-    import { seekBasedOnNumber } from '$lib/data/audio';
+    import { seekToVerse, hasAudioPlayed } from '$lib/data/audio';
     import { audioPlayer } from '$lib/data/stores';
 
     export let audioPhraseEndChars: string;
@@ -261,10 +261,13 @@ TODO:
     }
     // handles clicks on verse numbers
     function audioClickHandler(click) {
+        if (!hasAudioPlayed()) {
+            return;
+        }
         const element = click.target.textContent;
         const verseSelection = document.querySelector('[data-verse="' + element + '"]');
         const verseId = verseSelection.getAttribute('id');
-        seekBasedOnNumber(verseId);
+        seekToVerse(verseId);
     }
     function addNotesDiv(workspace) {
         const fnc = 'abcdefghijklmnopqrstuvwxyz';

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -19,7 +19,8 @@ TODO:
     import { prepareAudioPhraseEndChars, parsePhrase } from '$lib/scripts/parsePhrase';
     import { createVideoBlock, addVideoLinks } from '$lib/video';
     import { loadDocSetIfNotLoaded } from '$lib/data/scripture';
-    import { seekToVerse } from '$lib/data/audio';
+    import { seekToVerse, seekToVerseBasedOnNumberClicked } from '$lib/data/audio';
+    import { audioPlayer } from '$lib/data/stores';
 
     export let audioPhraseEndChars: string;
     export let bodyFontSize: any;
@@ -263,9 +264,16 @@ TODO:
         const element = click.target.textContent;
         const verseSelection = document.querySelector('[data-verse="' + element + '"]');
         const verseId = verseSelection.getAttribute('id');
-        seekToVerse(verseId);
+        seekToVerseBasedOnNumberClicked(verseId);
     }
-
+    // function selectionAudioClickHandler(click){
+    //     // const element = click.target.id;
+    //     // console.log(element);
+    //     // const x =element.replace(/[a-z]/g, 'a');
+    //     // const x = onClickText(
+    //     // console.log(x);
+    //     // seekToVerse(x);
+    // }
     function addNotesDiv(workspace) {
         const fnc = 'abcdefghijklmnopqrstuvwxyz';
         const phraseIndex = fnc.charAt(workspace.currentPhraseIndex);
@@ -409,7 +417,11 @@ TODO:
         if (e.target.getAttribute('class') === 'v') {
             audioClickHandler(e);
         } else {
-            onClickText(e, selectedVerses, maxSelections);
+            if (!$audioPlayer.playing){
+            const x = onClickText(e, selectedVerses, maxSelections);
+            const tagSelected = x + 'a';
+            seekToVerse(tagSelected);
+        }   
         }
     }
 

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -41,7 +41,7 @@ TODO:
     import { addHighlights, removeHighlights } from '$lib/data/highlights';
     import { shareText, shareImage } from '$lib/data/share';
     import { base } from '$app/paths';
-
+    import { playPause } from '$lib/data/audio';
     const isAudioPlayable = config?.mainFeatures['text-select-play-audio'];
     const isRepeatableAudio = config?.mainFeatures['audio-repeat-selection-button'];
     const isTextOnImageEnabled = config?.mainFeatures['text-on-image'];
@@ -100,7 +100,11 @@ TODO:
 
         selectedVerses.reset();
     }
-
+    // resets underlined verses and plays verse audio
+    function playVerseAudio(){
+        playPause();
+        selectedVerses.reset();
+    }
     async function copy() {
         var copyText =
             (await selectedVerses.getCompositeText()) +
@@ -178,12 +182,14 @@ TODO:
                     />
                 </div>
             {:else}
-                {#if isAudioPlayable}
-                    <button class="dy-btn-sm dy-btn-ghost">
-                        <AudioIcon.Play color={barIconColor} />
+                {#if isAudioPlayable && $refs.hasAudio && $refs.hasAudio.timingFile}
+                    <button 
+                    class="dy-btn-sm dy-btn-ghost"
+                    on:click={() => playVerseAudio()}>
+                    <AudioIcon.Play color={barIconColor} />
                     </button>
                 {/if}
-                {#if isRepeatableAudio}
+                {#if isRepeatableAudio && $refs.hasAudio && $refs.hasAudio.timingFile}
                     <button class="dy-btn-sm dy-btn-ghost">
                         <AudioIcon.PlayRepeat color={barIconColor} />
                     </button>

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -101,7 +101,7 @@ TODO:
         selectedVerses.reset();
     }
     // resets underlined verses and plays verse audio
-    function playVerseAudio(){
+    function playVerseAudio() {
         playPause();
         selectedVerses.reset();
     }
@@ -183,10 +183,8 @@ TODO:
                 </div>
             {:else}
                 {#if isAudioPlayable && $refs.hasAudio && $refs.hasAudio.timingFile}
-                    <button 
-                    class="dy-btn-sm dy-btn-ghost"
-                    on:click={() => playVerseAudio()}>
-                    <AudioIcon.Play color={barIconColor} />
+                    <button class="dy-btn-sm dy-btn-ghost" on:click={() => playVerseAudio()}>
+                        <AudioIcon.Play color={barIconColor} />
                     </button>
                 {/if}
                 {#if isRepeatableAudio && $refs.hasAudio && $refs.hasAudio.timingFile}

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -42,7 +42,7 @@ TODO:
     import { addHighlights, removeHighlights } from '$lib/data/highlights';
     import { shareText, shareImage } from '$lib/data/share';
     import { base } from '$app/paths';
-    import { playPause } from '$lib/data/audio';
+    import { play, seekToVerse } from '$lib/data/audio';
     const isAudioPlayable = config?.mainFeatures['text-select-play-audio'];
     const isRepeatableAudio = config?.mainFeatures['audio-repeat-selection-button'];
     const isTextOnImageEnabled = config?.mainFeatures['text-on-image'];
@@ -103,7 +103,10 @@ TODO:
     }
     // resets underlined verses and plays verse audio
     function playVerseAudio() {
-        playPause();
+        const element = $selectedVerses[0].verse
+        const tagSelected = element + 'a';
+        seekToVerse(tagSelected);
+        play();
         $audioActive = true;
         selectedVerses.reset();
     }

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -103,7 +103,7 @@ TODO:
     }
     // resets underlined verses and plays verse audio
     function playVerseAudio() {
-        const element = $selectedVerses[0].verse
+        const element = $selectedVerses[0].verse;
         const tagSelected = element + 'a';
         seekToVerse(tagSelected);
         play();

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -34,7 +34,8 @@ TODO:
         theme,
         themeColors,
         highlights,
-        bookmarks
+        bookmarks,
+        audioActive
     } from '$lib/data/stores';
     import toast, { Toaster } from 'svelte-french-toast';
     import { addBookmark, findBookmark, removeBookmark } from '$lib/data/bookmarks';
@@ -103,6 +104,7 @@ TODO:
     // resets underlined verses and plays verse audio
     function playVerseAudio() {
         playPause();
+        $audioActive = true;
         selectedVerses.reset();
     }
     async function copy() {

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -295,4 +295,3 @@ export function seekToVerse(verseClicked) {
     //forces highlighting change
     updateTime();
 }
-

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -292,13 +292,8 @@ export function seekToVerse(verseClicked) {
             break;
         }
     }
-}
-// this function is called when a verse number is clicked on and changes the audio to that verse
-export function seekBasedOnNumber(verseId) {
-    if (!hasAudioPlayed()) {
-        return;
-    }
-    // Calls seek to verse to find the verse associtated with the verse number clicked. Calls update time to change highlighting.
-    seekToVerse(verseId);
+    //forces highlighting change
     updateTime();
+}
+    }
 }

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -157,7 +157,7 @@ function toggleTimeRunning() {
     return;
 }
 // checks if audio has played
-function hasAudioPlayed() {
+export function hasAudioPlayed() {
     return currentAudioPlayer.progress > 0;
 }
 function pause() {
@@ -295,5 +295,4 @@ export function seekToVerse(verseClicked) {
     //forces highlighting change
     updateTime();
 }
-    }
-}
+

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -17,7 +17,7 @@ interface AudioPlayer {
     timer: number;
 }
 const cache = new MRUCache<string, AudioPlayer>(10);
-let currentAudioPlayer;
+export let currentAudioPlayer;
 audioPlayerStore.subscribe(async (value) => {
     currentAudioPlayer = value;
     await getAudio();
@@ -278,10 +278,9 @@ export async function getAudioSourceInfo(item: {
         timing: timing.length > 0 ? timing : null
     };
 }
-
-// changes audio to the verse number clicked on
+// changes audio to the verse clicked on
 export function seekToVerse(verseId) {
-    if (!hasAudioPlayed()) {
+    if (!currentAudioPlayer.timing) {
         return;
     }
     const elements = currentAudioPlayer.timing;
@@ -290,8 +289,15 @@ export function seekToVerse(verseId) {
         if (verseId === tag) {
             const newtime = currentAudioPlayer.timing[i].starttime;
             seek(newtime);
-            updateTime();
             break;
         }
     }
+}
+// changes audio to the verse number clicked on
+export function seekToVerseBasedOnNumberClicked(verseId) {
+    if (!hasAudioPlayed()) {
+        return;
+    }
+    seekToVerse(verseId);
+    updateTime();
 }

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -169,7 +169,7 @@ function pause() {
     toggleTimeRunning();
 }
 
-function play() {
+export function play() {
     if (!currentAudioPlayer.loaded) return;
     if (!currentAudioPlayer.playing) {
         currentAudioPlayer.audio?.play();
@@ -294,7 +294,7 @@ export function seekToVerse(verseId) {
     }
 }
 // changes audio to the verse number clicked on
-export function seekToVerseBasedOnNumberClicked(verseId) {
+export function seekBasedOnNumber(verseId) {
     if (!hasAudioPlayed()) {
         return;
     }

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -278,26 +278,27 @@ export async function getAudioSourceInfo(item: {
         timing: timing.length > 0 ? timing : null
     };
 }
-// changes audio to the verse clicked on
-export function seekToVerse(verseId) {
+// This function can be called when the text selection toolbar play button is clicked on and it changes the audio to the start of the verse clicked on
+export function seekToVerse(verseClicked) {
     if (!currentAudioPlayer.timing) {
         return;
     }
     const elements = currentAudioPlayer.timing;
     for (let i = 0; i < elements.length; i++) {
         const tag = currentAudioPlayer.timing[i].tag;
-        if (verseId === tag) {
+        if (verseClicked === tag) {
             const newtime = currentAudioPlayer.timing[i].starttime;
             seek(newtime);
             break;
         }
     }
 }
-// changes audio to the verse number clicked on
+// this function is called when a verse number is clicked on and changes the audio to that verse
 export function seekBasedOnNumber(verseId) {
     if (!hasAudioPlayed()) {
         return;
     }
+    // Calls seek to verse to find the verse associtated with the verse number clicked. Calls update time to change highlighting.
     seekToVerse(verseId);
     updateTime();
 }

--- a/src/lib/scripts/verseSelectUtil.ts
+++ b/src/lib/scripts/verseSelectUtil.ts
@@ -14,7 +14,7 @@ export function onClickText(e: any, selectedVerses: any, maxSelections: any) {
             // Display all selected entries in order
             for (let i = 0; i < selectedVerses.length(); i++) {
                 const selected = selectedVerses.getVerseByIndex(i);
-                return selected.verse[0];
+                return selected.verse;
             }
         } else {
             selectedVerses.removeVerse(id);

--- a/src/lib/scripts/verseSelectUtil.ts
+++ b/src/lib/scripts/verseSelectUtil.ts
@@ -11,12 +11,11 @@ export function onClickText(e: any, selectedVerses: any, maxSelections: any) {
             if (currentLength < maxSelections) {
                 selectedVerses.addVerse(id);
             }
-
             // Display all selected entries in order
-            // for (let i = 0; i < selectedVerses.length(); i++)  {
-            //     const selected = selectedVerses.getVerseByIndex(i);
-            //     console.log("Selection %o: verse: %o, text: %o", i, selected.verse, selected.text);
-            // }
+            for (let i = 0; i < selectedVerses.length(); i++) {
+                const selected = selectedVerses.getVerseByIndex(i);
+                return selected.verse[0];
+            }
         } else {
             selectedVerses.removeVerse(id);
         }

--- a/src/lib/scripts/verseSelectUtil.ts
+++ b/src/lib/scripts/verseSelectUtil.ts
@@ -12,10 +12,9 @@ export function onClickText(e: any, selectedVerses: any, maxSelections: any) {
                 selectedVerses.addVerse(id);
             }
             // Display all selected entries in order
-            for (let i = 0; i < selectedVerses.length(); i++) {
-                const selected = selectedVerses.getVerseByIndex(i);
-                return selected.verse;
-            }
+            // for (let i = 0; i < selectedVerses.length(); i++) {
+            //     const selected = selectedVerses.getVerseByIndex(i);
+            // }
         } else {
             selectedVerses.removeVerse(id);
         }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,6 +4,7 @@
     import ChapterSelector from '$lib/components/ChapterSelector.svelte';
     import ScrolledContent from '$lib/components/ScrolledContent.svelte';
     import {
+        audioPlayer,
         audioActive,
         bodyFontSize,
         bodyLineHeight,
@@ -387,7 +388,7 @@
             </div>
         </div>
     </div>
-    {#if $selectedVerses.length > 0}
+    {#if $selectedVerses.length > 0 && !$audioPlayer.playing}
         <div class="text-selection">
             <TextSelectionToolbar />
         </div>


### PR DESCRIPTION
* The play button plays the audio if verses are selected and audio paused.
* The play and repeat buttons disappear if there are no timing files.
* The audio starts from the verse that is selected closest to the beginning of the chapter.
* If audio is playing, verse selection is disabled.
* Fixes #362.