### PR TITLE
Use correct allow-single-pane feature in 12.1

### DIFF
--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -1235,9 +1235,12 @@ function filterFeaturesNotReady(data: ConfigData) {
     data.mainFeatures['settings-share-usage-data'] = false;
 
     if (data.bookCollections) {
-        //only allow single pane book collections
+        // only allow single pane book collections
+        // in SAB 12.1, the feature changed names from bc-allow-single-pane to bc-layout-allow-single-pane
         data.bookCollections = data.bookCollections.filter(
-            (collection) => collection.features['bc-allow-single-pane']
+            (collection) =>
+                collection?.features['bc-allow-single-pane'] ??
+                collection?.features['bc-layout-allow-single-pane']
         );
     }
     return data;

--- a/src/lib/components/LayoutOptions.svelte
+++ b/src/lib/components/LayoutOptions.svelte
@@ -25,7 +25,8 @@ Displays the three different layout option menus.
     const allDocSets = config.bookCollections.map((ds) => ({
         id: ds.languageCode + '_' + ds.id,
         name: ds.collectionName,
-        singlePane: ds.features['bc-allow-single-pane'],
+        singlePane:
+            ds?.features['bc-allow-single-pane'] ?? ds?.features['bc-layout-allow-single-pane'],
         description: ds?.collectionDescription
     }));
 

--- a/src/lib/data/stores/collection.ts
+++ b/src/lib/data/stores/collection.ts
@@ -7,7 +7,8 @@ function findCollection(id) {
     return {
         id: ds.languageCode + '_' + ds.id,
         name: ds.collectionName,
-        singlePane: ds.features['bc-allow-single-pane'],
+        singlePane:
+            ds?.features['bc-allow-single-pane'] ?? ds?.features['bc-layout-allow-single-pane'],
         description: ds?.collectionDescription
     };
 }


### PR DESCRIPTION
In 12.1, the feature name that controls whether a collection is allowed in single-pane mode changed
from: bc-allow-single-pane
to:   bc-layout-allow-single-pane