### PR TITLE
Allow for non string features in method signature.

### DIFF
--- a/src/lib/video/index.ts
+++ b/src/lib/video/index.ts
@@ -63,7 +63,7 @@ function getYouTubeVideoId(url: string): string {
 export function getEmbeddedVideoUrl(
     videoUrl: string,
     autoplay: boolean,
-    features: { [key: string]: string }
+    features: { [key: string]: any }
 ) {
     let returnUrl = videoUrl;
     const type = getVideoType(videoUrl);
@@ -140,7 +140,7 @@ export function getEmbeddedVideoUrl(
 export function createVideoBlockFromUrl(
     document: Document,
     videoUrl: string,
-    features: { [key: string]: string }
+    features: { [key: string]: any }
 ): HTMLElement {
     const url = getEmbeddedVideoUrl(videoUrl, false, features);
 


### PR DESCRIPTION
The method signature called for an array of strings.  The features include boolean types and perhaps others.   Changing the type to any removes errors being detected in the locations where it is called.