### PR TITLE
Display message when there are no annotations

### DIFF
--- a/src/routes/bookmarks/+page.svelte
+++ b/src/routes/bookmarks/+page.svelte
@@ -4,7 +4,7 @@
     import { BookmarkIcon } from '$lib/icons';
     import ShareIcon from '$lib/icons/ShareIcon.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
-    import { bookmarks, refs, t } from '$lib/data/stores';
+    import { refs, t } from '$lib/data/stores';
     import { formatDate } from '$lib/scripts/dateUtils';
     import { removeBookmark, type BookmarkItem } from '$lib/data/bookmarks';
     import { SORT_DATE, SORT_REFERENCE, toSorted } from '$lib/data/annotation-sort';

--- a/src/routes/bookmarks/+page.svelte
+++ b/src/routes/bookmarks/+page.svelte
@@ -4,7 +4,7 @@
     import { BookmarkIcon } from '$lib/icons';
     import ShareIcon from '$lib/icons/ShareIcon.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
-    import { refs, t } from '$lib/data/stores';
+    import { bookmarks, refs, t } from '$lib/data/stores';
     import { formatDate } from '$lib/scripts/dateUtils';
     import { removeBookmark, type BookmarkItem } from '$lib/data/bookmarks';
     import { SORT_DATE, SORT_REFERENCE, toSorted } from '$lib/data/annotation-sort';
@@ -70,26 +70,30 @@
     </div>
 
     <div id="bookmarks" class="overflow-y-auto p-2.5">
-        {#each toSorted($page.data.bookmarks, sortOrder) as b}
-            {@const iconCard = {
-                docSet: b.docSet,
-                collection: b.collection,
-                book: b.book,
-                chapter: b.chapter,
-                verse: b.verse,
-                reference: b.reference,
-                text: b.text,
-                date: formatDate(new Date(b.date)),
-                actions: [
-                    $t['Annotation_Menu_View'],
-                    $t['Annotation_Menu_Share'],
-                    $t['Annotation_Menu_Delete']
-                ]
-            }}
-
-            <IconCard on:menuaction={(e) => handleMenuAction(e, b)} {...iconCard}>
-                <BookmarkIcon slot="icon" color="#b10000" />
-            </IconCard>
-        {/each}
+        {#if $page.data.bookmarks.length === 0}
+            <div class="annotation-message-none">{$t['Annotation_Bookmarks_None']}</div>
+            <div class="annotation-message-none-info">{$t['Annotation_Bookmarks_None_Info']}</div>
+        {:else}
+            {#each toSorted($page.data.bookmarks, sortOrder) as b}
+                {@const iconCard = {
+                    docSet: b.docSet,
+                    collection: b.collection,
+                    book: b.book,
+                    chapter: b.chapter,
+                    verse: b.verse,
+                    reference: b.reference,
+                    text: b.text,
+                    date: formatDate(new Date(b.date)),
+                    actions: [
+                        $t['Annotation_Menu_View'],
+                        $t['Annotation_Menu_Share'],
+                        $t['Annotation_Menu_Delete']
+                    ]
+                }}
+                <IconCard on:menuaction={(e) => handleMenuAction(e, b)} {...iconCard}>
+                    <BookmarkIcon slot="icon" color="#b10000" />
+                </IconCard>
+            {/each}
+        {/if}
     </div>
 </div>

--- a/src/routes/highlights/+page.svelte
+++ b/src/routes/highlights/+page.svelte
@@ -76,23 +76,28 @@
     </div>
 
     <div class="overflow-y-auto p-2.5">
-        {#each toSorted($page.data.highlights, sortOrder) as h}
-            {@const colorCard = {
-                docSet: h.docSet,
-                book: h.book,
-                chapter: h.chapter,
-                verse: h.verse,
-                reference: h.reference,
-                text: h.text,
-                date: formatDate(new Date(h.date)),
-                actions: [
-                    $t['Annotation_Menu_View'],
-                    $t['Annotation_Menu_Share'],
-                    $t['Annotation_Menu_Delete']
-                ],
-                penColor: h.penColor
-            }}
-            <ColorCard on:menuaction={(e) => handleMenuaction(e, h)} {...colorCard} />
-        {/each}
+        {#if $page.data.highlights.length === 0}
+            <div class="annotation-message-none">{$t['Annotation_Highlights_None']}</div>
+            <div class="annotation-message-none-info">{$t['Annotation_Highlights_None_Info']}</div>
+        {:else}
+            {#each toSorted($page.data.highlights, sortOrder) as h}
+                {@const colorCard = {
+                    docSet: h.docSet,
+                    book: h.book,
+                    chapter: h.chapter,
+                    verse: h.verse,
+                    reference: h.reference,
+                    text: h.text,
+                    date: formatDate(new Date(h.date)),
+                    actions: [
+                        $t['Annotation_Menu_View'],
+                        $t['Annotation_Menu_Share'],
+                        $t['Annotation_Menu_Delete']
+                    ],
+                    penColor: h.penColor
+                }}
+                <ColorCard on:menuaction={(e) => handleMenuaction(e, h)} {...colorCard} />
+            {/each}
+        {/if}
     </div>
 </div>

--- a/src/routes/notes/+page.svelte
+++ b/src/routes/notes/+page.svelte
@@ -73,26 +73,31 @@
     </div>
 
     <div class="overflow-y-auto p-2.5">
-        {#each toSorted($page.data.notes, sortOrder) as n}
-            {@const iconCard = {
-                docSet: n.docSet,
-                collection: n.collection,
-                book: n.book,
-                chapter: n.chapter,
-                verse: n.verse,
-                reference: n.reference,
-                text: n.text,
-                date: formatDate(new Date(n.date)),
-                actions: [
-                    $t['Annotation_Menu_View'],
-                    $t['Annotation_Menu_Edit'],
-                    $t['Annotation_Menu_Share'],
-                    $t['Annotation_Menu_Delete']
-                ]
-            }}
-            <IconCard on:menuaction={(e) => handleMenuaction(e, n)} {...iconCard}>
-                <NoteIcon slot="icon" color={$monoIconColor} />
-            </IconCard>
-        {/each}
+        {#if $page.data.notes.length === 0}
+            <div class="annotation-message-none">{$t['Annotation_Notes_None']}</div>
+            <div class="annotation-message-none-info">{$t['Annotation_Notes_None_Info']}</div>
+        {:else}
+            {#each toSorted($page.data.notes, sortOrder) as n}
+                {@const iconCard = {
+                    docSet: n.docSet,
+                    collection: n.collection,
+                    book: n.book,
+                    chapter: n.chapter,
+                    verse: n.verse,
+                    reference: n.reference,
+                    text: n.text,
+                    date: formatDate(new Date(n.date)),
+                    actions: [
+                        $t['Annotation_Menu_View'],
+                        $t['Annotation_Menu_Edit'],
+                        $t['Annotation_Menu_Share'],
+                        $t['Annotation_Menu_Delete']
+                    ]
+                }}
+                <IconCard on:menuaction={(e) => handleMenuaction(e, n)} {...iconCard}>
+                    <NoteIcon slot="icon" color={$monoIconColor} />
+                </IconCard>
+            {/each}
+        {/if}
     </div>
 </div>


### PR DESCRIPTION
Fixes #541

Works the same as "display message when there is no history". For the bookmarks, highlights, and notes,
when there is no annotation, display a message.
This way it does not look like an error.