### PR TITLE
Add paragraphs around table rows

### DIFF
--- a/convert/convertBooks.ts
+++ b/convert/convertBooks.ts
@@ -190,6 +190,10 @@ function isImageMissing(imageSource: string): boolean {
     return !fs.existsSync(path.join('data', 'illustrations', imageSource));
 }
 
+function addParagraphMarkersAroundTableRows(text: string): string {
+    return text.replace(/((?:\\tr [^\n]*\n)+)/g, '\n\\p\n$1\\p\n');
+}
+
 type FilterFunction = (text: string, bcId: string, bookId: string) => string;
 
 const usfmFilterFunctions: FilterFunction[] = [
@@ -199,7 +203,8 @@ const usfmFilterFunctions: FilterFunction[] = [
     convertMarkdownsToMilestones,
     handleNoCaptionFigures,
     removeMissingFigures,
-    trimTrailingWhitespace
+    trimTrailingWhitespace,
+    addParagraphMarkersAroundTableRows
 ];
 
 const htmlFilterFunctions: FilterFunction[] = [updateImgTags, trimTrailingWhitespace];


### PR DESCRIPTION
There is a bug in Proskomma where the generation of events is messed up if you have a series of table row markers \tr.  A work-around is to put paragraph makers \p around the series of table row markers.