### PR TITLE
add text appearance selector to contents menu

### DIFF
--- a/src/lib/components/TextAppearanceSelector.svelte
+++ b/src/lib/components/TextAppearanceSelector.svelte
@@ -3,6 +3,8 @@
 The navbar component. We have sliders that update reactively to both font size and line height.
 3 buttons to change the style from normal, sepia and dark.
 -->
+<svelte:options accessors={true} />
+
 <script>
     import Modal from './Modal.svelte';
     import Slider from './Slider.svelte';
@@ -10,6 +12,7 @@ The navbar component. We have sliders that update reactively to both font size a
     import {
         bodyFontSize,
         bodyLineHeight,
+        contentsFontSize,
         currentFont,
         fontChoices,
         language,
@@ -29,6 +32,9 @@ The navbar component. We have sliders that update reactively to both font size a
         modalThis.showModal();
     }
 
+    export let options = {};
+    console.log(options);
+    $: contentsMode = options?.contentsMode ?? false;
     export let vertOffset = '1rem'; //Prop that will have the navbar's height (in rem) passed in
     //The positioningCSS positions the modal 1rem below the navbar and 1rem from the right edge of the screen (on mobile it will be centered)
     $: positioningCSS =
@@ -37,10 +43,10 @@ The navbar component. We have sliders that update reactively to both font size a
         'rem; inset-inline-end:1rem;';
     $: barColor = $themeColors['SliderBarColor'];
     $: progressColor = $themeColors['SliderProgressColor'];
-    $: showFonts = $fontChoices.length > 1;
+    $: showFonts = !contentsMode && $fontChoices.length > 1;
 
     const showFontSize = config.mainFeatures['text-font-size-slider'];
-    const showLineHeight = config.mainFeatures['text-line-height-slider'];
+    $: showLineHeight = !contentsMode && config.mainFeatures['text-line-height-slider'];
     const showThemes = themes.length > 1;
 
     $: showTextAppearence = showFontSize || showLineHeight || showThemes || showFonts;
@@ -107,15 +113,25 @@ The navbar component. We have sliders that update reactively to both font size a
                 {#if showFontSize}
                     <div class="grid gap-4 items-center range-row m-2">
                         <TextAppearanceIcon color={$monoIconColor} />
-                        <Slider
-                            bind:value={$bodyFontSize}
-                            {barColor}
-                            {progressColor}
-                            min={config.mainFeatures['text-size-min']}
-                            max={config.mainFeatures['text-size-max']}
-                        />
+                        {#if contentsMode}
+                            <Slider
+                                bind:value={$contentsFontSize}
+                                {barColor}
+                                {progressColor}
+                                min={config.mainFeatures['text-size-min']}
+                                max={config.mainFeatures['text-size-max']}
+                            />
+                        {:else}
+                            <Slider
+                                bind:value={$bodyFontSize}
+                                {barColor}
+                                {progressColor}
+                                min={config.mainFeatures['text-size-min']}
+                                max={config.mainFeatures['text-size-max']}
+                            />
+                        {/if}
                         <div class="text-md text-{$monoIconColor} place-self-end">
-                            {$bodyFontSize}
+                            {contentsMode ? $contentsFontSize : $bodyFontSize}
                         </div>
                     </div>
                 {/if}

--- a/src/lib/components/TextAppearanceSelector.svelte
+++ b/src/lib/components/TextAppearanceSelector.svelte
@@ -33,7 +33,6 @@ The navbar component. We have sliders that update reactively to both font size a
     }
 
     export let options = {};
-    console.log(options);
     $: contentsMode = options?.contentsMode ?? false;
     export let vertOffset = '1rem'; //Prop that will have the navbar's height (in rem) passed in
     //The positioningCSS positions the modal 1rem below the navbar and 1rem from the right edge of the screen (on mobile it will be centered)

--- a/src/lib/data/stores/view.js
+++ b/src/lib/data/stores/view.js
@@ -90,6 +90,11 @@ setDefaultStorage('bodyLineHeight', '175');
 export const bodyLineHeight = writable(localStorage.bodyLineHeight);
 bodyLineHeight.subscribe((lineHeight) => (localStorage.bodyLineHeight = lineHeight));
 
+/**Font size of contents elements */
+setDefaultStorage('contentsFontSize', '17');
+export const contentsFontSize = writable(localStorage.contentsFontSize);
+contentsFontSize.subscribe((fontSize) => (localStorage.contentsFontSize = fontSize));
+
 export const showDesktopSidebar = derived(
     userSettings,
     ($userSettings) => $userSettings['desktop-sidebar']

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -40,6 +40,7 @@
                         noteDialog.showModal();
                         break;
                     case MODAL_TEXT_APPERANCE:
+                        textAppearanceSelector.options = data;
                         textAppearanceSelector.showModal();
                         break;
                     case MODAL_FONT:

--- a/src/routes/contents/[id]/+page.svelte
+++ b/src/routes/contents/[id]/+page.svelte
@@ -9,14 +9,16 @@
         modal,
         MODAL_COLLECTION,
         convertStyle,
-        contentsStack
+        contentsStack,
+        MODAL_TEXT_APPERANCE,
+        contentsFontSize
     } from '$lib/data/stores';
     import { compareVersions, pathJoin } from '$lib/scripts/stringUtils';
     import { base } from '$app/paths';
     import { refs } from '$lib/data/stores';
     import { goto } from '$app/navigation';
     import config from '$lib/data/config';
-    import { AudioIcon } from '$lib/icons';
+    import { AudioIcon, TextAppearanceIcon } from '$lib/icons';
 
     const imageFolder =
         compareVersions(config.programVersion, '12.0') < 0 ? 'illustrations' : 'contents';
@@ -172,7 +174,22 @@
             <label for="sidebar" slot="center">
                 <div class="btn btn-ghost normal-case text-xl">{title}</div>
             </label>
-            <!-- <div slot="right-buttons" /> -->
+            <div slot="right-buttons" class="flex items-center">
+                <div class="flex">
+                    {#if $page.data.features['show-text-size-button'] === true}
+                        <!-- svelte-ignore a11y-click-events-have-key-events -->
+                        <!-- svelte-ignore a11y-label-has-associated-control -->
+                        <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+                        <label
+                            class="dy-btn dy-btn-ghost p-0.5 dy-no-animation"
+                            on:click={() =>
+                                modal.open(MODAL_TEXT_APPERANCE, { contentsMode: true })}
+                        >
+                            <TextAppearanceIcon color="white" />
+                        </label>
+                    {/if}
+                </div>
+            </div>
         </Navbar>
     </div>
 
@@ -215,7 +232,7 @@
                         </div>
                     {/if}
 
-                    <div class="contents-text-block">
+                    <div class="contents-text-block" style:font-size="{$contentsFontSize}px">
                         <!-- check for title -->
                         {#if $page.data.features['show-titles'] === true}
                             <div class="contents-title">


### PR DESCRIPTION
fixes issue #537, contents text size should be
adjustable
- shows the modal for text TextAppearance if the setting is true
- adds a contentsMdoe to TextAppearanceSelector
- shows only the options that need to be shown if its in contents mode
- creates a seperate contentsTextSize