### PR TITLE
Add convertContents to DAB

### DIFF
--- a/convert/index.ts
+++ b/convert/index.ts
@@ -44,6 +44,7 @@ const programType = config.data.programType;
 //Classes common to both SAB and DAB
 const commonStepClasses = [
     ConvertConfig,
+    ConvertContents,
     ConvertStyles,
     ConvertManifest,
     ConvertMedia,
@@ -53,7 +54,7 @@ const commonStepClasses = [
 ];
 
 //Classes only necessary for SAB
-const SABStepClasses = [ConvertContents, ConvertPlans, ConvertBooks];
+const SABStepClasses = [ConvertPlans, ConvertBooks];
 
 const DABStepClasses = [
     // ConvertReversalIndex,


### PR DESCRIPTION
* Even though DAB doesn't have contents menu, the template depends on importing at least an empty contents.js file