### PR TITLE
Bug: Footnote Caller Incorrectly Styled

### DIFF
--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -1020,7 +1020,6 @@ TODO:
                                 // console.log('Footnote or xref');
                                 footnoteSpan = document.createElement('span');
                                 footnoteSpan.setAttribute('data-graft', footnoteId);
-                                footnoteSpan.classList.add('footnote');
                                 const a = document.createElement('a');
                                 const sup = document.createElement('sup');
                                 sup.classList.add('footnote');


### PR DESCRIPTION
Footnote class in root span styles footnote caller incorrectly.

Resolve by removing footnote class from root span.