### PR TITLE
DAB 12.2: Make audio-source optional in audio-sources

### DIFF
--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -647,7 +647,7 @@ function convertConfig(dataDir: string, verbose: number) {
     // Audio Sources
     const audioSources = document
         .getElementsByTagName('audio-sources')[0]
-        .getElementsByTagName('audio-source');
+        ?.getElementsByTagName('audio-source');
     if (audioSources?.length > 0) {
         data.audio = { sources: {} };
         for (const source of audioSources) {


### PR DESCRIPTION
In DAB 12.2, audio-sources is always there, but it might not have audio-source elements in it.