### PR TITLE
HACK: switch web, email, tel urls to use embedded /jmp

### DIFF
--- a/convert/convertMarkdown.test.ts
+++ b/convert/convertMarkdown.test.ts
@@ -15,21 +15,17 @@ describe('convertMarkdownsToMilestones', () => {
     });
     it('converts a telephone markdown to a milestone', () => {
         // Gen 3:14 translates this [TEL](tel:6145551212)
-        expect(modifiedContent).toContain(
-            '\\ztellink-s | link="tel%3A6145551212"\\*TEL \\ztellink-e\\*'
-        );
+        expect(modifiedContent).toContain('/jmp TEL|href="tel%3A6145551212"/jmp*');
     });
     it('converts an email markdown to a milestone', () => {
         // Gen 3:14 translates this [EMAIL DAVID](mailto:david_moore1@sil.org)
         expect(modifiedContent).toContain(
-            '\\zelink-s | link="mailto%3Adavid_moore1%40sil.org"\\*EMAIL DAVID \\zelink-e\\*'
+            '/jmp EMAIL DAVID|href="mailto%3Adavid_moore1%40sil.org"/jmp*'
         );
     });
     it('converts a web link markdown to a milestone', () => {
         // Gen 3:13 translates this [Web Link](https://www.sil.org/)
-        expect(modifiedContent).toContain(
-            '\\zweblink-s | link="https%3A%2F%2Fwww.sil.org%2F"\\*Web Link \\zweblink-e\\*'
-        );
+        expect(modifiedContent).toContain('/jmp Web Link|href="https%3A%2F%2Fwww.sil.org%2F"/jmp*');
     });
     it('adds an empty markdown as text ', () => {
         // Gen 3:13 adds [Empty Markdown to text]
@@ -38,31 +34,31 @@ describe('convertMarkdownsToMilestones', () => {
     it('converts an audio clip markdown to a milestone', () => {
         // Gen 3:12 translates this [Audio](audioclip.mp3)
         expect(modifiedContent).toContain(
-            '\\zaudioc-s | link="audioclip.mp3" \\*Audio \\zaudioc-e\\*'
+            '\\zaudioc-s |link="audioclip.mp3" \\*Audio\\zaudioc-e\\*'
         );
     });
     it('converts a full reference markdown to a milestone', () => {
         // Gen 3:11 translates [Beatitudes](C01.MAT.5.1)
         expect(modifiedContent).toContain(
-            '\\zreflink-s | link="C01.MAT.5.1"\\*Beatitudes \\zreflink-e\\*'
+            '\\zreflink-s |link="C01.MAT.5.1"\\*Beatitudes\\zreflink-e\\*'
         );
     });
     it('converts a markdown reference without a book collection', () => {
         // Gen 3:10 translates [No BC Link](MAT.5.1)
         expect(modifiedContent).toContain(
-            '\\zreflink-s | link="C01.MAT.5.1"\\*No BC Link \\zreflink-e\\*'
+            '\\zreflink-s |link="C01.MAT.5.1"\\*No BC Link\\zreflink-e\\*'
         );
     });
     it('converts a markdown reference without book collection or verse', () => {
         // Gen 3:9 translates [No BC No Verse Link](MAT.5)
         expect(modifiedContent).toContain(
-            '\\zreflink-s | link="C01.MAT.5.1"\\*No BC No Verse Link \\zreflink-e\\*'
+            '\\zreflink-s |link="C01.MAT.5.1"\\*No BC No Verse Link\\zreflink-e\\*'
         );
     });
     it('converts a markdown reference with just chapter verse', () => {
         // Gen 3:8 translates [Just chapter verse](7.1)
         expect(modifiedContent).toContain(
-            '\\zreflink-s | link="C01.GEN.7.1"\\*Just chapter verse \\zreflink-e\\*'
+            '\\zreflink-s |link="C01.GEN.7.1"\\*Just chapter verse\\zreflink-e\\*'
         );
     });
 });

--- a/convert/convertMarkdown.ts
+++ b/convert/convertMarkdown.ts
@@ -143,17 +143,13 @@ function isImageLink(ref: string, excl: string): boolean {
     return result;
 }
 function audioUSFM(link: string, text: string): string {
-    // \zaudioc-s | link="audioclip.mp3"\*audioclip.mp3\zaudioc-e\*
+    // \zaudioc-s |link="audioclip.mp3"\*audioclip.mp3\zaudioc-e\*
     let result = '';
     const refLower = link.toLowerCase();
     const ext = getFilenameExt(refLower);
     if (ext === 'mp3' || ext === 'wav') {
         result =
-            ' \\zaudioc-s | link="' +
-            encodeURIComponent(link) +
-            '" \\*' +
-            text +
-            ' \\zaudioc-e\\* ';
+            ' \\zaudioc-s |link="' + encodeURIComponent(link) + '" \\*' + text + '\\zaudioc-e\\* ';
     }
     return result;
 }
@@ -163,21 +159,18 @@ function imageUSFM(link: string, text: string): string {
     return result;
 }
 function weblinkUSFM(link: string, text: string): string {
-    // \zweblink-s | link="https://www.sil.org/"\*Web Link \zweblink-e\*
-    const result =
-        ' \\zweblink-s | link="' + encodeURIComponent(link) + '"\\*' + text + ' \\zweblink-e\\* ';
+    // HACK: USFM supports web links through \jmp, Proskomma doesn't support \jmp. Pass them through as /jmp in text and process in ScriptureViewSofria.
+    const result = `/jmp ${text}|href="${encodeURIComponent(link)}"/jmp* `;
     return result;
 }
 function emailUSFM(link: string, text: string): string {
-    // \zelink-s | link="mailto:david_moore1@sil.org"\*EMAIL DAVID \zelink-e\*
-    const result =
-        ' \\zelink-s | link="' + encodeURIComponent(link) + '"\\*' + text + ' \\zelink-e\\* ';
+    // HACK: USFM supports web links through \jmp, Proskomma doesn't support \jmp. Pass them through as /jmp in text and process in ScriptureViewSofria.
+    const result = `/jmp ${text}|href="${encodeURIComponent(link)}"/jmp* `;
     return result;
 }
 function telUSFM(link: string, text: string): string {
-    // \ztellink-s | link="tel:6144323864"\*CAMB \ztellink-e\*
-    const result =
-        ' \\ztellink-s | link="' + encodeURIComponent(link) + '"\\*' + text + ' \\ztellink-e\\* ';
+    // HACK: USFM supports web links through \jmp, Proskomma doesn't support \jmp. Pass them through as /jmp in text and process in ScriptureViewSofria.
+    const result = `/jmp ${text}|href="${encodeURIComponent(link)}"/jmp* `;
     return result;
 }
 function referenceUSFM(link: string, text: string, bcId: string, bookid: string): string {
@@ -208,11 +201,11 @@ function referenceUSFM(link: string, text: string, bcId: string, bookid: string)
         const reference =
             refCollection + '.' + refBook + '.' + refChapter.toString() + '.' + refVerse.toString();
         result =
-            ' \\zreflink-s | link="' +
+            ' \\zreflink-s |link="' +
             encodeURIComponent(reference) +
             '"\\*' +
             text +
-            ' \\zreflink-e\\* ';
+            '\\zreflink-e\\* ';
     }
     return result;
 }


### PR DESCRIPTION
We were using milestones for web, email, and tel urls, but this didn't work when they were in \s headings. Proskomma doesn't support \jmp yet. Pass these links through as /jmp and convert in ScriptureViewSofria. When Proskomma supports \jmp, switch and remove convertJmp code.