### PR TITLE
Collection footer does not take on book footer

### DIFF
--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -372,6 +372,14 @@ function convertFooter(markdown: string | undefined, appdef: Document): string |
         ?.replace(/%program-version%/g, programVersion ?? '');
 }
 
+function convertCollectionFooter(collectionTag: Element, document: Document) {
+    const footerTags = Array.from(collectionTag.children).filter(
+        (child) => child.tagName === 'footer'
+    );
+    const footer = convertFooter(footerTags[0]?.innerHTML, document);
+    return footer;
+}
+
 function convertConfig(dataDir: string, verbose: number) {
     const dom = new jsdom.JSDOM(readFileSync(path.join(dataDir, 'appdef.xml')).toString(), {
         contentType: 'text/xml'
@@ -630,8 +638,7 @@ function convertConfig(dataDir: string, verbose: number) {
             ? collectionAbbreviationTags[0].innerHTML
             : undefined;
         if (verbose >= 2) console.log(`.. collectionAbbreviation: `, collectionAbbreviation);
-        const footerTags = tag.getElementsByTagName('footer');
-        const footer = convertFooter(footerTags[0]?.innerHTML, document);
+        const footer = convertCollectionFooter(tag, document);
         if (verbose >= 2) console.log(`.. footer: `, footer);
 
         const bcStyles = tag.querySelector('styles');


### PR DESCRIPTION
Fixes #569

Previously, the conversion process would sometimes assign a book-specific footer to the entire collection. This generally happened when the collection-level footer was undefined.

Now, the conversion process correctly assigns footers to book collections as specified by the app.xml exported from SAB.