### PR TITLE
Updated PlanStopDialog to Svelte 5

### DIFF
--- a/src/lib/components/PlanStopDialog.svelte
+++ b/src/lib/components/PlanStopDialog.svelte
@@ -2,7 +2,7 @@
 @component
 Plan Stop Modal Dialog component.
 -->
-<svelte:options accessors={true} />
+<svelte:options />
 
 <script>
     import { goto } from '$app/navigation';
@@ -12,10 +12,10 @@ Plan Stop Modal Dialog component.
     import { getRoute } from '$lib/navigate';
     import Modal from './Modal.svelte';
 
-    export let planId = undefined;
+    let { planId = undefined, vertOffset = '1rem' } = $props();
 
     const modalId = 'planStopDialog';
-    let modal;
+    let modal = $state(undefined);
 
     export function showModal() {
         modal.showModal();
@@ -33,12 +33,12 @@ Plan Stop Modal Dialog component.
         });
     }
 
-    export let vertOffset = '1rem'; //Prop that will have the navbar's height (in rem) passed in
     //The positioningCSS positions the modal 1rem below the navbar and 1rem from the right edge of the screen (on mobile it will be centered)
-    $: positioningCSS =
+    const positioningCSS = $derived(
         'position:absolute; top:' +
-        (Number(vertOffset.replace('rem', '')) + 1) +
-        'rem; inset-inline-end:1rem;';
+            (Number(vertOffset.replace('rem', '')) + 1) +
+            'rem; inset-inline-end:1rem;'
+    );
 </script>
 
 <Modal bind:this={modal} id={modalId}>
@@ -59,7 +59,7 @@ Plan Stop Modal Dialog component.
                     <button class="dy-btn message-button" id="no">
                         {$t['Button_No']}
                     </button>
-                    <button class="dy-btn message-button" id="yes" on:click={() => handleYes()}>
+                    <button class="dy-btn message-button" id="yes" onclick={() => handleYes()}>
                         {$t['Button_Yes']}
                     </button>
                 </div>

--- a/src/lib/components/PlanStopDialog.svelte
+++ b/src/lib/components/PlanStopDialog.svelte
@@ -2,7 +2,6 @@
 @component
 Plan Stop Modal Dialog component.
 -->
-<svelte:options />
 
 <script>
     import { goto } from '$app/navigation';
@@ -13,6 +12,7 @@ Plan Stop Modal Dialog component.
     import Modal from './Modal.svelte';
 
     let { planId = undefined, vertOffset = '1rem' } = $props();
+    export { planId };
 
     const modalId = 'planStopDialog';
     let modal = $state(undefined);

--- a/src/lib/components/PlanStopDialog.svelte
+++ b/src/lib/components/PlanStopDialog.svelte
@@ -11,8 +11,7 @@ Plan Stop Modal Dialog component.
     import { getRoute } from '$lib/navigate';
     import Modal from './Modal.svelte';
 
-    let { planId = undefined, vertOffset = '1rem' } = $props();
-    export { planId };
+    let { planId = $bindable(undefined), vertOffset = '1rem' } = $props();
 
     const modalId = 'planStopDialog';
     let modal = $state(undefined);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -85,7 +85,7 @@
     let collectionSelector: CollectionSelector = $state();
     let fontSelector: FontSelector = $state();
     let noteDialog: NoteDialog = $state();
-    let planStopDialog: PlanStopDialog = $state();
+    let planStopDialog: PlanStopDialog;
     let planStopId: string;
     let audioPlaybackSpeed: AudioPlaybackSpeed = $state();
 </script>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -69,7 +69,7 @@
                         fontSelector.showModal();
                         break;
                     case MODAL_STOP_PLAN:
-                        planStopDialog.planId = data;
+                        planStopId = data;
                         planStopDialog.showModal();
                         break;
                     case MODAL_PLAYBACK_SPEED:
@@ -86,6 +86,7 @@
     let fontSelector: FontSelector = $state();
     let noteDialog: NoteDialog = $state();
     let planStopDialog: PlanStopDialog = $state();
+    let planStopId: string;
     let audioPlaybackSpeed: AudioPlaybackSpeed = $state();
 </script>
 
@@ -117,7 +118,11 @@
 
         <FontSelector bind:this={fontSelector} />
 
-        <PlanStopDialog bind:this={planStopDialog} vertOffset={NAVBAR_HEIGHT} />
+        <PlanStopDialog
+            bind:this={planStopDialog}
+            bind:planId={planStopId}
+            vertOffset={NAVBAR_HEIGHT}
+        />
 
         <AudioPlaybackSpeed bind:this={audioPlaybackSpeed} />
     </div>


### PR DESCRIPTION
Per #819

This PR updates PlanStopDialog.svelte to Svelte 5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved internal handling of dialog state and data binding for the plan stop dialog. No visible changes to appearance or functionality for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->