### PR TITLE
Fix deprecated call to filesystem

### DIFF
--- a/convert/convertBooks.ts
+++ b/convert/convertBooks.ts
@@ -159,7 +159,7 @@ export async function convertBooks(
             fs.cpSync(folderSrcDir, folderDstDir, { recursive: true });
         } else {
             if (fs.existsSync(folderDstDir)) {
-                fs.rmdirSync(folderDstDir, { recursive: true });
+                fs.rmSync(folderDstDir, { recursive: true, force: true });
             }
         }
     });


### PR DESCRIPTION
Replaces call to fs.rmdirSync() with fs.rmSync().

See npm deprecation [DEP0147](https://nodejs.org/api/deprecations.html#DEP0147)