### PR TITLE
fix copying data to static folder during dev script

### DIFF
--- a/convert/convertBadges.ts
+++ b/convert/convertBadges.ts
@@ -1,7 +1,7 @@
 import { Promisable, Task, TaskOutput } from './Task';
 import path from 'path';
 import { ConfigTaskOutput } from './convertConfig';
-import { copyFile, existsSync, mkdirSync, writeFileSync } from 'fs';
+import { copyFile, existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 
 export async function convertBadges(
     badgesDir: string,
@@ -9,6 +9,13 @@ export async function convertBadges(
     verbose: number
 ) {
     const dstBadgeDir = path.join('static', 'badges');
+    if (!configData.data.mainFeatures['share-apple-app-link']) {
+        if (existsSync(dstBadgeDir)) {
+            rmSync(dstBadgeDir, { recursive: true });
+        }
+        return;
+    }
+
     if (!existsSync(dstBadgeDir)) {
         mkdirSync(dstBadgeDir);
     }
@@ -16,7 +23,7 @@ export async function convertBadges(
     // Badge languages from config
     const languages = Object.keys(configData.data.interfaceLanguages!.writingSystems);
     // Make sure there is english for fallback
-    if (!languages.includes('en')) {
+    if (languages.length > 1 && !languages.includes('en')) {
         languages.push('en');
     }
     const foundLanguages = [];
@@ -52,7 +59,7 @@ export interface BadgesTaskOutput extends TaskOutput {
 }
 
 export class ConvertBadges extends Task {
-    public triggerFiles: string[] = [];
+    public triggerFiles: string[] = ['appdef.xml'];
     public badgesDir: string;
     constructor(dataDir: string) {
         super(dataDir);

--- a/convert/convertMedia.ts
+++ b/convert/convertMedia.ts
@@ -1,4 +1,4 @@
-import { CopySyncOptions, cpSync } from 'fs';
+import { CopySyncOptions, cpSync, existsSync } from 'fs';
 import { rimraf } from 'rimraf';
 import path from 'path';
 import { Task, TaskOutput } from './Task';
@@ -76,7 +76,14 @@ export class ConvertMedia extends Task {
     ): Promise<TaskOutput> {
         const modifiedDirectories = new Set<string>();
         for (const p of modifiedPaths) {
-            modifiedDirectories.add(p.split(path.sep)[0]);
+            // During the first run, paths are just the folders in the trigger files.
+            // During an update due to watch (especially switching projects), the paths
+            // include all the file names (appdef.xml, etc)
+            const parts = p.split(path.sep);
+            const subdir = parts[0];
+            if (this.triggerFiles.includes(subdir)) {
+                modifiedDirectories.add(subdir);
+            }
         }
         await this.convertMedia(this.dataDir, verbose, [...modifiedDirectories]);
         return {


### PR DESCRIPTION
* When runing `npm run dev`, if the developer switched projects, then convertMedia was getting a list of all the files changed and copying everything instead of filtering by triggerFiles
* The better change would likely be to filter it on the outside. However, then we would need to change the interface to be triggerFiles and triggerFolders since we would need to process them differently.

* Also fix how badges are processed to only include english is actually sharing apple app link.
* also, clean up the folder if it already exists and not sharing.