### PR TITLE
Migrate search to Svelte 5

### DIFF
--- a/src/lib/components/SearchForm.svelte
+++ b/src/lib/components/SearchForm.svelte
@@ -2,18 +2,27 @@
     import config from '$lib/data/config';
     import { convertStyle, s, t, themeColors } from '$lib/data/stores';
     import { SearchIcon } from '$lib/icons';
-    import { createEventDispatcher } from 'svelte';
 
-    export let phrase: string;
-    export let wholeWords: boolean;
-    export let matchAccents: boolean;
+    export interface SearchFormSubmitEvent {
+        phrase: string;
+        wholeWords: boolean;
+        matchAccents: boolean;
+    }
+    interface SearchFormProps {
+        phrase: string;
+        wholeWords: boolean;
+        matchAccents: boolean;
+        submit: (event: SearchFormSubmitEvent) => void;
+    }
 
-    let searchbar;
+    let { phrase, wholeWords, matchAccents, submit }: SearchFormProps = $props();
+
+    let searchbar: HTMLInputElement | undefined = $state(undefined);
 
     // const specialCharacters =
     //     config.mainFeatures['input-buttons']?.split(' ').filter((c) => c.length) ?? [];
 
-    let specialCharacters = [];
+    let specialCharacters: string[] = $state([]);
     if (config.programType == 'SAB') {
         specialCharacters =
             config.mainFeatures['input-buttons']?.split(' ').filter((c) => c.length) ?? [];
@@ -35,11 +44,10 @@
         );
     }
 
-    let dismissSearchBar = false;
+    let dismissSearchBar: boolean = $state(false);
 
-    const dispatch = createEventDispatcher();
-
-    function submit() {
+    function doSubmit(event: Event) {
+        event.preventDefault();
         if (!phrase) return;
         // Dismiss the search bar by disabling it.
         // Then re-enable the search bar to allow the user to modify the query.
@@ -47,7 +55,7 @@
         setTimeout(() => {
             dismissSearchBar = false;
         }, 50);
-        dispatch('submit', { phrase, wholeWords, matchAccents });
+        submit({ phrase, wholeWords, matchAccents });
     }
 </script>
 
@@ -72,7 +80,7 @@
                 bind:value={phrase}
             />
             <button
-                on:click|preventDefault={submit}
+                onclick={doSubmit}
                 class="dy-btn mx-2 flex-none"
                 style={convertStyle($s['ui.search.button'])}
                 style:background-color="var(--SearchButtonColor)"
@@ -92,7 +100,7 @@
                         style={convertStyle($s['ui.search.buttons'])}
                         style:background-color="var(--TabBackgroundColor)"
                         style:color="var(--TextColor)"
-                        on:click={(e) => addSpecialCharacter(character, e)}
+                        onclick={(e) => addSpecialCharacter(character, e)}
                     >
                         {character}
                     </button>

--- a/src/routes/lexicon/search/+page.svelte
+++ b/src/routes/lexicon/search/+page.svelte
@@ -2,39 +2,35 @@
     import { goto } from '$app/navigation';
     import LexiconEntryView from '$lib/components/LexiconEntryView.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
-    import SearchForm from '$lib/components/SearchForm.svelte';
+    import SearchForm, { type SearchFormSubmitEvent } from '$lib/components/SearchForm.svelte';
     import WordNavigationStrip from '$lib/components/WordNavigationStrip.svelte';
     import config from '$lib/data/config';
-    import { themeColors } from '$lib/data/stores';
     import { vernacularLanguageStore, vernacularWordsStore } from '$lib/data/stores/lexicon';
     import { SearchIcon } from '$lib/icons';
     import { getRoute } from '$lib/navigate';
     import { searchDictionary } from '$lib/search-worker/dab-search-worker';
     import type { SearchOptions } from '$lib/search/domain/interfaces/data-interfaces';
 
-    export let data;
+    let { data } = $props();
 
-    let phrase: string = '';
-    let wholeWords: boolean = false;
-    let matchAccents: boolean = false;
-    let wordIds;
-    let searchWord;
-    let vernacularLanguage;
-    let selectedWord;
-    $: vernacularLanguage = $vernacularLanguageStore;
+    let phrase: string = $state('');
+    let wholeWords: boolean = $state(false);
+    let matchAccents: boolean = $state(false);
+    let wordIds: number[] | undefined = $state();
+    let searchWord: string | undefined = $state();
+    let selectedWord: any = $state();
+    const vernacularLanguage = $derived($vernacularLanguageStore);
+    const vernacularWordsList = $derived($vernacularWordsStore);
 
-    let vernacularWordsList;
-    $: vernacularWordsList = $vernacularWordsStore;
-
-    let scrollDiv;
+    let scrollDiv: HTMLDivElement | undefined = $state(undefined);
 
     // Handle form submission from SearchForm component
-    async function handleSearchSubmit(event) {
+    async function handleSearchSubmit(event: SearchFormSubmitEvent) {
         const {
             phrase: newPhrase,
             wholeWords: newWholeWords,
             matchAccents: newMatchAccents
-        } = event.detail;
+        } = event;
 
         let options: SearchOptions = {
             docSet: '',
@@ -83,7 +79,7 @@
                     <button
                         class="dy-btn dy-btn-ghost dy-btn-circle"
                         style="color: var(--ShareButtonTextColor);"
-                        on:click={() => {
+                        onclick={() => {
                             wordIds = null;
                             searchWord = '';
                             selectedWord = null;
@@ -115,12 +111,7 @@
         <div class="overflow-auto" bind:this={scrollDiv}>
             <div class="flex justify-center">
                 {#if !wordIds || wordIds.length == 0}
-                    <SearchForm
-                        bind:phrase
-                        bind:wholeWords
-                        bind:matchAccents
-                        on:submit={handleSearchSubmit}
-                    />
+                    <SearchForm {phrase} {wholeWords} {matchAccents} submit={handleSearchSubmit} />
                 {/if}
             </div>
 

--- a/src/routes/search/[collection]/+page.svelte
+++ b/src/routes/search/[collection]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
     import Navbar from '$lib/components/Navbar.svelte';
-    import SearchForm from '$lib/components/SearchForm.svelte';
+    import SearchForm, { type SearchFormSubmitEvent } from '$lib/components/SearchForm.svelte';
     import SearchResultList from '$lib/components/SearchResultList.svelte';
     import { t, themeColors } from '$lib/data/stores';
     import { getRoute } from '$lib/navigate';
@@ -11,7 +11,7 @@
         UserSearchOptions
     } from '$lib/search/domain/interfaces/presentation-interfaces';
     import { makeSearchSession } from '$lib/search/factories';
-    import { onMount, tick, type ComponentEvents } from 'svelte';
+    import { onMount, tick } from 'svelte';
 
     export let data;
 
@@ -49,15 +49,15 @@
 
     const session = makeSearchSession(presenter);
 
-    function handleSubmit(event: ComponentEvents<SearchForm>['submit']) {
+    function handleSubmit(event: SearchFormSubmitEvent) {
         goto(getRoute(`/search/${data.collection}?savedResults=true`));
         queryId++;
         const options = {
             collection: data.collection,
-            wholeWords: event.detail.wholeWords,
-            matchAccents: event.detail.matchAccents
+            wholeWords: event.wholeWords,
+            matchAccents: event.matchAccents
         };
-        session.submit(event.detail.phrase, options);
+        session.submit(event.phrase, options);
     }
 
     /**
@@ -119,7 +119,7 @@
 
     <div class="overflow-auto" bind:this={scrollDiv} on:scroll={onScroll}>
         <div class="flex justify-center">
-            <SearchForm on:submit={handleSubmit} bind:phrase bind:wholeWords bind:matchAccents />
+            <SearchForm submit={handleSubmit} {phrase} {wholeWords} {matchAccents} />
         </div>
 
         <div class="flex justify-center px-4">


### PR DESCRIPTION
* convert submit event dispatcher to event prop
* convert export let properties to props
* use state runes for reactive variables
* convert reactive statements to derived runes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the structure and typing of search form components and state management for a more consistent and explicit interface.
	- Updated event handling to use callback props instead of Svelte event dispatching.
	- Switched event handler syntax from Svelte directives to standard DOM attributes in relevant components.
- **Style**
	- Enhanced code clarity and maintainability through explicit typing and state initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->