### PR TITLE
Fix crash on single image user menu entry

### DIFF
--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -189,10 +189,12 @@ The sidebar/drawer.
                             rel="noreferrer"
                         >
                             <picture>
-                                <source
-                                    srcset="{base}/icons/menu-items/{item.images[1]
-                                        .file} 2x, {base}/icons/menu-items/{item.images[2].file} 3x"
-                                />
+                                {#if item.images.length === 3}
+                                    <source
+                                        srcset="{base}/icons/menu-items/{item.images[1]
+                                            .file} 2x, {base}/icons/menu-items/{item.images[2].file} 3x"
+                                    />
+                                {/if}
                                 <img
                                     src="{base}/icons/menu-items/{item.images[0].file}"
                                     height="24"


### PR DESCRIPTION
Fix issue #424 If the user menu item is a custom menu entry, only one image is available 