### PR TITLE
Quiet warnings

### DIFF
--- a/src/lib/components/Slider.svelte
+++ b/src/lib/components/Slider.svelte
@@ -34,6 +34,7 @@ A simple slider component.
 
     input[type='range'] {
         -webkit-appearance: none;
+        appearance: none;
         margin-right: 15px;
         width: auto;
         height: 7px;
@@ -50,6 +51,7 @@ A simple slider component.
     /* Input Thumb */
     input[type='range']::-webkit-slider-thumb {
         -webkit-appearance: none;
+        appearance: none;
         height: 20px;
         width: 20px;
         border-radius: 50%;
@@ -62,6 +64,7 @@ A simple slider component.
 
     input[type='range']::-moz-range-thumb {
         -webkit-appearance: none;
+        appearance: none;
         height: 20px;
         width: 20px;
         border-radius: 50%;
@@ -74,6 +77,7 @@ A simple slider component.
 
     input[type='range']::-ms-thumb {
         -webkit-appearance: none;
+        appearance: none;
         height: 20px;
         width: 20px;
         border-radius: 50%;
@@ -107,6 +111,7 @@ A simple slider component.
 
     input[type='range']::-moz-range-track {
         -webkit-appearance: none;
+        appearance: none;
         box-shadow: none;
         border: none;
         background: transparent;
@@ -115,6 +120,7 @@ A simple slider component.
 
     input[type='range']::-ms-track {
         -webkit-appearance: none;
+        appearance: none;
         box-shadow: none;
         border: none;
         background: transparent;


### PR DESCRIPTION
We get these warning when running "check" script:

```
/Users/chrish/codereview/appbuilder-pwa/src/lib/components/Slider.svelte:36:9 Warn: Also define the standard property 'appearance' for compatibility (css)
    input[type='range'] {
        -webkit-appearance: none;
        margin-right: 15px;

/Users/chrish/codereview/appbuilder-pwa/src/lib/components/Slider.svelte:64:9 Warn: Also define the standard property 'appearance' for compatibility (css)
    input[type='range']::-moz-range-thumb {
        -webkit-appearance: none;
        height: 20px;

/Users/chrish/codereview/appbuilder-pwa/src/lib/components/Slider.svelte:76:9 Warn: Also define the standard property 'appearance' for compatibility (css)
    input[type='range']::-ms-thumb {
        -webkit-appearance: none;
        height: 20px;

/Users/chrish/codereview/appbuilder-pwa/src/lib/components/Slider.svelte:109:9 Warn: Also define the standard property 'appearance' for compatibility (css)
    input[type='range']::-moz-range-track {
        -webkit-appearance: none;
        box-shadow: none;

/Users/chrish/codereview/appbuilder-pwa/src/lib/components/Slider.svelte:117:9 Warn: Also define the standard property 'appearance' for compatibility (css)
    input[type='range']::-ms-track {
        -webkit-appearance: none;
        box-shadow: none;
```