### PR TITLE
Fix setting verse-numbers setting

### DIFF
--- a/src/lib/data/stores/setting.ts
+++ b/src/lib/data/stores/setting.ts
@@ -357,7 +357,7 @@ function defaultUserSettings() {
     return userPreferenceSettings.reduce((defaults, setting) => {
         defaults[setting.key] = setting.defaultValue;
         return defaults;
-    });
+    }, {});
 }
 mergeDefaultStorage('userSettings', defaultUserSettings());
 export const userSettings = writable(JSON.parse(localStorage.userSettings));


### PR DESCRIPTION
Without the initial value set to an empty map, the array.reduce didn't correctly assign the key,defaultValue for verse-numbers,