### PR TITLE
Ignore temporary data directories with the namng pattern data-XXX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ node_modules
 .env.*
 !.env.example
 data/*
+data-*/*
+!data-sandbox/*
+data-sandbox/node_modules
 !data/.empty
 static/sab-stylesheet.css
 static/badges


### PR DESCRIPTION
There are times when I need to compare data from different apps or data generated by different version of SAB/DAB.  So I have been copying the data to something like "data-sab", "data-12.1.1", etc.

I don't want these showing up in the changed files.`

Since we already had data-sandbox as a source directory, I had to do a bit of fudging with the patterns so that new files in that directory would not be ignored, but the data-sandbox/node_modules would still be ignored. Ugh.