### PR TITLE
Work-around fetch in about

### DIFF
--- a/src/routes/about/+page.js
+++ b/src/routes/about/+page.js
@@ -1,5 +1,6 @@
 /** @type {import('./$types').PageLoad} */
 export async function load() {
+    // use window.fetch for now so that the ?raw works.
     const response = await fetch('/about.partial.html?raw');
     const partial = await response.text();
     return { partial };

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -15,7 +15,7 @@
             <!-- <div slot="right-buttons" /> -->
         </Navbar>
     </div>
-    <div class="overflow-y-auto">
+    <div class="overflow-y-auto mx-auto max-w-screen-md">
         {@html data.partial}
     </div>
 </div>


### PR DESCRIPTION
* We should be doing, but it is not working: export async function load( { fetch } ) { await fetch('/about.partial.html?raw'); }
* restore using window.fetch for now
* update style to use width limited to md breakpoint