### PR TITLE
Fix navigate with show verse selector and no verses

### DIFF
--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -88,7 +88,7 @@ The navbar component.
                 }
                 case c:
                     $nextRef.chapter = e.detail.text;
-                    if (!showVerseSelector || $nextRef.chapter === 'i') {
+                    if (!showVerseSelector || $nextRef.chapter === 'i' || verseCount === 0) {
                         await completeNavigation();
                     } else {
                         bookSelector.setActive(v);

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -36,7 +36,7 @@ The navbar component.
         switch (e.detail.tab) {
             case c:
                 $nextRef.chapter = e.detail.text;
-                if (!showVerseSelector || $nextRef.chapter === 'i') {
+                if (!showVerseSelector || $nextRef.chapter === 'i' || verseCount === 0) {
                     await completeNavigation();
                 } else {
                     chapterSelector.setActive(v);


### PR DESCRIPTION
When a chapter is selected that has no verses, then initiate the navigation immediately.