### PR TITLE
Fix quiz conversion process regarding collections

### DIFF
--- a/convert/convertBooks.ts
+++ b/convert/convertBooks.ts
@@ -299,15 +299,12 @@ export async function convertBooks(
     //write frozen archives
 
     //push files to be written to files array
-    freezer.forEach((value, key) => {
-        // don't write pkf if there is nothing to write
-        if (value) {
-            files.push({
-                path: path.join('static', 'collections', key + '.pkf'),
-                content: value
-            });
-        }
-    });
+    freezer.forEach((value, key) =>
+        files.push({
+            path: path.join('static', 'collections', key + '.pkf'),
+            content: value
+        })
+    );
 
     //write index file
     writeFileSync(

--- a/convert/convertBooks.ts
+++ b/convert/convertBooks.ts
@@ -227,43 +227,7 @@ export async function convertBooks(
         const frozen = freeze(pk);
         freezer.set(context.docSet, frozen[context.docSet]);
         //start catalog generation process
-        catalogEntries.push(
-            pk.gqlQuery(queries.catalogQuery({ cv: true })).then((j) => {
-                if (j.data.nDocSets > 0) {
-                    return j;
-                } else {
-                    if (verbose) {
-                        console.log(` -- Empty DocSet: ${context.docSet}`);
-                    }
-                    // return empty version of appropriate docSet,
-                    // as the query failed due to lack of documents.
-                    return {
-                        data: {
-                            nDocSets: 1,
-                            nDocuments: 0,
-                            docSets: [
-                                {
-                                    id: context.docSet,
-                                    tagsKv: [],
-                                    selectors: [
-                                        {
-                                            key: 'lang',
-                                            value: context.lang
-                                        },
-                                        {
-                                            key: 'abbr',
-                                            value: context.bcId
-                                        }
-                                    ],
-                                    hasMapping: false,
-                                    documents: []
-                                }
-                            ]
-                        }
-                    };
-                }
-            })
-        );
+        catalogEntries.push(pk.gqlQuery(queries.catalogQuery({ cv: true })));
 
         //check if folder exists for collection
         const collPath = path.join('static', 'collections', context.bcId);

--- a/convert/convertBooks.ts
+++ b/convert/convertBooks.ts
@@ -299,12 +299,15 @@ export async function convertBooks(
     //write frozen archives
 
     //push files to be written to files array
-    freezer.forEach((value, key) =>
-        files.push({
-            path: path.join('static', 'collections', key + '.pkf'),
-            content: value
-        })
-    );
+    freezer.forEach((value, key) => {
+        // don't write pkf if there is nothing to write
+        if (value) {
+            files.push({
+                path: path.join('static', 'collections', key + '.pkf'),
+                content: value
+            });
+        }
+    });
 
     //write index file
     writeFileSync(

--- a/convert/convertBooks.ts
+++ b/convert/convertBooks.ts
@@ -180,7 +180,7 @@ export async function convertBooks(
             bcGlossary = loadGlossary(collection, dataDir);
         }
         //add empty array of quizzes for book collection
-        quizzes[context.docSet] = [];
+        quizzes[context.bcId] = [];
         for (const book of collection.books) {
             let bookConverted = false;
             switch (book.type) {
@@ -192,12 +192,12 @@ export async function convertBooks(
                     break;
                 case 'quiz':
                     bookConverted = true;
-                    quizzes[context.docSet].push({ id: book.id, name: book.name });
+                    quizzes[context.bcId].push({ id: book.id, name: book.name });
                     files.push({
                         path: path.join(
                             'static',
                             'collections',
-                            context.docSet,
+                            context.bcId,
                             'quizzes',
                             book.id + '.json'
                         ),
@@ -230,14 +230,14 @@ export async function convertBooks(
         catalogEntries.push(pk.gqlQuery(queries.catalogQuery({ cv: true })));
 
         //check if folder exists for collection
-        const collPath = path.join('static', 'collections', context.docSet);
+        const collPath = path.join('static', 'collections', context.bcId);
         if (!existsSync(collPath)) {
             if (verbose) console.log('creating: ' + collPath);
             mkdirSync(collPath, { recursive: true });
         }
         //add quizzes path if necessary
-        if (quizzes[context.docSet].length > 0) {
-            const qPath = path.join('static', 'collections', context.docSet, 'quizzes');
+        if (quizzes[context.bcId].length > 0) {
+            const qPath = path.join('static', 'collections', context.bcId, 'quizzes');
             if (!existsSync(qPath)) {
                 if (verbose) console.log('creating: ' + qPath);
                 mkdirSync(qPath, { recursive: true });


### PR DESCRIPTION
Per @chrisvire 's request, switched quiz conversion to store quizzes in a folder named after the parent collection instead of the docSet.

The primary rationale is that docSet is a Proskomma specific entity, rather than one specific to an SAB project, unlike book collections.