### PR TITLE
Fix saved search results

### DIFF
--- a/src/routes/search/[collection]/[[savedResults]]/+page.svelte
+++ b/src/routes/search/[collection]/[[savedResults]]/+page.svelte
@@ -50,7 +50,7 @@
     const session = makeSearchSession(presenter);
 
     function handleSubmit(event: SearchFormSubmitEvent) {
-        goto(getRoute(`/search/${data.collection}?savedResults=true`));
+        goto(getRoute(`/search/${data.collection}/saved`));
         queryId++;
         const options = {
             collection: data.collection,
@@ -81,7 +81,7 @@
     }
 
     async function init() {
-        const useSavedResults = new URLSearchParams(window.location.search).get('savedResults');
+        const useSavedResults = data.savedResults === 'saved';
         if (useSavedResults) {
             // Load saved results
             restoreResults = true;

--- a/src/routes/search/[collection]/[[savedResults]]/+page.ts
+++ b/src/routes/search/[collection]/[[savedResults]]/+page.ts
@@ -6,5 +6,5 @@ export async function load({ params }) {
 
     if (!collection) throw error(404);
 
-    return { collection: collection.id };
+    return { collection: collection.id, savedResults: params.savedResults };
 }


### PR DESCRIPTION
When we implemented hash-based routing in #766, this broke saved search results.  This feature depended on query string parameters which don't work at the end of the hash-based route. Change this feature to use optional slug parameter.