### PR TITLE
Detect System Language of Browser

### DIFF
--- a/src/lib/data/language.test.ts
+++ b/src/lib/data/language.test.ts
@@ -1,0 +1,22 @@
+import { test, expect } from 'vitest';
+import { findLanguage } from './language';
+
+test('findLanguage returns exact match', () => {
+    expect(findLanguage('en', 'es', ['en', 'fr', 'es'])).toBe('en');
+});
+
+test('findLanguage returns fallback if no match', () => {
+    expect(findLanguage('sh', 'es', ['en', 'fr', 'es'])).toBe('es');
+});
+
+test('findLanguage returns more general match', () => {
+    expect(findLanguage('en-US', 'es', ['en', 'fr', 'es'])).toBe('en');
+});
+
+test('findLanguage returns similar', () => {
+    expect(findLanguage('en-US', 'es', ['en-UK', 'fr', 'es'])).toBe('en-UK');
+});
+
+test('findLanguage preferes general match over fuzzy match', () => {
+    expect(findLanguage('en-US', 'es', ['en-UK', 'en', 'fr', 'es'])).toBe('en');
+});

--- a/src/lib/data/language.test.ts
+++ b/src/lib/data/language.test.ts
@@ -1,22 +1,42 @@
-import { test, expect } from 'vitest';
-import { findLanguage } from './language';
+import { test, expect, describe } from 'vitest';
+import { findBestLanguage, findLanguage } from './language';
 
-test('findLanguage returns exact match', () => {
-    expect(findLanguage('en', 'es', ['en', 'fr', 'es'])).toBe('en');
+describe('findLanguage', () => {
+    test('findLanguage returns exact match', () => {
+        expect(findLanguage('en', ['en', 'fr', 'es'])).toBe('en');
+    });
+
+    test('findLanguage returns more general match', () => {
+        expect(findLanguage('en-US', ['en', 'fr', 'es'])).toBe('en');
+    });
+
+    test('findLanguage returns similar', () => {
+        expect(findLanguage('en-US', ['en-UK', 'fr', 'es'])).toBe('en-UK');
+    });
+
+    test('findLanguage preferes general match over fuzzy match', () => {
+        expect(findLanguage('en-US', ['en-UK', 'en', 'fr', 'es'])).toBe('en');
+    });
 });
 
-test('findLanguage returns fallback if no match', () => {
-    expect(findLanguage('sh', 'es', ['en', 'fr', 'es'])).toBe('es');
-});
+describe('findBestLanguage', () => {
+    test('first preference has exact match', () => {
+        expect(findBestLanguage(['en', 'fr'], 'es', ['fr', 'en', 'es'])).toBe('en');
+    });
 
-test('findLanguage returns more general match', () => {
-    expect(findLanguage('en-US', 'es', ['en', 'fr', 'es'])).toBe('en');
-});
+    test('first preference no match, second preference exact match', () => {
+        expect(findBestLanguage(['zh', 'fr'], 'es', ['fr', 'en', 'es'])).toBe('fr');
+    });
 
-test('findLanguage returns similar', () => {
-    expect(findLanguage('en-US', 'es', ['en-UK', 'fr', 'es'])).toBe('en-UK');
-});
+    test('first preference has fuzzy match', () => {
+        expect(findBestLanguage(['en-US', 'fr'], 'es', ['fr', 'en', 'es'])).toBe('en');
+    });
 
-test('findLanguage preferes general match over fuzzy match', () => {
-    expect(findLanguage('en-US', 'es', ['en-UK', 'en', 'fr', 'es'])).toBe('en');
+    test('first preference no match, second preference fuzzy match', () => {
+        expect(findBestLanguage(['zh', 'fr-XX'], 'es', ['fr', 'en', 'es'])).toBe('fr');
+    });
+
+    test('if no preference returns fallback', () => {
+        expect(findBestLanguage([], 'es', ['fr', 'es', 'en'])).toBe('es');
+    });
 });

--- a/src/lib/data/language.ts
+++ b/src/lib/data/language.ts
@@ -1,0 +1,47 @@
+/**
+ * Utility functions for UI language settings
+ */
+import config from '$lib/data/config';
+
+export function getLanguages() {
+    return Object.keys(config.interfaceLanguages.writingSystems);
+}
+
+// Get the best language to use as a default.
+//
+// Use the desired language if it is listed in `available`.
+// Otherwise, use a similar language if available (ex: en-US instead of en-UK)
+// Otherwise, use the fallback language.
+export function findLanguage(desired, fallback, available) {
+    let bestSimilarity = 0;
+    let bestMatch = fallback;
+    available.forEach((lang) => {
+        let similarity = compareLanguages(lang, desired);
+        if (similarity > bestSimilarity) {
+            bestSimilarity = similarity;
+            bestMatch = lang;
+        }
+    });
+    return bestMatch;
+}
+
+// Choose a default language from among those available.
+export function getDefaultLanguage() {
+    const fallbackLanguage = config.translationMappings.defaultLang;
+    const systemLanguage = window.navigator.language;
+    return findLanguage(systemLanguage, fallbackLanguage, getLanguages());
+}
+
+function compareLanguages(lang1, lang2) {
+    let parts1 = lang1.split('-');
+    let parts2 = lang2.split('-');
+    const n = Math.min(parts1.length, parts2.length);
+    for (let i = 0; i < n; i++) {
+        if (parts1[i] !== parts2[i]) {
+            // Subtract a fraction because the rest of the tag does not match.
+            // This allows 'en-US' to match 'en' more strongly than 'en-UK'.
+            return i - 0.5;
+        }
+    }
+    return n;
+}

--- a/src/lib/data/language.ts
+++ b/src/lib/data/language.ts
@@ -12,7 +12,7 @@ export function getLanguages() {
 // Use the desired language if it is listed in `available`.
 // Otherwise, use a similar language if available (ex: en-US instead of en-UK)
 // Otherwise, use the fallback language.
-export function findLanguage(desired, fallback, available) {
+export function findLanguage(desired: string, fallback: string, available: string[]): string {
     let bestSimilarity = 0;
     let bestMatch = fallback;
     available.forEach((lang) => {
@@ -26,13 +26,23 @@ export function findLanguage(desired, fallback, available) {
 }
 
 // Choose a default language from among those available.
-export function getDefaultLanguage() {
+export function getDefaultLanguage(): string {
     const fallbackLanguage = config.translationMappings.defaultLang;
-    const systemLanguage = window.navigator.language;
-    return findLanguage(systemLanguage, fallbackLanguage, getLanguages());
+    if (config.interfaceLanguages.useSystemLanguage) {
+        const systemLanguage = window.navigator.language;
+        return findLanguage(systemLanguage, fallbackLanguage, getLanguages());
+    }
+    return fallbackLanguage;
 }
 
-function compareLanguages(lang1, lang2) {
+// Return a score representing how similar the two language codes are.
+//
+// The following languages are ranked in their similarity with 'en-US':
+//      en-US   (Perfect match)
+//      en      (More general)
+//      en-UK   (Different locale)
+//      fr      (Completely different)
+function compareLanguages(lang1: string, lang2: string): number {
     let parts1 = lang1.split('-');
     let parts2 = lang2.split('-');
     const n = Math.min(parts1.length, parts2.length);

--- a/src/lib/data/stores/localization.js
+++ b/src/lib/data/stores/localization.js
@@ -1,10 +1,11 @@
 import { derived } from 'svelte/store';
 import { userSettings } from './setting';
+import { getLanguages } from '$lib/data/language';
 import config from '../config';
 
 /** localization */
-export const languageDefault = config.translationMappings.defaultLang;
-export const languages = Object.keys(config.interfaceLanguages.writingSystems);
+export const languageDefault = userSettings['interface-language']?.defaultValue;
+export const languages = getLanguages();
 export const language = derived(
     userSettings,
     ($userSettings) => $userSettings['interface-language']

--- a/src/lib/data/stores/localization.js
+++ b/src/lib/data/stores/localization.js
@@ -4,8 +4,10 @@ import { getLanguages } from '$lib/data/language';
 import config from '../config';
 
 /** localization */
-export const languageDefault =
-    userSettings['interface-language']?.defaultValue ?? config.translationMappings.defaultLang;
+
+// If a word can't be translated in the current language, use languageDefault.
+export const languageDefault = config.translationMappings.defaultLang;
+
 export const languages = getLanguages();
 export const language = derived(
     userSettings,

--- a/src/lib/data/stores/localization.js
+++ b/src/lib/data/stores/localization.js
@@ -4,7 +4,8 @@ import { getLanguages } from '$lib/data/language';
 import config from '../config';
 
 /** localization */
-export const languageDefault = userSettings['interface-language']?.defaultValue;
+export const languageDefault =
+    userSettings['interface-language']?.defaultValue ?? config.translationMappings.defaultLang;
 export const languages = getLanguages();
 export const language = derived(
     userSettings,

--- a/src/lib/data/stores/setting.ts
+++ b/src/lib/data/stores/setting.ts
@@ -1,6 +1,6 @@
 import { writable, readable, get } from 'svelte/store';
 import { setDefaultStorage, mergeDefaultStorage } from './storage';
-import { getDefaultLanguage, getLanguages } from '$lib/data/language';
+import { getDefaultLanguage } from '$lib/data/language';
 import config from '../config';
 
 export const SETTINGS_CATEGORY_INTERFACE = 'Settings_Category_Interface';

--- a/src/lib/data/stores/setting.ts
+++ b/src/lib/data/stores/setting.ts
@@ -1,5 +1,6 @@
 import { writable, readable, get } from 'svelte/store';
 import { setDefaultStorage, mergeDefaultStorage } from './storage';
+import { getDefaultLanguage, getLanguages } from '$lib/data/language';
 import config from '../config';
 
 export const SETTINGS_CATEGORY_INTERFACE = 'Settings_Category_Interface';
@@ -317,7 +318,7 @@ export const userPreferenceSettings = ((): Array<App.UserPreferenceSetting> => {
             category: SETTINGS_CATEGORY_INTERFACE,
             title: 'Settings_Interface_Language',
             key: 'interface-language',
-            defaultValue: config.translationMappings.defaultLang,
+            defaultValue: getDefaultLanguage(),
             entries,
             values
         });


### PR DESCRIPTION
Fixes #487 

On the Appearance > Interface > Languages page in SAB, there are preferences for which language to use:

![image](https://github.com/sillsdev/appbuilder-pwa/assets/76575908/05c7a75b-7b7d-412e-9c80-75a51fdbfe12)

If the app is configured to use the system language as default, it obtains preferred languages from the browser and compares them to available UI translations.  If a matching translation is found (or a similar one, ex: en-US instead of en-UK), this is the default language.  Otherwise, the app will use the fallback language specified in SAB.

The logic for choosing a language that matches the user's preference is found in `getDefaultLanguage()` in `src/lib/data/language.ts`.

The following screenshots demonstrate how the "Preferred Language" setting in Google Chrome affects the default language in the app on a mobile device.

![image](https://github.com/sillsdev/appbuilder-pwa/assets/76575908/d110fcc0-6387-4058-89e7-068ea8268058)

![image](https://github.com/sillsdev/appbuilder-pwa/assets/76575908/32d82813-56db-46fb-9bcc-1cdce88fe23b)
