### PR TITLE
Feature/convert quiz #500

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ static/videos
 static/icons
 static/*.partial.html
 static/manifest.json
+static/assets
 src/lib/data/catalog.js
 src/lib/data/firebase-config.js
 src/lib/data/config.js

--- a/convert/convertBooks.ts
+++ b/convert/convertBooks.ts
@@ -9,6 +9,7 @@ import { SABProskomma } from '../src/lib/sab-proskomma';
 import { queries, postQueries, freeze } from '../sab-proskomma-tools';
 import { convertMarkdownsToMilestones } from './convertMarkdown';
 import { verifyGlossaryEntries } from './verifyGlossaryEntries';
+import { hasAudioExtension, hasImageExtension } from './stringUtils';
 
 /**
  * Loops through bookCollections property of configData.
@@ -329,14 +330,6 @@ type Quiz = {
     }[];
     passScore?: number; //\pm
 };
-
-function hasImageExtension(text: string): boolean {
-    return text.match(/\.(png|jpeg|jpg|webp)$/i) !== null;
-}
-
-function hasAudioExtension(text: string): boolean {
-    return text.match(/\.(mp3|wav|ogg|webm)$/i) !== null;
-}
 
 function convertQuizBook(context: ConvertBookContext, book: Book): Quiz {
     if (context.verbose) {

--- a/convert/convertBooks.ts
+++ b/convert/convertBooks.ts
@@ -339,17 +339,17 @@ function convertQuizBook(context: ConvertBookContext, book: Book): Quiz {
         path.join(context.dataDir, 'books', context.bcId, book.file),
         'utf8'
     );
-    let quiz: Quiz = {
+    const quiz: Quiz = {
         id: quizSFM.match(/\\id ([^\\\r\n]+)/i)![1],
         name: quizSFM.match(/\\qn ([^\\\r\n]+)/i)?.at(1),
         shortName: quizSFM.match(/\\qs ([^\\\r\n]+)/i)?.at(1),
         columns: quizSFM.match(/\\ac ([^\\\r\n]+)/i)?.at(1)
             ? parseInt(quizSFM.match(/\\ac ([^\\\r\n]+)/i)![1])
             : undefined,
-        rightAnswerAudio: quizSFM.match(/\\ra ([^\\\r\n]+)/gi)?.map(m => {
+        rightAnswerAudio: quizSFM.match(/\\ra ([^\\\r\n]+)/gi)?.map((m) => {
             return m.match(/\\ra ([^\\\r\n]+)/i)![1];
         }),
-        wrongAnswerAudio: quizSFM.match(/\\wa ([^\\\r\n]+)/gi)?.map(m => {
+        wrongAnswerAudio: quizSFM.match(/\\wa ([^\\\r\n]+)/gi)?.map((m) => {
             return m.match(/\\wa ([^\\\r\n]+)/i)![1];
         }),
         questions: [], //questions handled below
@@ -391,6 +391,7 @@ function convertQuizBook(context: ConvertBookContext, book: Book): Quiz {
                 if (!hasAudioExtension(parsed[2])) {
                     answer.correct = true;
                 }
+            /**es-lint-ignore-no-fallthrough */
             case 'aw':
                 //answer can have either an image, or text with optional audio
                 if (hasImageExtension(parsed[2])) {
@@ -409,12 +410,11 @@ function convertQuizBook(context: ConvertBookContext, book: Book): Quiz {
                 break;
             case 'ae':
                 if (!question.answers[aCount - 1].explanation) {
-                    question.answers[aCount - 1].explanation = { text: "" }
+                    question.answers[aCount - 1].explanation = { text: '' };
                 }
                 if (hasAudioExtension(parsed[2])) {
                     question.answers[aCount - 1].explanation!.audio = parsed[2];
-                }
-                else {
+                } else {
                     question.answers[aCount - 1].explanation!.text = parsed[2];
                 }
                 break;

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -474,12 +474,14 @@ function convertConfig(dataDir: string, verbose: number) {
     data.styles = parseStyles(mainStyles, verbose);
 
     // Traits
-    const traitTags = document.getElementsByTagName('traits')[0].getElementsByTagName('trait');
+    const traitTags = document.getElementsByTagName('traits')[0]?.getElementsByTagName('trait');
     data.traits = {};
 
-    for (const tag of traitTags) {
-        data.traits[tag.attributes.getNamedItem('name')!.value] =
-            tag.attributes.getNamedItem('value')?.value === 'true';
+    if (traitTags?.length > 0) {
+        for (const tag of traitTags) {
+            data.traits[tag.attributes.getNamedItem('name')!.value] =
+                tag.attributes.getNamedItem('value')?.value === 'true';
+        }
     }
     // Add traits
     data.traits['has-borders'] = !dirEmpty(path.join(dataDir, 'borders'));

--- a/convert/convertMedia.ts
+++ b/convert/convertMedia.ts
@@ -26,6 +26,21 @@ function cloneDirectory(from: string, to: string, verbose: number, optional = fa
     }
 }
 
+/**
+ * Copies extra media assets from supplied data folder to static/assets
+ */
+function cloneToAssets(from: string[], verbose: number) {
+    from.forEach((f) => {
+        if (
+            cpSyncOptional(path.join('data', f), path.join('static', 'assets', f), {
+                recursive: true
+            })
+        ) {
+            if (verbose) console.log(`copied ${path.join('data', f)} to ${path.join('static', 'assets', f)}`);
+        } else if (verbose) console.log(`${path.join('data', f)} does not exist`);
+    });
+}
+
 export interface MediaTaskOutput extends TaskOutput {
     taskName: 'ConvertMedia';
 }
@@ -89,5 +104,7 @@ export class ConvertMedia extends Task {
                 !required.includes(p)
             );
         }
+
+        cloneToAssets(['quiz-right-answer.mp3', 'quiz-wrong-answer.mp3'], verbose);
     }
 }

--- a/convert/convertMedia.ts
+++ b/convert/convertMedia.ts
@@ -36,7 +36,10 @@ function cloneToAssets(from: string[], verbose: number) {
                 recursive: true
             })
         ) {
-            if (verbose) console.log(`copied ${path.join('data', f)} to ${path.join('static', 'assets', f)}`);
+            if (verbose)
+                console.log(
+                    `copied ${path.join('data', f)} to ${path.join('static', 'assets', f)}`
+                );
         } else if (verbose) console.log(`${path.join('data', f)} does not exist`);
     });
 }

--- a/convert/stringUtils.ts
+++ b/convert/stringUtils.ts
@@ -21,6 +21,15 @@ export function getFilenameExt(filename: string): string {
     }
     return extension;
 }
+
+export function hasImageExtension(text: string): boolean {
+    return text.match(/\.(png|jpeg|jpg|webp)$/i) !== null;
+}
+
+export function hasAudioExtension(text: string): boolean {
+    return text.match(/\.(mp3|wav|ogg|webm)$/i) !== null;
+}
+
 export function filenameWithoutPath(filename: string): string {
     let result: string = '';
     if (isNotBlank(filename)) {


### PR DESCRIPTION
Partially fixes #500.

Converts quiz books from SFM to usable JSON.
Copies default audio provided by SAB to `static/assets/*`.

Also ignores null `<traits></traits>` in `appdef.xml`, although this may not be a necessary change, as it was only an issue when there were no standard scripture books defined for the app, which caused other problems.