### PR TITLE
Fix crash on book selector

### DIFF
--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -59,6 +59,7 @@ The navbar component.
                         $nextRef.chapter = 'i';
                         completeNavigation();
                     }
+                    $nextRef.chapter = '1';
                     break;
                 case c:
                     $nextRef.chapter = e.detail.text;
@@ -144,22 +145,6 @@ The navbar component.
             }
         ];
     };
-
-    let verseGridGroup = (chapters, chapter) => {
-        let verses = chapters[chapter];
-        if (!verses) {
-            return [];
-        }
-        let value = [
-            {
-                cells: Object.keys(chapters[chapter]).map((x) => ({
-                    label: x,
-                    id: x
-                }))
-            }
-        ];
-        return value;
-    }
 </script>
 
 <!-- Book Selector -->
@@ -195,7 +180,14 @@ The navbar component.
                     [v]: {
                         component: SelectGrid,
                         props: {
-                            options: verseGridGroup(chapters, chapter)
+                            options: [
+                                {
+                                    cells: Object.keys(chapters[chapter]).map((x) => ({
+                                        label: x,
+                                        id: x
+                                    }))
+                                }
+                            ]
                         },
                         visible: showChapterSelector && showVerseSelector
                     }

--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -31,7 +31,15 @@ The navbar component.
         .books.find((x) => x.id === book).name;
 
     function chapterCount(book) {
-        let count = Object.keys(books.find((x) => x.bookCode === book).versesByChapters).length;
+        let count = 0;
+        // const bookType = config.bookCollections
+        //     .find((x) => x.id === $refs.collection)
+        //     .books.find((x) => x.id === book).type;
+        // if (bookType === 'songs') {
+        //     count = 0;
+        // } else {
+            count = Object.keys(books.find((x) => x.bookCode === book).versesByChapters).length;
+        // }
         return count;
     }
 
@@ -144,6 +152,25 @@ The navbar component.
             }
         ];
     };
+
+    let verseGridGroup = (chapters, chapter) => {
+        console.log('chapters: %o chapter: %o', chapters, chapter);
+        let verses = chapters[chapter];
+        console.log('verses: %o', verses);
+        if (!verses) {
+            return [];
+        }
+        let value = [
+            {
+                cells: Object.keys(chapters[chapter]).map((x) => ({
+                    label: x,
+                    id: x
+                }))
+            }
+        ];
+        console.log('value: %o', value);
+        return value;
+    }
 </script>
 
 <!-- Book Selector -->
@@ -179,14 +206,15 @@ The navbar component.
                     [v]: {
                         component: SelectGrid,
                         props: {
-                            options: [
-                                {
-                                    cells: Object.keys(chapters[chapter]).map((x) => ({
-                                        label: x,
-                                        id: x
-                                    }))
-                                }
-                            ]
+                            options: verseGridGroup(chapters, chapter)
+                            // [
+                            //     {
+                            //         cells: Object.keys(chapters[chapter]).map((x) => ({
+                            //             label: x,
+                            //             id: x
+                            //         }))
+                            //     }
+                            // ]
                         },
                         visible: showChapterSelector && showVerseSelector
                     }

--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -31,15 +31,7 @@ The navbar component.
         .books.find((x) => x.id === book).name;
 
     function chapterCount(book) {
-        let count = 0;
-        // const bookType = config.bookCollections
-        //     .find((x) => x.id === $refs.collection)
-        //     .books.find((x) => x.id === book).type;
-        // if (bookType === 'songs') {
-        //     count = 0;
-        // } else {
-            count = Object.keys(books.find((x) => x.bookCode === book).versesByChapters).length;
-        // }
+        let count = Object.keys(books.find((x) => x.bookCode === book).versesByChapters).length;
         return count;
     }
 
@@ -154,9 +146,7 @@ The navbar component.
     };
 
     let verseGridGroup = (chapters, chapter) => {
-        console.log('chapters: %o chapter: %o', chapters, chapter);
         let verses = chapters[chapter];
-        console.log('verses: %o', verses);
         if (!verses) {
             return [];
         }
@@ -168,7 +158,6 @@ The navbar component.
                 }))
             }
         ];
-        console.log('value: %o', value);
         return value;
     }
 </script>
@@ -207,14 +196,6 @@ The navbar component.
                         component: SelectGrid,
                         props: {
                             options: verseGridGroup(chapters, chapter)
-                            // [
-                            //     {
-                            //         cells: Object.keys(chapters[chapter]).map((x) => ({
-                            //             label: x,
-                            //             id: x
-                            //         }))
-                            //     }
-                            // ]
                         },
                         visible: showChapterSelector && showVerseSelector
                     }

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -78,7 +78,24 @@ The navbar component.
         let count = Object.keys(chapters[chapter]).length;
         return count;
     }
-
+    let verseGridGroup = (chapters, chapter) => {
+        console.log('chapters: %o chapter: %o', chapters, chapter);
+        let verses = chapters[chapter];
+        console.log('verses: %o', verses);
+        if (!verses) {
+            return [];
+        }
+        let value = [
+            {
+                cells: Object.keys(chapters[chapter]).map((x) => ({
+                    label: x,
+                    id: x
+                }))
+            }
+        ];
+        console.log('value: %o', value);
+        return value;
+    }
     /**list of books in current docSet*/
     $: books = catalog.find((d) => d.id === $refs.docSet).documents;
     /**list of chapters in current book*/
@@ -133,14 +150,15 @@ The navbar component.
                                 component: SelectGrid,
                                 props: {
                                     cols: 5,
-                                    options: [
-                                        {
-                                            cells: Object.keys(chapters[chapter]).map((x) => ({
-                                                label: x,
-                                                id: x
-                                            }))
-                                        }
-                                    ]
+                                    options: verseGridGroup(chapters, chapter)
+                                    // [
+                                    //     {
+                                    //         cells: Object.keys(chapters[chapter]).map((x) => ({
+                                    //             label: x,
+                                    //             id: x
+                                    //         }))
+                                    //     }
+                                    // ]
                                 },
                                 visible: showVerseSelector
                             }

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -78,21 +78,7 @@ The navbar component.
         let count = Object.keys(chapters[chapter]).length;
         return count;
     }
-    let verseGridGroup = (chapters, chapter) => {
-        let verses = chapters[chapter];
-        if (!verses) {
-            return [];
-        }
-        let value = [
-            {
-                cells: Object.keys(chapters[chapter]).map((x) => ({
-                    label: x,
-                    id: x
-                }))
-            }
-        ];
-        return value;
-    }
+
     /**list of books in current docSet*/
     $: books = catalog.find((d) => d.id === $refs.docSet).documents;
     /**list of chapters in current book*/
@@ -147,7 +133,14 @@ The navbar component.
                                 component: SelectGrid,
                                 props: {
                                     cols: 5,
-                                    options: verseGridGroup(chapters, chapter)
+                                    options: [
+                                        {
+                                            cells: Object.keys(chapters[chapter]).map((x) => ({
+                                                label: x,
+                                                id: x
+                                            }))
+                                        }
+                                    ]
                                 },
                                 visible: showVerseSelector
                             }

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -79,9 +79,7 @@ The navbar component.
         return count;
     }
     let verseGridGroup = (chapters, chapter) => {
-        console.log('chapters: %o chapter: %o', chapters, chapter);
         let verses = chapters[chapter];
-        console.log('verses: %o', verses);
         if (!verses) {
             return [];
         }
@@ -93,7 +91,6 @@ The navbar component.
                 }))
             }
         ];
-        console.log('value: %o', value);
         return value;
     }
     /**list of books in current docSet*/
@@ -151,14 +148,6 @@ The navbar component.
                                 props: {
                                     cols: 5,
                                     options: verseGridGroup(chapters, chapter)
-                                    // [
-                                    //     {
-                                    //         cells: Object.keys(chapters[chapter]).map((x) => ({
-                                    //             label: x,
-                                    //             id: x
-                                    //         }))
-                                    //     }
-                                    // ]
                                 },
                                 visible: showVerseSelector
                             }


### PR DESCRIPTION
Problem can occur if you are going from a high chapter number (Like Genesis 50) to a book with fewer chapters.  The initial setup of the verse grid is using the old chapter number and not finding it in the new book, which causes an exception in SelectGrid. 