### PR TITLE
Change Proskomma import from graphql to direct API

### DIFF
--- a/src/lib/sab-proskomma/index.ts
+++ b/src/lib/sab-proskomma/index.ts
@@ -101,4 +101,15 @@ export class SABProskomma extends Proskomma {
     loadSuccinctDocSet(succinctOb: any) {
         return super.loadSuccinctDocSet(succinctOb);
     }
+
+    importDoc(selectors: any, contentType: string, content: string, tags: string[]) {
+        return super.importDocument(
+            selectors,
+            contentType,
+            content,
+            this.customTags,
+            this.emptyBlocks,
+            tags
+        );
+    }
 }

--- a/src/lib/sab-proskomma/proskomma.d.ts
+++ b/src/lib/sab-proskomma/proskomma.d.ts
@@ -6,5 +6,14 @@ declare module 'proskomma-core' {
         loadSuccinctDocSet(succinctOb: any): any;
         docSets: [];
         serializeSuccinct(document: any): any;
+        importDocument(
+            selectors: any,
+            contentType: string,
+            contentString: string,
+            filterOptions?: any,
+            customTags?: any,
+            emptyBlocks?: any,
+            tags?: any
+        ): any;
     }
 }


### PR DESCRIPTION
When using graphql to import documents into Proskomma, the contents is surrounded by triple double quotes.  If content actually has triple double quotes, then it fails to import.

See Scriptoria project 3949 for an example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved document import functionality for scripture books, with enhanced error handling and logging.
- **Bug Fixes**
	- Error messages now provide clearer details when importing non-standard documents fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->