### PR TITLE
Fix c-drop direction to be based on current direction

### DIFF
--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -336,6 +336,9 @@ LOGGING:
             if (chapterNumberFormatSetting === 'drop-cap') {
                 workspace.paragraphDiv.className = 'm';
                 div.classList.add('c-drop');
+                // SAB is statically generating div.c-drop: { float: left|right; } based on settings than can change
+                // So override that style based on the current directin of the text
+                div.style.float = direction.toLowerCase() === 'ltr' ? 'left' : 'right';
                 div.innerText = workspace.chapterNumText;
                 workspace.paragraphDiv.appendChild(div);
                 if (!config.mainFeatures['hide-verse-number-1']) {


### PR DESCRIPTION
In the native app, the sab-stylesheet is dynamically regenerated all the time.  For the PWA, it is statically generated.

The c-drop float value needs to depend on the current direction of the text.

I found this issue while viewing an app that was defined as RTL but it had a book collection that was LTR.