### PR TITLE
Tap on note icon to view or edit

### DIFF
--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -24,7 +24,13 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
     </label>
 {/if}
 
-<dialog bind:this={dialog} {id} class="dy-modal cursor-pointer" style:direction={$direction}>
+<dialog
+    bind:this={dialog}
+    {id}
+    on:close
+    class="dy-modal cursor-pointer"
+    style:direction={$direction}
+>
     <form
         method="dialog"
         style={convertStyle($s['ui.dialog']) + addCSS}

--- a/src/lib/components/NoteDialog.svelte
+++ b/src/lib/components/NoteDialog.svelte
@@ -48,11 +48,10 @@
                 reference: $selectedVerses[0].reference
             });
         }
-        reset();
     }
 </script>
 
-<Modal bind:this={modal} {id} useLabel={false}>
+<Modal bind:this={modal} {id} on:close={reset} useLabel={false}>
     <svelte:fragment slot="content">
         <div id="container" class="flex flex-col justify-evenly">
             <div class="w-full flex justify-between">
@@ -81,14 +80,14 @@
                         style:font-size="{$bodyFontSize}px">{text}</pre>
                 {/if}
             </div>
-            <div class="w-full flex mt-4 justify-between">
-                <button on:click={reset} class="dy-btn dy-btn-sm dy-btn-ghost"
-                    >{$t['Button_Cancel']}</button
-                >
-                <button on:click={modifyNote} class="dy-btn dy-btn-sm dy-btn-ghost"
-                    >{$t['Button_OK']}</button
-                >
-            </div>
+            {#if editing}
+                <div class="w-full flex mt-4 justify-between">
+                    <button class="dy-btn dy-btn-sm dy-btn-ghost">{$t['Button_Cancel']}</button>
+                    <button on:click={modifyNote} class="dy-btn dy-btn-sm dy-btn-ghost"
+                        >{$t['Button_OK']}</button
+                    >
+                </div>
+            {/if}
         </div>
     </svelte:fragment>
 </Modal>

--- a/src/lib/components/NoteDialog.svelte
+++ b/src/lib/components/NoteDialog.svelte
@@ -2,27 +2,32 @@
 
 <script>
     import Modal from './Modal.svelte';
-    import { t, selectedVerses } from '$lib/data/stores';
+    import { EditIcon } from '$lib/icons';
+    import { t, selectedVerses, bodyFontSize, currentFont } from '$lib/data/stores';
     import { editNote, addNote } from '$lib/data/notes';
 
     export let note = undefined;
+    export let editing = false;
+
     let id = 'note';
     let modal;
     let title;
-    let textArea;
+    let text;
 
     export function showModal() {
         if (note !== undefined) {
-            textArea.value = note.text;
+            text = note.text;
             title = 'Annotation_Note_Edit';
         } else {
+            editing = true;
             title = 'Annotation_Note_Add';
         }
         modal.showModal();
     }
 
     function reset() {
-        textArea.value = '';
+        text = '';
+        editing = false;
         selectedVerses.reset();
     }
 
@@ -30,7 +35,7 @@
         if (note !== undefined) {
             await editNote({
                 note: note,
-                newText: textArea.value
+                newText: text
             });
         } else {
             await addNote({
@@ -39,7 +44,7 @@
                 book: $selectedVerses[0].book,
                 chapter: $selectedVerses[0].chapter,
                 verse: $selectedVerses[0].verse,
-                text: textArea.value,
+                text,
                 reference: $selectedVerses[0].reference
             });
         }
@@ -50,9 +55,31 @@
 <Modal bind:this={modal} {id} useLabel={false}>
     <svelte:fragment slot="content">
         <div id="container" class="flex flex-col justify-evenly">
-            <div class="annotation-item-title w-full pb-3">{$t[title]}</div>
+            <div class="w-full flex justify-between">
+                <div
+                    class="annotation-item-title w-full pb-3"
+                    style:font-weight={editing ? 'normal' : 'bold'}
+                >
+                    {$t[title]}
+                </div>
+                {#if !editing}
+                    <button
+                        on:click={() => {
+                            editing = true;
+                        }}
+                    >
+                        <EditIcon />
+                    </button>
+                {/if}
+            </div>
             <div>
-                <textarea bind:this={textArea} class="dy-textarea w-full" />
+                {#if editing}
+                    <textarea bind:value={text} class="dy-textarea w-full" />
+                {:else}
+                    <pre
+                        style:font-family={$currentFont}
+                        style:font-size="{$bodyFontSize}px">{text}</pre>
+                {/if}
             </div>
             <div class="w-full flex mt-4 justify-between">
                 <button on:click={reset} class="dy-btn dy-btn-sm dy-btn-ghost"

--- a/src/lib/components/NoteDialog.svelte
+++ b/src/lib/components/NoteDialog.svelte
@@ -1,6 +1,6 @@
 <svelte:options accessors={true} />
 
-<script>
+<script lang="ts">
     import Modal from './Modal.svelte';
     import { EditIcon } from '$lib/icons';
     import { t, selectedVerses, bodyFontSize, currentFont } from '$lib/data/stores';
@@ -11,8 +11,8 @@
 
     let id = 'note';
     let modal;
-    let title;
-    let text;
+    let title: string;
+    let text: string;
 
     $: heading = editing ? $t[title] ?? '' : note?.reference ?? '';
 
@@ -73,13 +73,19 @@
                     </button>
                 {/if}
             </div>
-            <div>
+            <div style:word-wrap="break-word">
                 {#if editing}
                     <textarea bind:value={text} class="dy-textarea w-full" />
-                {:else}
-                    <pre
-                        style:font-family={$currentFont}
-                        style:font-size="{$bodyFontSize}px">{text}</pre>
+                {:else if text !== undefined}
+                    {#each text.split(/\r?\n/) as line}
+                        {#if line}
+                            <p style:font-family={$currentFont} style:font-size="{$bodyFontSize}px">
+                                {line}
+                            </p>
+                        {:else}
+                            <br />
+                        {/if}
+                    {/each}
                 {/if}
             </div>
             {#if editing}

--- a/src/lib/components/NoteDialog.svelte
+++ b/src/lib/components/NoteDialog.svelte
@@ -14,6 +14,8 @@
     let title;
     let text;
 
+    $: heading = editing ? $t[title] ?? '' : note?.reference ?? '';
+
     export function showModal() {
         if (note !== undefined) {
             text = note.text;
@@ -59,7 +61,7 @@
                     class="annotation-item-title w-full pb-3"
                     style:font-weight={editing ? 'normal' : 'bold'}
                 >
-                    {$t[title]}
+                    {heading}
                 </div>
                 {#if !editing}
                     <button

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -15,7 +15,7 @@ LOGGING:
     import { catalog } from '$lib/data/catalog';
     import config from '$lib/data/config';
     import { base } from '$app/paths';
-    import { footnotes, refs, logs } from '$lib/data/stores';
+    import { footnotes, refs, logs, modal, MODAL_NOTE } from '$lib/data/stores';
     import {
         generateHTML,
         handleHeaderLinkPressed,
@@ -30,6 +30,7 @@ LOGGING:
     import { createVideoBlock, addVideoLinks } from '$lib/video';
     import { loadDocSetIfNotLoaded } from '$lib/data/scripture';
     import { seekToVerse, hasAudioPlayed } from '$lib/data/audio';
+    import { findNote } from '$lib/data/notes';
     import { audioPlayer } from '$lib/data/stores';
     import { checkForMilestoneLinks } from '$lib/scripts/milestoneLinks';
     import { ciEquals, isDefined, isNotBlank, splitString } from '$lib/scripts/stringUtils';
@@ -470,13 +471,18 @@ LOGGING:
     const noteSvg = () => {
         return '<svg fill="#000000" style="display:inline" xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 96 96"><path d="M 21.07 74.80 L 8.76 87.35 Q 8.00 88.12 8.00 87.03 Q 8.00 52.12 8.00 18.00 Q 8.00 7.73 18.00 7.80 Q 48.00 8.00 78.00 8.00 Q 88.27 8.00 88.18 18.00 Q 88.00 40.13 88.09 62.25 Q 88.13 72.31 78.00 72.22 C 72.03 72.17 25.23 70.89 23.56 72.37 Q 22.78 73.07 21.07 74.80 Z M 72.00 21.60 A 0.60 0.60 0.0 0 0 71.40 21.00 L 24.60 21.00 A 0.60 0.60 0.0 0 0 24.00 21.60 L 24.00 28.40 A 0.60 0.60 0.0 0 0 24.60 29.00 L 71.40 29.00 A 0.60 0.60 0.0 0 0 72.00 28.40 L 72.00 21.60 Z M 72.00 35.60 A 0.60 0.60 0.0 0 0 71.40 35.00 L 24.60 35.00 A 0.60 0.60 0.0 0 0 24.00 35.60 L 24.00 42.40 A 0.60 0.60 0.0 0 0 24.60 43.00 L 71.40 43.00 A 0.60 0.60 0.0 0 0 72.00 42.40 L 72.00 35.60 Z M 60.00 49.60 A 0.60 0.60 0.0 0 0 59.40 49.00 L 24.60 49.00 A 0.60 0.60 0.0 0 0 24.00 49.60 L 24.00 56.40 A 0.60 0.60 0.0 0 0 24.60 57.00 L 59.40 57.00 A 0.60 0.60 0.0 0 0 60.00 56.40 L 60.00 49.60 Z"</path></svg>';
     };
+    function editNote(note) {
+        modal.open(MODAL_NOTE, note);
+    }
     function addNotedVerses(notesInChapter) {
         notesInChapter.then((notes) => {
             for (var k = 0; k < notes.length; k++) {
-                let notesSpan = document.getElementById('bookmarks' + notes[k].verse);
+                const note = notes[k];
+                let notesSpan = document.getElementById('bookmarks' + note.verse);
                 let noteSpan = document.createElement('span');
                 noteSpan.id = 'note' + k;
                 noteSpan.innerHTML = noteSvg();
+                noteSpan.onclick = (event) => editNote(note);
                 notesSpan.appendChild(noteSpan);
             }
         });


### PR DESCRIPTION
Fixes #490 

The user may click on a note icon next to a verse to view the note in a modal popup.  In the modal, the user can tap a pencil icon to edit the note.

![image](https://github.com/sillsdev/appbuilder-pwa/assets/76575908/c3bf826f-ef89-49b9-9202-0c21177e9fd0)
