### PR TITLE
Fix search; don't filter books

### DIFF
--- a/src/lib/search-worker/data/pk-verse-provider.ts
+++ b/src/lib/search-worker/data/pk-verse-provider.ts
@@ -84,7 +84,10 @@ export class ProskommaVerseProvider implements QueryVerseProvider {
     async setBooks() {
         this.nextBook = 0;
         const queryData = await this.pk.queryBooks(this.searchPhrase, this.options);
-        this.books = queryData.filter((bk) => bk.idParts.type === 'book');
+        // Note: We might need to filter if Proskomma includes other type of documents.
+        //       Currently, type = null for scripture books
+        // this.books = queryData.filter((bk) => bk.idParts.type === 'book');
+        this.books = queryData;
     }
 
     async versesOfBook(book: GQLBookId): Promise<SearchCandidate[]> {

--- a/src/lib/search-worker/data/test/pk-verse-provider.test.ts
+++ b/src/lib/search-worker/data/test/pk-verse-provider.test.ts
@@ -13,21 +13,14 @@ const testBooks: GQLBookId[] = [
         id: 'abc',
         bookCode: 'test1',
         idParts: {
-            type: 'book'
+            type: null
         }
     },
     {
         id: 'xyz',
         bookCode: 'test2',
         idParts: {
-            type: 'book'
-        }
-    },
-    {
-        id: 'songs123',
-        bookCode: 'test3',
-        idParts: {
-            type: 'song'
+            type: null
         }
     }
 ];


### PR DESCRIPTION
When search was written, somehow the document type was set to book and now it is not. So search wasn't searching any books.