### PR TITLE
Fix analytics error when contents item selected

### DIFF
--- a/src/routes/contents/[id]/+page.svelte
+++ b/src/routes/contents/[id]/+page.svelte
@@ -91,13 +91,12 @@
     }
 
     function getReference(item) {
-        let docSet;
-        let collection;
+        let docSet = $refs.docSet;
+        let collection = docSet.split('_')[1];
         let book;
         let chapter;
         let verse;
         const reference = item.linkTarget.split('.');
-
         if (item.layoutMode && item.layoutCollection?.length > 0) {
             /* 
             Note: have not handled layout modes


### PR DESCRIPTION
If the contents item doesn't specify a book collection, analytics callback logging history failed with unfilled promise error