### PR TITLE
Revert svelte-gestures to 5.0.7 which works with Svelte 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
                 "svelte": "^5",
                 "svelte-check": "^4.1.1",
                 "svelte-eslint-parser": "^0.43",
-                "svelte-gestures": "^5",
+                "svelte-gestures": "5.0.7",
                 "svelte-preprocess": "^6",
                 "tailwindcss": "^3.4",
                 "ts-node": "^10.8.1",
@@ -8883,9 +8883,9 @@
             }
         },
         "node_modules/svelte-gestures": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/svelte-gestures/-/svelte-gestures-5.1.3.tgz",
-            "integrity": "sha512-ELOlzuH9E4+S1biCCTfusRlvzFpnqRPlljEqayoBTu5STH42u0kTT45D1m3Py3E9UmIyZTgrSLw6Fus/fh75Dw==",
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/svelte-gestures/-/svelte-gestures-5.0.7.tgz",
+            "integrity": "sha512-TeCrcHQdnlTJKFTlEm6Vh1el0O1cLnbmVLeHqJqW8OayhsYNsEnuDL491+4HUkrHBpaaApKCGIFXKsPZqAoVKw==",
             "dev": true
         },
         "node_modules/svelte-preprocess": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "svelte": "^5",
         "svelte-check": "^4.1.1",
         "svelte-eslint-parser": "^0.43",
-        "svelte-gestures": "^5",
+        "svelte-gestures": "5.0.7",
         "svelte-preprocess": "^6",
         "tailwindcss": "^3.4",
         "ts-node": "^10.8.1",


### PR DESCRIPTION
svelte-gestures 5.1.3 only works with Svelte 5 syntax. When we switch the code to Svelte 5 that uses svelte-gestures, then we will need to upgrade it again.