### PR TITLE
Fix TabsMenu

### DIFF
--- a/src/lib/components/TabsMenu.svelte
+++ b/src/lib/components/TabsMenu.svelte
@@ -59,17 +59,17 @@ A component to display tabbed menus.
             {/if}
         {/each}
     </div>
-    <div
-        style={convertStyle($s['ui.background'])}
-        class:p-2={!hasTabs}
-        style:overflow-y={scroll ? 'auto' : ''}
-        style:max-height={height}
-    >
-        {console.log('active', active)}
-        <svelte:component
-            this={options[active].component}
-            on:menuaction={handleMenuaction}
-            {...options[active].props}
-        />
-    </div>
 {/if}
+<div
+    style={convertStyle($s['ui.background'])}
+    class:p-2={!hasTabs}
+    style:overflow-y={scroll ? 'auto' : ''}
+    style:max-height={height}
+>
+    {console.log('active', active)}
+    <svelte:component
+        this={options[active].component}
+        on:menuaction={handleMenuaction}
+        {...options[active].props}
+    />
+</div>


### PR DESCRIPTION
* When implementing #817, I accidentally broke TabsMenu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured that the active tab content is always displayed, even if there is only one tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->