### PR TITLE
Allow dash and space in book collection id

### DIFF
--- a/sab-proskomma/index.ts
+++ b/sab-proskomma/index.ts
@@ -67,7 +67,7 @@ export class SABProskomma extends Proskomma {
             {
                 name: 'abbr',
                 type: 'string',
-                regex: '^[A-Za-z0-9]+$'
+                regex: '^[A-Za-z0-9 -]+$'
             }
         ];
         this.validateSelectors();


### PR DESCRIPTION
Requires next release of SAB after 11.3