### PR TITLE
#681 Run Convert Scripts Based on Project Type

### DIFF
--- a/convert/index.ts
+++ b/convert/index.ts
@@ -38,21 +38,7 @@ const verbose: number = verboseLevel
     : 0;
 
 const config = new ConvertConfig(dataDir).run(verbose);
-let programType = config.data.programType;
-
-//Used to sort the final list. This is neccesary because some scripts depend on others being run first.
-const stepClassesOrder = [
-    ConvertConfig,
-    ConvertContents,
-    ConvertPlans,
-    ConvertStyles,
-    ConvertManifest,
-    ConvertMedia,
-    ConvertBooks,
-    ConvertFirebase,
-    ConvertBadges,
-    ConvertAbout
-]
+const programType = config.data.programType;
 
 //Classes common to both SAB and DAB
 const commonStepClasses = [
@@ -74,7 +60,7 @@ const SABStepClasses = [
 
 //The convert scripts for this project type have not been implemented yet
 // const DABStepClasses = [
-//     ReversalIndex,
+//     ConvertReversalIndex,
 //     ConvertSQLite
 // ];
 
@@ -82,7 +68,7 @@ const stepClasses: Task[] = [
     ...commonStepClasses,
     ...(programType == 'SAB' ? SABStepClasses : [])
     //...(programType == 'DAB' ? DABStepClasses : [])
-].sort((a, b) => {return stepClassesOrder.indexOf(a) - stepClassesOrder.indexOf(b);}).map((x) => new x(dataDir));
+].map((x) => new x(dataDir));
 
 const allPaths = new Set(
     stepClasses.reduce((acc, step) => acc.concat(step.triggerFiles), [] as string[])

--- a/convert/index.ts
+++ b/convert/index.ts
@@ -59,7 +59,6 @@ const commonStepClasses = [
     ConvertConfig,
     ConvertStyles,
     ConvertManifest,
-    ConvertContents,
     ConvertMedia,
     ConvertFirebase,
     ConvertBadges,
@@ -68,6 +67,7 @@ const commonStepClasses = [
 
 //Classes only necessary for SAB
 const SABStepClasses = [
+    ConvertContents,
     ConvertPlans,
     ConvertBooks
 ];

--- a/convert/index.ts
+++ b/convert/index.ts
@@ -45,6 +45,7 @@ const commonStepClasses = [
     ConvertConfig,
     ConvertStyles,
     ConvertManifest,
+    ConvertContents,
     ConvertMedia,
     ConvertFirebase,
     ConvertBadges,
@@ -52,7 +53,6 @@ const commonStepClasses = [
 ];
 
 const SABStepClasses = [
-    ConvertContents,
     ConvertPlans,
     ConvertBooks
 ];

--- a/convert/index.ts
+++ b/convert/index.ts
@@ -37,17 +37,36 @@ const verbose: number = verboseLevel
         : 1
     : 0;
 
-const stepClasses: Task[] = [
+const config = new ConvertConfig(dataDir).run(verbose);
+let programType = config.data.programType;
+
+//Classes common to both SAB and DAB
+const commonStepClasses = [
     ConvertConfig,
-    ConvertContents,
-    ConvertPlans,
     ConvertStyles,
     ConvertManifest,
     ConvertMedia,
-    ConvertBooks,
     ConvertFirebase,
     ConvertBadges,
     ConvertAbout
+];
+
+const SABStepClasses = [
+    ConvertContents,
+    ConvertPlans,
+    ConvertBooks
+];
+
+//The convert scripts for this project type have not been implemented yet
+// const DABStepClasses = [
+//     ReversalIndex,
+//     ConvertSQLite
+// ];
+
+const stepClasses: Task[] = [
+    ...commonStepClasses,
+    ...(programType == 'SAB' ? SABStepClasses : [])
+    //...(programType == 'DAB' ? DABStepClasses : [])
 ].map((x) => new x(dataDir));
 const allPaths = new Set(
     stepClasses.reduce((acc, step) => acc.concat(step.triggerFiles), [] as string[])

--- a/convert/index.ts
+++ b/convert/index.ts
@@ -52,11 +52,7 @@ const commonStepClasses = [
 ];
 
 //Classes only necessary for SAB
-const SABStepClasses = [
-    ConvertContents,
-    ConvertPlans,
-    ConvertBooks
-];
+const SABStepClasses = [ConvertContents, ConvertPlans, ConvertBooks];
 
 //The convert scripts for this project type have not been implemented yet
 // const DABStepClasses = [


### PR DESCRIPTION
Some convert scripts are only necessary for SAB, and some in the future will only be neccessary for DAB. This pull request:

-Separates the list of convert scripts into common, SAB only, and a future DAB only
-Uses programType from ConvertConfig (which comes from appdef.xml) to determine which lists to use