### PR TITLE
Fix About page to use styles

### DIFF
--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -16,6 +16,8 @@
         </Navbar>
     </div>
     <div class="overflow-y-auto mx-auto max-w-screen-md">
-        {@html data.partial}
+        <div id="container" class="about">
+            {@html data.partial}
+        </div>
     </div>
 </div>


### PR DESCRIPTION
Fixes #461

SAB defines body.about style.  All of the body styles are converted to #container by convertStyles.ts. So insert a dev with id=container and class=about so that the generated style will be picked up.