### PR TITLE
Fix/empty docset

### DIFF
--- a/convert/convertBooks.ts
+++ b/convert/convertBooks.ts
@@ -299,12 +299,15 @@ export async function convertBooks(
     //write frozen archives
 
     //push files to be written to files array
-    freezer.forEach((value, key) =>
-        files.push({
-            path: path.join('static', 'collections', key + '.pkf'),
-            content: value
-        })
-    );
+    freezer.forEach((value, key) => {
+        // don't write pkf if there is nothing to write
+        if (value) {
+            files.push({
+                path: path.join('static', 'collections', key + '.pkf'),
+                content: value
+            });
+        }
+    });
 
     //write index file
     writeFileSync(


### PR DESCRIPTION
Per @chrisvire 's request, moved some changes from PR #571 to a new PR.

In some cases when attempting to implement quizzes, a data set was used which contained book collections that only had quizzes. This PR is an attempt to fix the problems that arose during the conversion process on those data sets.

While this fixes those problems, I am very certain that the chosen solution, not writing a pkf when there is no Proskomma docSet, will break many things in the app itself.

Pretty much everything in `src/lib/data/scripture.js` is likely to break from this change, which will also probably cause problems in `src/routes/+page.svelte`.

One potential solution that could fix those issues would be extending `src/lib/sab-proskomma` to be able to handle an empty pkf, and then make sure an empty pkf is written instead of no pkf.

The main reason this PR exists is because we have data sets that cause this problem. It may be the case that something should be changed in Scripture App Builder itself to prevent the creation of data sets that cause this problem in the first place.