### PR TITLE
Remove testing code that always displayed the collection selector

### DIFF
--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -400,7 +400,7 @@
                         </button>
 
                         <!-- Collection Selector Button -->
-                        {#if true || (showCollectionNavbar && enoughCollections)}
+                        {#if showCollectionNavbar && enoughCollections}
                             <button
                                 class="dy-btn dy-btn-ghost dy-btn-circle"
                                 on:click={() => modal.open(MODAL_COLLECTION)}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The "Collection Selector Button" now only appears when both the collection navbar is enabled and there are enough collections, preventing it from displaying unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->