### PR TITLE
Numeral System for Chapter/Verse Navigation

### DIFF
--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -12,10 +12,12 @@ The navbar component.
     import { catalog } from '$lib/data/catalog';
     import config from '$lib/data/config';
     import SelectList from './SelectList.svelte';
+    import * as numerals from '$lib/scripts/numeralSystem';
 
     $: book = $nextRef.book === '' ? $refs.book : $nextRef.book;
     $: chapter = $nextRef.chapter === '' ? $refs.chapter : $nextRef.chapter;
     $: verseCount = getVerseCount(chapter, chapters);
+    $: numeralSystem = numerals.systemForBook(config, $refs.collection, book);
 
     const showChapterSelector = config.mainFeatures['show-chapter-selector-after-book'];
     $: listView = $userSettings['book-selection'] === 'list';
@@ -152,7 +154,10 @@ The navbar component.
                 rows: hasIntroduction
                     ? [{ label: $t['Chapter_Introduction_Title'], id: 'i' }]
                     : null,
-                cells: Object.keys(chapters).map((x) => ({ label: x, id: x }))
+                cells: Object.keys(chapters).map((x) => ({
+                    label: numerals.formatNumber(numeralSystem, x),
+                    id: x
+                }))
             }
         ];
     };
@@ -176,7 +181,7 @@ The navbar component.
             value = [
                 {
                     cells: Object.keys(selectedChapter).map((x) => ({
-                        label: x,
+                        label: numerals.formatNumber(numeralSystem, x),
                         id: x
                     }))
                 }

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -11,6 +11,7 @@ The navbar component.
     import { DropdownIcon } from '$lib/icons';
     import { catalog } from '$lib/data/catalog';
     import config from '$lib/data/config';
+    import * as numerals from '$lib/scripts/numeralSystem';
 
     /**reference to chapter selector so code can use TabsMenu.setActive*/
     let chapterSelector;
@@ -20,6 +21,7 @@ The navbar component.
     $: chapter = $nextRef.chapter === '' ? $refs.chapter : $nextRef.chapter;
     $: showVerseSelector = $userSettings['verse-selection'];
     $: verseCount = getVerseCount(book, chapter);
+    $: numeralSystem = numerals.systemForBook(config, $refs.collection, book);
 
     $: c = $t.Selector_Chapter;
     $: v = $t.Selector_Verse;
@@ -109,7 +111,7 @@ The navbar component.
             value = [
                 {
                     cells: Object.keys(selectedChapter).map((x) => ({
-                        label: x,
+                        label: numerals.formatNumber(numeralSystem, x),
                         id: x
                     }))
                 }
@@ -159,7 +161,7 @@ The navbar component.
                                                   ]
                                                 : null,
                                             cells: Object.keys(chapters).map((x) => ({
-                                                label: x,
+                                                label: numerals.formatNumber(numeralSystem, x),
                                                 id: x
                                             }))
                                         }

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -133,7 +133,7 @@ The navbar component.
     <Dropdown on:nav-end={resetNavigation} cols="5">
         <svelte:fragment slot="label">
             <div class="normal-case" style={convertStyle($s['ui.selector.chapter'])}>
-                {chapter}
+                {numerals.formatNumber(numeralSystem, chapter)}
             </div>
             {#if canSelect}
                 <DropdownIcon color="white" />

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -1785,9 +1785,7 @@ LOGGING:
 
     $: currentIsBibleBook = isBibleBook(references);
 
-    $: numeralSystem = numerals.systemFromString(
-        getStyle(config, 'numeralSystem', references.collection, currentBook) || 'Default'
-    );
+    $: numeralSystem = numerals.systemForBook(config, references.collection, currentBook);
 
     $: versePerLine = verseLayout === 'one-per-line';
     /**list of books in current docSet*/

--- a/src/lib/scripts/numeralSystem.test.ts
+++ b/src/lib/scripts/numeralSystem.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import * as num from './numeralSystem';
+import { getStyle } from './configUtils';
 
 test('fromString returns Oriya correctly', () => {
     expect(num.systemFromString('Oriya')).toBe(num.NumeralSystemData.ORIYA);
@@ -18,4 +19,49 @@ test('formatNumber to khmer', () => {
     expect(num.formatNumber(num.NumeralSystemData.KHMER, '48390')).toBe(
         '\u17E4\u17E8\u17E3\u17E9\u17E0'
     );
+});
+
+test('systemForBook gets numeralSystem from book collection', () => {
+    const config = {
+        bookCollections: [
+            {
+                id: 'C01',
+                style: {
+                    numeralSystem: 'Bengali'
+                },
+                books: [
+                    {
+                        id: 'MAT',
+                        style: {
+                            font: 'something'
+                        }
+                    }
+                ]
+            }
+        ]
+    };
+    expect(num.systemForBook(config, 'C01', 'MAT')).toBe(num.NumeralSystemData.BENGALI);
+});
+
+test('systemForBook gets numeralSystem from book', () => {
+    const config = {
+        bookCollections: [
+            {
+                id: 'C01',
+                style: {
+                    numeralSystem: 'Bengali'
+                },
+                books: [
+                    {
+                        id: 'MAT',
+                        style: {
+                            font: 'something',
+                            numeralSystem: 'Arabic'
+                        }
+                    }
+                ]
+            }
+        ]
+    };
+    expect(num.systemForBook(config, 'C01', 'MAT')).toBe(num.NumeralSystemData.EASTERN_ARABIC);
 });

--- a/src/lib/scripts/numeralSystem.ts
+++ b/src/lib/scripts/numeralSystem.ts
@@ -1,3 +1,5 @@
+import { getStyle } from './configUtils';
+
 /**
  * Represent numbers in an internathional numeral system.
  */
@@ -33,6 +35,11 @@ export function systemFromString(text: string): NumeralSystem {
 
 export function systemNames(): string[] {
     return Object.values(NumeralSystemData).map((system) => system.name);
+}
+
+export function systemForBook(config: any, collection: string, book: string): NumeralSystem {
+    const system = getStyle(config, 'numeralSystem', collection, book);
+    return systemFromString(system);
 }
 
 export function formatNumber(system: NumeralSystem, value: string): any {


### PR DESCRIPTION
Fixes #488 

The following setting in Scripture App Builder controls the numeral system for chapter and verse numbers within a book collection:

![image](https://github.com/sillsdev/appbuilder-pwa/assets/76575908/58608c27-0c50-487f-b663-0550b3ae3017)

This setting can be further customized for each book within a collection:

![image](https://github.com/sillsdev/appbuilder-pwa/assets/76575908/07bde718-bbc6-443d-ad73-906a33ccfa59)


This fix makes these settings effective for chapter and verse selectors, as the following screenshots show.

![image](https://github.com/sillsdev/appbuilder-pwa/assets/76575908/3a7038c2-b0e6-4279-b647-46d90628b46c)

![image](https://github.com/sillsdev/appbuilder-pwa/assets/76575908/051ceb52-2f48-4ba7-9a26-bd044089ba4b)

