### PR TITLE
Display html books

### DIFF
--- a/config/index.d.ts
+++ b/config/index.d.ts
@@ -21,6 +21,7 @@ export type StyleData = {
 export type BookData = {
     id: string;
     type?: string;
+    format?: string;
     name: string;
     abbreviation: string;
     additionalNames?: {

--- a/convert/convertBooks.ts
+++ b/convert/convertBooks.ts
@@ -430,8 +430,6 @@ function convertHtmlBook(context: ConvertBookContext, book: BookData, files: any
         path: dstFile,
         content
     });
-
-    //process.stdout.write(`copyHtmlBook: bookId:${book.id}, src:${srcFile}, dst:${dstFile}\n`);
 }
 
 function convertQuizBook(context: ConvertBookContext, book: BookData): Quiz {

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -398,6 +398,9 @@ function convertConfig(dataDir: string, verbose: number) {
             const footer = convertFooter(footerTags[0]?.innerHTML, document);
             if (verbose >= 2) console.log(`.... footer: `, footer);
 
+            const format = book.attributes.getNamedItem('format')?.value;
+            const file = book.getElementsByTagName('f')[0]?.innerHTML;
+
             books.push({
                 portions: book.getElementsByTagName('portions')[0]?.attributes.getNamedItem('value')
                     ?.value,
@@ -409,13 +412,14 @@ function convertConfig(dataDir: string, verbose: number) {
                 fonts,
                 id: book.attributes.getNamedItem('id')!.value,
                 type: book.attributes.getNamedItem('type')?.value,
+                format,
                 name: book.getElementsByTagName('n')[0]?.innerHTML,
                 additionalNames,
                 section: book.getElementsByTagName('sg')[0]?.innerHTML,
                 testament: book.getElementsByTagName('g')[0]?.innerHTML,
                 abbreviation: book.getElementsByTagName('v')[0]?.innerHTML,
                 audio,
-                file: book.getElementsByTagName('f')[0]?.innerHTML.replace(/\.\w*$/, '.usfm'),
+                file: format ? file : file.replace(/\.\w*$/, '.usfm'), // Default format is USFM and multiple files are combined into single .usfm
                 features: bookFeatures,
                 quizFeatures,
                 style,

--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -34,7 +34,7 @@ The navbar component.
         displayLabel ??
         config.bookCollections
             .find((x) => x.id === $refs.collection)
-            .books.find((x) => x.id === book).name;
+            .books.find((x) => x.id === book)?.name;
 
     function chapterCount(book) {
         let count = Object.keys(books.find((x) => x.bookCode === book).versesByChapters).length;
@@ -134,7 +134,7 @@ The navbar component.
     /**list of books, quizzes, and quiz groups in current docSet*/
     $: books = $refs.catalog.documents;
     /**list of chapters in current book*/
-    $: chapters = books.find((d) => d.bookCode === book).versesByChapters;
+    $: chapters = books.find((d) => d.bookCode === book)?.versesByChapters ?? [];
 
     function getBookUrl(book) {
         let url;
@@ -152,7 +152,7 @@ The navbar component.
             .find((x) => x.id === colId)
             .books.forEach((book) => {
                 const url = getBookUrl(book);
-                if (books.find((x) => x.bookCode === book.id) || url) {
+                if ($refs.allBookIds.find((x) => x === book.id) || url) {
                     let label = book[bookLabel] || book.name;
                     let cell = { label, id: book.id, url };
                     let group = book.testament || '';
@@ -189,7 +189,7 @@ The navbar component.
     };
 
     let chapterGridGroup = (chapters) => {
-        let hasIntroduction = books.find((x) => x.bookCode === book).hasIntroduction;
+        let hasIntroduction = books.find((x) => x.bookCode === book)?.hasIntroduction;
         return [
             {
                 rows: hasIntroduction

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -75,10 +75,12 @@ The navbar component.
         nextRef.reset();
     }
 
-    function getChapterCount(book) {
-        let books = $refs.catalog.documents;
-        let count = Object.keys(books.find((x) => x.bookCode === book).versesByChapters).length;
-        return count;
+    function getChapterCount(bookId) {
+        const book = $refs.catalog.documents.find((x) => x.bookCode === bookId);
+        if (book) {
+            return Object.keys(book.versesByChapters).length;
+        }
+        return 0;
     }
 
     function getVerseCount(book, chapter) {
@@ -86,7 +88,7 @@ The navbar component.
             return 0;
         }
         let books = $refs.catalog.documents;
-        let chapters = books.find((d) => d.bookCode === book).versesByChapters;
+        let chapters = books.find((d) => d.bookCode === book)?.versesByChapters;
         if (!chapters || Object.keys(chapters).length === 0) {
             return 0;
         }
@@ -134,7 +136,7 @@ The navbar component.
     /**list of books in current docSet*/
     $: books = $refs.catalog.documents;
     /**list of chapters in current book*/
-    $: chapters = books.find((d) => d.bookCode === book).versesByChapters;
+    $: chapters = books.find((d) => d.bookCode === book)?.versesByChapters;
     $: showSelector =
         config.mainFeatures['show-chapter-number-on-app-bar'] && getChapterCount($refs.book) > 0;
     const canSelect = config.mainFeatures['show-chapter-selector'];

--- a/src/lib/components/HtmlBookView.svelte
+++ b/src/lib/components/HtmlBookView.svelte
@@ -1,0 +1,48 @@
+<!--
+@component
+Display an HTML Book.
+-->
+<script lang="ts">
+    import config from '$lib/data/config';
+    import { base } from '$app/paths';
+
+    export let references: any;
+    export let bodyLineHeight: any;
+    export let bodyFontSize: any;
+    export let fetch: any;
+
+    $: fontSize = bodyFontSize + 'px';
+    $: lineHeight = bodyLineHeight + '%';
+
+    let htmlHead: string;
+    let htmlBody: string;
+
+    $: loadHtml(references.collection, references.book);
+
+    async function loadHtml(collectionId: string, bookId: string) {
+        console.log(`loadHtml: ${collectionId}, ${bookId}`);
+        const book = config.bookCollections
+            .find((x) => x.id === collectionId)
+            ?.books.find((x) => x.id === bookId);
+
+        if (book) {
+            const result = await fetch(`${base}/collections/${references.collection}/${book.file}`);
+
+            if (result.ok) {
+                const fullHtml = await result.text();
+
+                // Extract content within <head> and <body>
+                htmlHead = fullHtml.match(/<head[^>]*>([\s\S]*?)<\/head>/i)?.[1] || '';
+                htmlBody = fullHtml.match(/<body[^>]*>([\s\S]*?)<\/body>/i)?.[1] || '';
+            }
+        }
+    }
+</script>
+
+<svelte:head>
+    {@html htmlHead}
+</svelte:head>
+
+<div style="line-height: {lineHeight}; font-size: {fontSize};">
+    {@html htmlBody}
+</div>

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -1976,7 +1976,7 @@ LOGGING:
 
     $: (() => {
         performance.mark('query-start');
-        const bookHasIntroduction = books.find((x) => x.bookCode === currentBook).hasIntroduction;
+        const bookHasIntroduction = books.find((x) => x.bookCode === currentBook)?.hasIntroduction;
         let chapterToDisplay = currentChapter;
         if (bookHasIntroduction && chapterToDisplay == 'i') {
             chapterToDisplay = '1';

--- a/src/lib/data/catalogData.ts
+++ b/src/lib/data/catalogData.ts
@@ -22,6 +22,11 @@ export interface CatalogData {
         };
     }[];
     tags: {};
+    quizzes: {};
+    htmlBooks: {
+        id: string;
+        name: string;
+    }[];
 }
 
 export async function loadCatalog(docSet: string): Promise<CatalogData> {

--- a/src/lib/data/navigation.test.ts
+++ b/src/lib/data/navigation.test.ts
@@ -59,6 +59,32 @@ const config = {
                         textSize: 20,
                         verseNumbers: 'default'
                     }
+                },
+                {
+                    chapters: 1,
+                    chaptersN: '1',
+                    id: 'B001',
+                    name: 'Book 1',
+                    testament: 'Extra',
+                    abbreviation: 'BK1',
+                    audio: [],
+                    file: 'book1.html',
+                    features: {
+                        'show-chapter-numbers': false
+                    }
+                },
+                {
+                    chapters: 1,
+                    chaptersN: '1',
+                    id: 'B002',
+                    name: 'Book 2',
+                    testament: 'Extra',
+                    abbreviation: 'BK2',
+                    audio: [],
+                    file: 'book2.html',
+                    features: {
+                        'show-chapter-numbers': false
+                    }
                 }
             ]
         },
@@ -141,7 +167,18 @@ const catalog1: CatalogData = {
             }
         }
     ],
-    tags: {}
+    tags: {},
+    quizzes: {},
+    htmlBooks: [
+        {
+            id: 'B001',
+            name: 'Book 1'
+        },
+        {
+            id: 'B002',
+            name: 'Book 2'
+        }
+    ]
 };
 
 const catalog2: CatalogData = {
@@ -176,7 +213,9 @@ const catalog2: CatalogData = {
             versesByChapters: {}
         }
     ],
-    tags: {}
+    tags: {},
+    quizzes: {},
+    htmlBooks: []
 };
 
 function getTestCatalog(docSet: string): Promise<CatalogData> {
@@ -583,6 +622,25 @@ describe('goTo', () => {
             await navContext.gotoInitial();
             await navContext.goto('eng_C01', 'MAT', '2');
             expect(navContext.reference).toBe('eng_C01.MAT.2');
+        });
+    });
+
+    describe('html books', () => {
+        test('reference with html book', async () => {
+            const navContext = new TestNavigationContext(getTestCatalog, config);
+            await navContext.gotoInitial();
+            await navContext.goto('eng_C01', 'B001', '1');
+            expect(navContext.reference).toBe('eng_C01.B001.1');
+            expect(navContext.book).toBe('B001');
+            expect(navContext.prev.book).toBeNull();
+            expect(navContext.next.book).toBeNull();
+        });
+
+        test('allBookIds contain html', async () => {
+            const navContext = new TestNavigationContext(getTestCatalog, config);
+            await navContext.gotoInitial();
+            expect(navContext.allBookIds.includes('B001')).toBeTruthy();
+            expect(navContext.catalog.documents.find((b) => b.bookCode === 'B001')).toBeFalsy();
         });
     });
 });

--- a/src/lib/data/stores/reference.ts
+++ b/src/lib/data/stores/reference.ts
@@ -17,6 +17,7 @@ interface ReferenceStore {
     next: { book: string | null; chapter: string | null };
     prev: { book: string | null; chapter: string | null };
     catalog: CatalogData;
+    allBookIds: string[];
     initialized: boolean;
 }
 
@@ -39,6 +40,7 @@ export const referenceStore = () => {
             next: nav.next,
             prev: nav.prev,
             catalog: nav.catalog,
+            allBookIds: nav.allBookIds,
             initialized: nav.initialized
         });
         localStorage.refs = nav.reference;

--- a/src/lib/data/stores/scripture.js
+++ b/src/lib/data/stores/scripture.js
@@ -151,11 +151,11 @@ export const fontChoices = derived(refs, ($refs) => {
     if (!$refs.initialized) return [];
     const bookFonts = config.bookCollections
         .find((x) => x.id === $refs.collection)
-        .books.find((x) => x.id === $refs.book).fonts;
+        .books.find((x) => x.id === $refs.book)?.fonts;
     const colFonts = config.bookCollections.find((x) => x.id === $refs.collection).fonts;
     const allFonts = [...new Set(config.fonts.map((x) => x.family))];
     const currentFonts =
-        bookFonts.length > 0 ? bookFonts : colFonts.length > 0 ? colFonts : allFonts;
+        bookFonts?.length > 0 ? bookFonts : colFonts.length > 0 ? colFonts : allFonts;
     currentFont.update((current) => {
         if (currentFonts.indexOf(current) === -1) {
             return currentFonts[0];

--- a/src/lib/scripts/configUtils.ts
+++ b/src/lib/scripts/configUtils.ts
@@ -64,6 +64,7 @@ export function getStyle(configData: any, option: string, bc: string, book: stri
     const bookData = bcData.books.find((x) => x.id === book);
     // Use the style of the book, if defined.
     if (
+        bookData &&
         bookData.style != null &&
         bookData.style[option] != null &&
         bookData.style[option] !== 'inherit'

--- a/src/routes/text/+page.js
+++ b/src/routes/text/+page.js
@@ -1,7 +1,7 @@
 import { initProskomma } from '$lib/data/scripture';
 
 /** @type {import('./$types').PageLoad} */
-export async function load({ url, fetch }) {
+export async function load({ fetch }) {
     const proskomma = await initProskomma({ fetch });
-    return { proskomma };
+    return { fetch, proskomma };
 }


### PR DESCRIPTION
- [x] Convert HTML books
  - [x] Update image tags to reference `/illustrations`
  - [x] Use BUILD_BASE_PATH for path to illustrations
- [x] HTML books display in the Book Selector 
- [x] When an HTML book is selected
  - [x] Display like scripture (with gutters on desktop)
  - [x] Chapter selector hidden
  - [x] Display title in book selector
  - [x] No swiping or next/prev buttons
  - [x] Use styles in `<head>` of the HTML file
  - [x] Display correctly on mobile
  - [x] Font size adjustment

Sample project provided by user: https://www.evangelischebijbelvertaling.nl/EBV.zip