### PR TITLE
Update Modal component to Svelte 5

### DIFF
--- a/src/lib/components/AudioPlaybackSpeed.svelte
+++ b/src/lib/components/AudioPlaybackSpeed.svelte
@@ -29,8 +29,8 @@
     }
 </script>
 
-<Modal bind:this={modalThis} id={modalId} useLabel={false}>
-    <svelte:fragment slot="content">
+<Modal bind:this={modalThis} id={modalId}>
+    {#snippet content()}
         <div style="color: {$monoIconColor}">
             <h1>
                 <b>{$t['Settings_Audio_Speed']}</b>
@@ -53,7 +53,7 @@
                 </div>
             </div>
         </div>
-    </svelte:fragment>
+    {/snippet}
 </Modal>
 
 <style>

--- a/src/lib/components/CollectionSelector.svelte
+++ b/src/lib/components/CollectionSelector.svelte
@@ -63,9 +63,8 @@ Book Collection Selector component.
     }
 </script>
 
-<!--addCSS is a prop for injecting CSS into the modal-->
-<Modal bind:this={modal} id={modalId} useLabel={false}>
-    <svelte:fragment slot="content">
+<Modal bind:this={modal} id={modalId}>
+    {#snippet content()}
         <TabsMenu
             bind:this={tabMenu}
             options={{
@@ -104,5 +103,5 @@ Book Collection Selector component.
                 on:click={() => handleOk()}>{$t['Button_OK']}</button
             >
         </div>
-    </svelte:fragment>
+    {/snippet}
 </Modal>

--- a/src/lib/components/FontSelector.svelte
+++ b/src/lib/components/FontSelector.svelte
@@ -24,8 +24,8 @@ Font Selector component.
     }
 </script>
 
-<Modal bind:this={modal} id={modalId} useLabel={false}>
-    <svelte:fragment slot="content">
+<Modal bind:this={modal} id={modalId}>
+    {#snippet content()}
         <FontList bind:this={fontList} selectedFont={$currentFont} />
         <div class="flex w-full justify-between dy-modal-action">
             <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -40,5 +40,5 @@ Font Selector component.
                 on:click={() => handleOk()}>{$t['Button_OK']}</button
             >
         </div>
-    </svelte:fragment>
+    {/snippet}
 </Modal>

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -7,11 +7,12 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
 @prop { Function } content - Snippet containing the content of the modal.
 @prop { Function } label   - Snippet containing the label of the model
 @prop { String }   addCSS  - CSS to inject into the model contents div/form.
+@prop { Function } onclose - Function to run when Modal closes.
 -->
 <script>
     import { convertStyle, direction, s } from '$lib/data/stores';
 
-    let { id, addCSS = '', content, label } = $props();
+    let { id, addCSS = '', content, label, onclose } = $props();
 
     let dialog;
 
@@ -27,7 +28,7 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
 {#if label}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-    <label for={id} class="dy-btn dy-btn-ghost p-0.5 dy-no-animation" on:click={{ id }.showModal()}>
+    <label for={id} class="dy-btn dy-btn-ghost p-0.5 dy-no-animation" onclick={{ id }.showModal()}>
         <!--Anything in this snippet will trigger the modal popup when clicked-->
         <!--{@render label()}-->
     </label>
@@ -36,7 +37,7 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
 <dialog
     bind:this={dialog}
     {id}
-    on:close
+    {onclose}
     class="dy-modal cursor-pointer"
     style:direction={$direction}
 >

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -30,7 +30,7 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
     <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
     <label for={id} class="dy-btn dy-btn-ghost p-0.5 dy-no-animation" onclick={{ id }.showModal()}>
         <!--Anything in this snippet will trigger the modal popup when clicked-->
-        <!--{@render label()}-->
+        {@render label()}
     </label>
 {/if}
 

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -3,27 +3,33 @@
 A simple modal component from DaisyUI. Closes when clicked outside of.
 
 See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
+@prop { String }   id      - ID for the modal.
+@prop { Function } content - Snippet containing the content of the modal.
+@prop { Function } label   - Snippet containing the label of the model
+@prop { String }   addCSS  - CSS to inject into the model contents div/form.
 -->
 <script>
     import { convertStyle, direction, s } from '$lib/data/stores';
 
-    export let id;
+    let { id, addCSS = '', content, label } = $props();
+
     let dialog;
-    export let useLabel = true; //If this is set to false, there will be no button/label with this modal to open it, and the modal may be initialized without filling the label slot.
+
+    /**
+     * This exported function allows buttons/labels
+     * in other divs to trigger the modal popup
+     */
     export function showModal() {
-        //This exported function allows buttons/labels in other divs to trigger the modal popup (see handleTextAppearanceSelector() and handleCollectionSelector() in +page.svelte).
         dialog.showModal();
     }
-    export let addCSS = ''; //Here addCSS is a prop for injecting CSS into the modal contents div/form below.
 </script>
 
-{#if useLabel}
+{#if label}
     <!-- svelte-ignore a11y_click_events_have_key_events -->
     <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
     <label for={id} class="dy-btn dy-btn-ghost p-0.5 dy-no-animation" on:click={{ id }.showModal()}>
-        <slot
-            name="label"
-        /><!--Anything passed into this slot will trigger the modal popup when clicked-->
+        <!--Anything in this snippet will trigger the modal popup when clicked-->
+        <!--{@render label()}-->
     </label>
 {/if}
 
@@ -39,7 +45,8 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
         style={convertStyle($s['ui.dialog']) + addCSS}
         class="dy-modal-box overflow-y-visible relative"
     >
-        <slot name="content" /><!--This is the slot for the popup's actual contents-->
+        {@render content?.()}
+        <!--This is the snippet for the popup's actual contents-->
     </form>
     <form method="dialog" class="dy-modal-backdrop">
         <!--This allows the modal to be closed when the user taps outside of the contents div/form-->

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -12,7 +12,7 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
 <script>
     import { convertStyle, direction, s } from '$lib/data/stores';
 
-    let { id, addCSS = '', content, label, onclose } = $props();
+    let { id, addCSS = '', content, label = null, onclose = null } = $props();
 
     let dialog;
 

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -5,14 +5,13 @@ A simple modal component from DaisyUI. Closes when clicked outside of.
 See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
 @prop { String }   id      - ID for the modal.
 @prop { Function } content - Snippet containing the content of the modal.
-@prop { Function } label   - Snippet containing the label of the model
 @prop { String }   addCSS  - CSS to inject into the model contents div/form.
 @prop { Function } onclose - Function to run when Modal closes.
 -->
 <script>
     import { convertStyle, direction, s } from '$lib/data/stores';
 
-    let { id, addCSS = '', content, label = null, onclose = null } = $props();
+    let { id, addCSS = '', content, onclose = null } = $props();
 
     let dialog;
 
@@ -24,15 +23,6 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
         dialog.showModal();
     }
 </script>
-
-{#if label}
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
-    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-    <label for={id} class="dy-btn dy-btn-ghost p-0.5 dy-no-animation" onclick={{ id }.showModal()}>
-        <!--Anything in this snippet will trigger the modal popup when clicked-->
-        {@render label()}
-    </label>
-{/if}
 
 <dialog
     bind:this={dialog}

--- a/src/lib/components/NoteDialog.svelte
+++ b/src/lib/components/NoteDialog.svelte
@@ -53,7 +53,7 @@
     }
 </script>
 
-<Modal bind:this={modal} {id} on:close={reset}>
+<Modal bind:this={modal} {id} onclose={reset}>
     {#snippet content()}
         <div class="flex flex-col justify-evenly">
             <div class="w-full flex justify-between">

--- a/src/lib/components/NoteDialog.svelte
+++ b/src/lib/components/NoteDialog.svelte
@@ -53,8 +53,8 @@
     }
 </script>
 
-<Modal bind:this={modal} {id} on:close={reset} useLabel={false}>
-    <svelte:fragment slot="content">
+<Modal bind:this={modal} {id} on:close={reset}>
+    {#snippet content()}
         <div class="flex flex-col justify-evenly">
             <div class="w-full flex justify-between">
                 <div class="w-full pb-3" style:font-weight={editing ? 'normal' : 'bold'}>
@@ -94,5 +94,5 @@
                 </div>
             {/if}
         </div>
-    </svelte:fragment>
+    {/snippet}
 </Modal>

--- a/src/lib/components/PlanStopDialog.svelte
+++ b/src/lib/components/PlanStopDialog.svelte
@@ -41,9 +41,8 @@ Plan Stop Modal Dialog component.
         'rem; inset-inline-end:1rem;';
 </script>
 
-<!--addCSS is a prop for injecting CSS into the modal-->
-<Modal bind:this={modal} id={modalId} useLabel={false}>
-    <svelte:fragment slot="content">
+<Modal bind:this={modal} id={modalId}>
+    {#snippet content()}
         <div id="container" class="message">
             <div class="message-body" id="message-body">
                 <div class="message-header"></div>
@@ -66,5 +65,5 @@ Plan Stop Modal Dialog component.
                 </div>
             </div>
         </div>
-    </svelte:fragment>
+    {/snippet}
 </Modal>

--- a/src/lib/components/TextAppearanceSelector.svelte
+++ b/src/lib/components/TextAppearanceSelector.svelte
@@ -105,9 +105,8 @@ The navbar component. We have sliders that update reactively to both font size a
 <!-- TextAppearanceSelector -->
 {#if showTextAppearence}
     <!-- svelte-ignore a11y_consider_explicit_label -->
-    <Modal bind:this={modalThis} id={modalId} useLabel={false} addCSS={positioningCSS}
-        ><!--addCSS is a prop for injecting CSS into the modal-->
-        <svelte:fragment slot="content">
+    <Modal bind:this={modalThis} id={modalId} addCSS={positioningCSS}>
+        {#snippet content()}
             <div class="grid gap-4">
                 <!-- Sliders for when text appearence text size is implemented place holder no functionality-->
                 {#if showFontSize}
@@ -198,7 +197,7 @@ The navbar component. We have sliders that update reactively to both font size a
                     </div>
                 {/if}
             </div>
-        </svelte:fragment>
+        {/snippet}
     </Modal>
 {/if}
 


### PR DESCRIPTION
 Per #819

Tested on all locations where Modal is used:
- [x] PlanStopDialog
- [x] NoteDialog
- [x] AudioPlaybackSpeed
- [x] TextAppearanceSelector
- [x] CollectionSelector
- [x] FontSelector

Label functionality is currently untested.
Not sure how to test that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated modal components to use a new syntax for content rendering, replacing slot fragments with snippet blocks.
  - Removed the label trigger from modal dialogs for a cleaner interface.
  - Streamlined modal content rendering and event handling for a more consistent user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->