### PR TITLE
Fix issues with displaying figures

### DIFF
--- a/convert/convertBooks.ts
+++ b/convert/convertBooks.ts
@@ -91,6 +91,32 @@ function removeMissingVerses(text: string, _bcId: string, _bookId: string): stri
     });
 }
 
+// This is a HACK!!!
+// See https://github.com/Proskomma/proskomma-json-tools/issues/63
+//
+function handleNoCaptionFigures(text: string, _bcId: string, _bookId: string): string {
+    // Regular expression to match \fig markers
+    const figRegex = /\\fig\s(.*?)\\fig\*/g;
+
+    // Replace each \fig marker with the appropriate action
+    return text.replace(figRegex, (match, figContent) => {
+        // Split the content of the \fig marker by pipe (|)
+        const parts = figContent.split('|');
+
+        // Extract the image caption
+        let imageCaption = parts[0];
+
+        // Check if the image caption is missing
+        if (!imageCaption) {
+            // Caption is missing, return "NO_CAPTION" as the caption inside of the original \fig marker
+            return match.replace('|', 'NO_CAPTION|');
+        } else {
+            // Caption is present, return the original \fig marker
+            return match;
+        }
+    });
+}
+
 function removeMissingFigures(text: string, _bcId: string, _bookId: string): string {
     // Regular expression to match \fig markers
     const figRegex = /\\fig\s(.*?)\\fig\*/g;
@@ -158,6 +184,7 @@ const usfmFilterFunctions: FilterFunction[] = [
     replaceVideoTags,
     replacePageTags,
     convertMarkdownsToMilestones,
+    handleNoCaptionFigures,
     removeMissingFigures,
     trimTrailingWhitespace
 ];

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -835,13 +835,16 @@ LOGGING:
         return source;
     }
     function showImage() {
+        return viewShowIllustrations && showImageInBook();
+    }
+    function showImageInBook() {
         const showBibleImage = viewShowBibleImages === 'normal';
-        const showImages = currentIsBibleBook && showBibleImage && viewShowIllustrations;
+        const showImages = !currentIsBibleBook || showBibleImage;
         return showImages;
     }
     function showVideo() {
         const showBibleVideo = viewShowBibleVideos === 'normal';
-        const showVideos = currentIsBibleBook && showBibleVideo;
+        const showVideos = !currentIsBibleBook || showBibleVideo;
         return showVideos;
     }
     function addFigureDiv(source: string, workspace: any) {
@@ -1358,8 +1361,13 @@ LOGGING:
                                         break;
                                     }
                                     case 'fig': {
-                                        const divFigureText = createIllustrationCaptionBlock(text);
-                                        workspace.figureDiv.append(divFigureText);
+                                        // This is a HACK!
+                                        // see https://github.com/Proskomma/proskomma-json-tools/issues/63
+                                        if (text !== 'NO_CAPTION') {
+                                            const divFigureText =
+                                                createIllustrationCaptionBlock(text);
+                                            workspace.figureDiv.append(divFigureText);
+                                        }
                                         break;
                                     }
                                     case 'audioc':


### PR DESCRIPTION
* HACK: Add NO_CAPTION to figs without captions and don't render it
* Always display figures or videos in non-scripture books