### PR TITLE
Support converting audio element without file

### DIFF
--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -523,8 +523,10 @@ function parseBookCollections(document: Document, verbose: number) {
                 const audioTag = page.getElementsByTagName('audio')[0];
                 if (!audioTag) continue;
                 const fTag = audioTag.getElementsByTagName('f')[0];
-                if (verbose >= 2)
-                    console.log(`... audioTag: ${audioTag.outerHTML}, fTag:${fTag.outerHTML}`);
+                if (verbose >= 2) {
+                    console.log(`... audioTag: ${audioTag.outerHTML}, fTag:${fTag?.outerHTML}`);
+                }
+                if (!fTag) continue;
                 audio.push({
                     num: parseInt(page.attributes.getNamedItem('num')!.value),
                     filename: fTag.innerHTML,


### PR DESCRIPTION
In SAB, you can configure an audio entry that has a timing file but without an audio file. It is not useful, but it is allowed.

Change the conversion of the appdef.xml to config.json to ignore audio entries without file sub-entries.