### PR TITLE
play contents menu audio clips

### DIFF
--- a/convert/convertContents.ts
+++ b/convert/convertContents.ts
@@ -140,7 +140,7 @@ export function convertContents(dataDir: string, configData: ConfigTaskOutput, v
 
             const audioFilename: { [lang: string]: string } = {};
             const audioTags = itemTag.getElementsByTagName('audio');
-            if (audioTags) {
+            if (audioTags?.length > 0) {
                 for (const audioTag of audioTags) {
                     const lang = audioTag.attributes.getNamedItem('lang')!.value;
                     audioFilename[lang] = decodeFromXml(audioTag.innerHTML);

--- a/src/routes/contents/[id]/+page.svelte
+++ b/src/routes/contents/[id]/+page.svelte
@@ -27,19 +27,12 @@
     function playAudio(event, item) {
         event.stopPropagation();
         //assign/use the proper filename
-        let filename;
-        if (item.audioFilename[$language]) {
-            filename = item.audioFilename[$language];
-        } else {
-            filename = item.audioFilename.default;
-        }
+        const filename = item.audioFilename[$language] ?? item.audioFilename.default;
 
         let audio = new Audio();
         audio.src = `${base}/${audioFolder}/${filename}`;
         audio.play();
     }
-
-    //console.log(config.interfaceLanguages);
 
     function onClick(event, item) {
         event.target.style.background = highlightColor;
@@ -203,10 +196,6 @@
                                 alt={item.imageFilename}
                             />
                         </div>
-                        <!-- Example of using item.audioFilename. Remove and replace with icon. -->
-                        <!-- {#if item.audioFilename[$language]}
-                            <a href="{base}/{audioFolder}/{item.audioFilename[$language]}">{item.audioFilename[$language]}</a>
-                            {/if} -->
                     {/if}
 
                     <div class="contents-text-block">

--- a/src/routes/contents/[id]/+page.svelte
+++ b/src/routes/contents/[id]/+page.svelte
@@ -24,14 +24,8 @@
     $: highlightColor = $themeColors['ContentsItemTouchColor'];
     $: title = setTitle($page);
 
-    //this is still being used because it is stll navigating to the page when you click on audio
-    //this might be fixed by z index? then you could go straight to playAudio()
-    $: audio = false;
-    function switchAudio(event) {
-        audio = true;
-    }
-
-    function playAudio(item) {
+    function playAudio(event, item) {
+        event.stopPropagation();
         //assign/use the proper filename
         let filename;
         if (item.audioFilename[$language]) {
@@ -50,15 +44,8 @@
     function onClick(event, item) {
         event.target.style.background = highlightColor;
         setTimeout(() => {
-            if (audio === false) {
-                //navigate
-                clicked(item);
-            } else {
-                //call function to play the audio (and not navigate)
-                playAudio(item);
-                //switch the audio back to false so the next time its clicked, it will react appropriately
-                audio = false;
-            }
+            //navigate
+            clicked(item);
         }, 100);
     }
 
@@ -197,7 +184,7 @@
                         <!-- svelte-ignore a11y-no-static-element-interactions -->
                         <div
                             class="contents-item-audio-image"
-                            on:click={(event) => switchAudio(event)}
+                            on:click={(event) => playAudio(event, item)}
                         >
                             <AudioIcon.Volume></AudioIcon.Volume>
                         </div>


### PR DESCRIPTION
- fixes issue #582
- adds the audio icon in the appropriate place if there is audio in the contents menu item
- changes the onclick to go to the playAudio() fuction instead of navigating if the
icon is clicked
- playAudio() function plays the correct audio based on the interface language
- also changes the formatting of the html to use <div> instead of <a> as per an update in the css
- potential issue: the way I go about playing the audio instead of navigating could be too
complicated/might not be neccessary if there is a
different way it should work (z-index?)