### PR TITLE
Ignore vite temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ src/lib/data/catalog.js
 src/lib/data/firebase-config.js
 src/lib/data/config.js
 src/lib/data/contents.js
+vite.config.js.timestamp*


### PR DESCRIPTION
On some lame platforms (Windows), there are vite temp files left behind

Ex: vite.config.js.timestamp-1738015073323-88f028b10ca2c.mjs