### PR TITLE
Issue #560 - Convert Content crashes on "other" link entries

### DIFF
--- a/convert/convertContents.ts
+++ b/convert/convertContents.ts
@@ -103,8 +103,8 @@ export function convertContents(dataDir: string, verbose: number) {
 
             const linkTags = itemTag.getElementsByTagName('link');
             const linkType = linkTags[0]?.attributes.getNamedItem('type')!.value;
-            const linkTarget = linkTags[0]?.attributes.getNamedItem('target')?.value ?? '';
-            const linkLocation = linkTags[0]?.attributes.getNamedItem('location')?.value ?? '';
+            const linkTarget = linkTags[0]?.attributes.getNamedItem('target')?.value ?? undefined;
+            const linkLocation = linkTags[0]?.attributes.getNamedItem('location')?.value ?? undefined;
 
             const features: any = {};
 

--- a/convert/convertContents.ts
+++ b/convert/convertContents.ts
@@ -104,7 +104,8 @@ export function convertContents(dataDir: string, verbose: number) {
             const linkTags = itemTag.getElementsByTagName('link');
             const linkType = linkTags[0]?.attributes.getNamedItem('type')!.value;
             const linkTarget = linkTags[0]?.attributes.getNamedItem('target')?.value ?? undefined;
-            const linkLocation = linkTags[0]?.attributes.getNamedItem('location')?.value ?? undefined;
+            const linkLocation =
+                linkTags[0]?.attributes.getNamedItem('location')?.value ?? undefined;
 
             const features: any = {};
 

--- a/convert/convertContents.ts
+++ b/convert/convertContents.ts
@@ -16,6 +16,7 @@ type ContentItem = {
     imageFilename?: string;
     linkType?: string;
     linkTarget?: string;
+    linkLocation?: string;
 };
 
 type ContentScreen = {
@@ -102,7 +103,8 @@ export function convertContents(dataDir: string, verbose: number) {
 
             const linkTags = itemTag.getElementsByTagName('link');
             const linkType = linkTags[0]?.attributes.getNamedItem('type')!.value;
-            const linkTarget = linkTags[0]?.attributes.getNamedItem('target')!.value;
+            const linkTarget = linkTags[0]?.attributes.getNamedItem('target')?.value ?? '';
+            const linkLocation = linkTags[0]?.attributes.getNamedItem('location')?.value ?? '';
 
             const features: any = {};
 
@@ -121,6 +123,7 @@ export function convertContents(dataDir: string, verbose: number) {
                 imageFilename,
                 linkType,
                 linkTarget,
+                linkLocation,
                 features
             });
         }


### PR DESCRIPTION
Handle link type "other" such as: ```<link type="other" location="layout" />```
Add a linkLocation field to the contents entries and set linkTarget to "" if not defined.
For website entries ( ```<link type="other" location="website" target="https://www.sil.org" /> ```) fill in both fields.
