### PR TITLE
Use SABProskomma

### DIFF
--- a/src/lib/data/scripture.js
+++ b/src/lib/data/scripture.js
@@ -1,7 +1,7 @@
 import { get } from 'svelte/store';
 import { base } from '$app/paths';
-import { Proskomma } from 'proskomma-core';
-import { thaw } from '../scripts/thaw';
+import { SABProskomma } from '../../../sab-proskomma';
+import { thaw } from '$lib/scripts/thaw';
 import { pk } from '$lib/data/stores/pk';
 import config from '$lib/data/config';
 // import { refs } from '$lib/data/stores/scripture';
@@ -9,7 +9,7 @@ import config from '$lib/data/config';
 export async function initProskomma({ fetch }) {
     let proskomma = get(pk);
     if (!proskomma) {
-        proskomma = new Proskomma();
+        proskomma = new SABProskomma();
 
         let docSet; //get(refs).docSet;
         if (!docSet) {


### PR DESCRIPTION
We need to use SABProskomma in runtime so that the lang check matches