### PR TITLE
CollectionList: Fix conversion of style object to string

### DIFF
--- a/src/lib/components/CollectionList.svelte
+++ b/src/lib/components/CollectionList.svelte
@@ -33,7 +33,7 @@ Custom list of collections for the LayoutOptions menu
                 class="flex justify-between"
                 role="button"
             >
-                <div style={$s['ui.layouts.selector']}>
+                <div style={convertStyle($s['ui.layouts.selector'])}>
                     <div style={convertStyle($s['ui.layouts.title'])}>
                         {d.name}
                     </div>


### PR DESCRIPTION
The style was being generated as style="[object Object]" instead of the real style values.
