### PR TITLE
Disable fetching badge information when not needed

### DIFF
--- a/src/routes/share/+page.js
+++ b/src/routes/share/+page.js
@@ -1,12 +1,15 @@
 import { base } from '$app/paths';
+import config from '$lib/data/config';
 
 /** @type {import('./$types').PageLoad} */
 export async function load({ fetch }) {
     let languages = [];
-    const response = await fetch(`${base}/badges/languages.json`);
-    const result = await response.json();
-    if (!result.error) {
-        languages = result;
+    if (config.mainFeatures['share-apple-app-link']) {
+        const response = await fetch(`${base}/badges/languages.json`);
+        const result = await response.json();
+        if (!result.error) {
+            languages = result;
+        }
     }
 
     return { languages };


### PR DESCRIPTION
* We only need the badges/languages.json if we are sharing an apple app link.