### PR TITLE
For book selector, use config if user setting not available

### DIFF
--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -20,7 +20,8 @@ The navbar component.
     $: numeralSystem = numerals.systemForBook(config, $refs.collection, book);
 
     const showChapterSelector = config.mainFeatures['show-chapter-selector-after-book'];
-    $: listView = $userSettings['book-selection'] === 'list';
+    $: listView =
+        ($userSettings['book-selection'] ?? config.mainFeatures['book-select']) === 'list';
     $: showVerseSelector = $userSettings['verse-selection'];
 
     // Translated book, chapter, and verse tab labels


### PR DESCRIPTION
* Gilaki project does not allow the user to switch from list to grid since there are long names in the book selector for videos.