### PR TITLE
Stop audio when navigating to another ref or route

### DIFF
--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -125,6 +125,12 @@ export function playPause() {
     }
     audioPlayerStore.set(currentAudioPlayer);
 }
+export function playStop() {
+    if (!currentAudioPlayer.loaded) return;
+    if (currentAudioPlayer.playing === true) {
+        pause();
+    }
+}
 // changes chapter
 export async function skip(direction) {
     pause();

--- a/src/lib/navigate/index.ts
+++ b/src/lib/navigate/index.ts
@@ -4,6 +4,7 @@ import { goto } from '$app/navigation';
 import { base } from '$app/paths';
 import { get } from 'svelte/store';
 import { logScreenView } from '$lib/data/analytics';
+import { playStop } from '$lib/data/audio';
 
 function logHistoryItemAdded(itemAdded: HistoryItem) {
     logScreenView(itemAdded);
@@ -21,6 +22,7 @@ export async function navigateToText(item: {
     chapter: string;
     verse?: string;
 }) {
+    playStop();
     await refs.set({
         docSet: item.docSet,
         book: item.book,
@@ -35,6 +37,7 @@ export async function navigateToText(item: {
 }
 
 export async function navigateToTextReference(reference: string) {
+    playStop();
     await refs.setReference(reference);
     const nowRef: any = get(refs);
     goto(`${base}/text`);
@@ -49,6 +52,7 @@ export async function navigateToTextReference(reference: string) {
 }
 
 export async function navigateToTextChapterInDirection(direction: number) {
+    playStop();
     await refs.skip(direction);
     const nowRef: any = get(refs);
     addHistory(

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -33,7 +33,7 @@
         userSettingsOrDefault,
         analytics
     } from '$lib/data/stores';
-    import { updateAudioPlayer, seekToVerse } from '$lib/data/audio';
+    import { updateAudioPlayer, seekToVerse, playStop } from '$lib/data/audio';
     import {
         AudioIcon,
         SearchIcon,
@@ -319,6 +319,11 @@
     }
     $: showBackButton =
         contents?.features?.['navigation-type'] === 'up' && $contentsStack.length > 0;
+
+    onDestroy(() => {
+        // stop audio when changing routes
+        playStop();
+    });
 </script>
 
 <div class="grid grid-rows-[auto,1fr,auto]" style="height:100vh;height:100dvh;">


### PR DESCRIPTION
Currently, the audio keeps playing when navigating to another location or displaying a different route. It should stop.

We have to be careful about not breaking the auto play between chapters.