### PR TITLE
Factor out content() snippet in favor of children

### DIFF
--- a/src/lib/components/AudioPlaybackSpeed.svelte
+++ b/src/lib/components/AudioPlaybackSpeed.svelte
@@ -30,30 +30,28 @@
 </script>
 
 <Modal bind:this={modalThis} id={modalId}>
-    {#snippet content()}
-        <div style="color: {$monoIconColor}">
-            <h1>
-                <b>{$t['Settings_Audio_Speed']}</b>
-            </h1>
-            <div class="speed-controls">
-                {#each speeds as speed}
-                    <label>
-                        <input
-                            type="radio"
-                            name="speed"
-                            value={speed.value}
-                            on:click={setPlaySpeed}
-                            checked={$userSettings['audio-speed'] === speed.value}
-                        />
-                        {speed.label}
-                    </label>
-                {/each}
-                <div class="dy-modal-action close-btn">
-                    <button class="dy-btn dy-btn-ghost">{$t['Button_Close']}</button>
-                </div>
+    <div style="color: {$monoIconColor}">
+        <h1>
+            <b>{$t['Settings_Audio_Speed']}</b>
+        </h1>
+        <div class="speed-controls">
+            {#each speeds as { value, label }}
+                <label>
+                    <input
+                        type="radio"
+                        name="speed"
+                        {value}
+                        on:click={setPlaySpeed}
+                        checked={$userSettings['audio-speed'] === value}
+                    />
+                    {label}
+                </label>
+            {/each}
+            <div class="dy-modal-action close-btn">
+                <button class="dy-btn dy-btn-ghost">{$t['Button_Close']}</button>
             </div>
         </div>
-    {/snippet}
+    </div>
 </Modal>
 
 <style>

--- a/src/lib/components/CollectionSelector.svelte
+++ b/src/lib/components/CollectionSelector.svelte
@@ -66,45 +66,43 @@ Book Collection Selector component.
 </script>
 
 <Modal bind:this={modal} id={modalId}>
-    {#snippet content()}
-        <TabsMenu
-            bind:this={tabMenu}
-            bind:active={tabMenuActive}
-            options={{
-                [LAYOUT_SINGLE]: {
-                    tab: { component: SinglePaneIcon },
-                    component: LayoutOptions,
-                    props: { layoutOption: LAYOUT_SINGLE },
-                    visible: showSinglePane
-                },
-                [LAYOUT_TWO]: {
-                    tab: { component: SideBySideIcon },
-                    component: LayoutOptions,
-                    props: { layoutOption: LAYOUT_TWO },
-                    visible: showSideBySide
-                },
-                [LAYOUT_VERSE_BY_VERSE]: {
-                    tab: { component: VerseByVerseIcon },
-                    component: LayoutOptions,
-                    props: { layoutOption: LAYOUT_VERSE_BY_VERSE },
-                    visible: showVerseByVerse
-                }
-            }}
-            scroll={true}
-        />
-        <div class="flex w-full justify-between dy-modal-action">
-            <!-- svelte-ignore a11y_click_events_have_key_events -->
-            <button
-                style={convertStyle($s['ui.dialog.button'])}
-                class="dy-btn dy-btn-sm dy-btn-ghost no-animation"
-                onclick={() => handleCancel()}>{$t['Button_Cancel']}</button
-            >
-            <!-- svelte-ignore a11y_click_events_have_key_events -->
-            <button
-                style={convertStyle($s['ui.dialog.button'])}
-                class="dy-btn dy-btn-sm dy-btn-ghost no-animation"
-                onclick={() => handleOk()}>{$t['Button_OK']}</button
-            >
-        </div>
-    {/snippet}
+    <TabsMenu
+        bind:this={tabMenu}
+        bind:active={tabMenuActive}
+        options={{
+            [LAYOUT_SINGLE]: {
+                tab: { component: SinglePaneIcon },
+                component: LayoutOptions,
+                props: { layoutOption: LAYOUT_SINGLE },
+                visible: showSinglePane
+            },
+            [LAYOUT_TWO]: {
+                tab: { component: SideBySideIcon },
+                component: LayoutOptions,
+                props: { layoutOption: LAYOUT_TWO },
+                visible: showSideBySide
+            },
+            [LAYOUT_VERSE_BY_VERSE]: {
+                tab: { component: VerseByVerseIcon },
+                component: LayoutOptions,
+                props: { layoutOption: LAYOUT_VERSE_BY_VERSE },
+                visible: showVerseByVerse
+            }
+        }}
+        scroll={true}
+    />
+    <div class="flex w-full justify-between dy-modal-action">
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <button
+            style={convertStyle($s['ui.dialog.button'])}
+            class="dy-btn dy-btn-sm dy-btn-ghost no-animation"
+            onclick={() => handleCancel()}>{$t['Button_Cancel']}</button
+        >
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <button
+            style={convertStyle($s['ui.dialog.button'])}
+            class="dy-btn dy-btn-sm dy-btn-ghost no-animation"
+            onclick={() => handleOk()}>{$t['Button_OK']}</button
+        >
+    </div>
 </Modal>

--- a/src/lib/components/FontSelector.svelte
+++ b/src/lib/components/FontSelector.svelte
@@ -25,20 +25,18 @@ Font Selector component.
 </script>
 
 <Modal bind:this={modal} id={modalId}>
-    {#snippet content()}
-        <FontList bind:this={fontList} selectedFont={$currentFont} />
-        <div class="flex w-full justify-between dy-modal-action">
-            <!-- svelte-ignore a11y-click-events-have-key-events -->
-            <button
-                style={convertStyle($s['ui.dialog.button'])}
-                class="dy-btn dy-btn-sm dy-btn-ghost no-animation">{$t['Button_Cancel']}</button
-            >
-            <!-- svelte-ignore a11y-click-events-have-key-events -->
-            <button
-                style={convertStyle($s['ui.dialog.button'])}
-                class="dy-btn dy-btn-sm dy-btn-ghost no-animation"
-                on:click={() => handleOk()}>{$t['Button_OK']}</button
-            >
-        </div>
-    {/snippet}
+    <FontList bind:this={fontList} selectedFont={$currentFont} />
+    <div class="flex w-full justify-between dy-modal-action">
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <button
+            style={convertStyle($s['ui.dialog.button'])}
+            class="dy-btn dy-btn-sm dy-btn-ghost no-animation">{$t['Button_Cancel']}</button
+        >
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <button
+            style={convertStyle($s['ui.dialog.button'])}
+            class="dy-btn dy-btn-sm dy-btn-ghost no-animation"
+            on:click={() => handleOk()}>{$t['Button_OK']}</button
+        >
+    </div>
 </Modal>

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -11,7 +11,7 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
 <script>
     import { convertStyle, direction, s } from '$lib/data/stores';
 
-    let { id, addCSS = '', content, onclose = null } = $props();
+    let { id, children, addCSS = '', onclose = null } = $props();
 
     let dialog;
 
@@ -36,7 +36,7 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
         style={convertStyle($s['ui.dialog']) + addCSS}
         class="dy-modal-box overflow-y-visible relative"
     >
-        {@render content?.()}
+        {@render children?.()}
         <!--This is the snippet for the popup's actual contents-->
     </form>
     <form method="dialog" class="dy-modal-backdrop">

--- a/src/lib/components/NoteDialog.svelte
+++ b/src/lib/components/NoteDialog.svelte
@@ -54,45 +54,43 @@
 </script>
 
 <Modal bind:this={modal} {id} onclose={reset}>
-    {#snippet content()}
-        <div class="flex flex-col justify-evenly">
-            <div class="w-full flex justify-between">
-                <div class="w-full pb-3" style:font-weight={editing ? 'normal' : 'bold'}>
-                    {heading}
-                </div>
-                {#if !editing}
-                    <button
-                        on:click={() => {
-                            editing = true;
-                        }}
-                    >
-                        <EditIcon />
-                    </button>
-                {/if}
+    <div class="flex flex-col justify-evenly">
+        <div class="w-full flex justify-between">
+            <div class="w-full pb-3" style:font-weight={editing ? 'normal' : 'bold'}>
+                {heading}
             </div>
-            <div style:word-wrap="break-word">
-                {#if editing}
-                    <textarea bind:value={text} class="dy-textarea w-full"></textarea>
-                {:else if text !== undefined}
-                    {#each text.split(/\r?\n/) as line}
-                        {#if line}
-                            <p style:font-family={$currentFont} style:font-size="{$bodyFontSize}px">
-                                {line}
-                            </p>
-                        {:else}
-                            <br />
-                        {/if}
-                    {/each}
-                {/if}
-            </div>
-            {#if editing}
-                <div class="w-full flex mt-4 justify-between">
-                    <button class="dy-btn dy-btn-sm dy-btn-ghost">{$t['Button_Cancel']}</button>
-                    <button on:click={modifyNote} class="dy-btn dy-btn-sm dy-btn-ghost"
-                        >{$t['Button_OK']}</button
-                    >
-                </div>
+            {#if !editing}
+                <button
+                    onclick={() => {
+                        editing = true;
+                    }}
+                >
+                    <EditIcon />
+                </button>
             {/if}
         </div>
-    {/snippet}
+        <div style:word-wrap="break-word">
+            {#if editing}
+                <textarea bind:value={text} class="dy-textarea w-full"></textarea>
+            {:else if text !== undefined}
+                {#each text.split(/\r?\n/) as line}
+                    {#if line}
+                        <p style:font-family={$currentFont} style:font-size="{$bodyFontSize}px">
+                            {line}
+                        </p>
+                    {:else}
+                        <br />
+                    {/if}
+                {/each}
+            {/if}
+        </div>
+        {#if editing}
+            <div class="w-full flex mt-4 justify-between">
+                <button class="dy-btn dy-btn-sm dy-btn-ghost">{$t['Button_Cancel']}</button>
+                <button onclick={modifyNote} class="dy-btn dy-btn-sm dy-btn-ghost"
+                    >{$t['Button_OK']}</button
+                >
+            </div>
+        {/if}
+    </div>
 </Modal>

--- a/src/lib/components/PlanStopDialog.svelte
+++ b/src/lib/components/PlanStopDialog.svelte
@@ -41,28 +41,26 @@ Plan Stop Modal Dialog component.
 </script>
 
 <Modal bind:this={modal} id={modalId}>
-    {#snippet content()}
-        <div id="container" class="message">
-            <div class="message-body" id="message-body">
-                <div class="message-header"></div>
-                <div class="message-title">
-                    {$t['Plans_Stop_Plan_Confirm_Title']}
-                </div>
-                <div class="message-text">
-                    {$t['Plans_Stop_Plan_Confirm_Message']}
-                </div>
+    <div id="container" class="message">
+        <div class="message-body" id="message-body">
+            <div class="message-header"></div>
+            <div class="message-title">
+                {$t['Plans_Stop_Plan_Confirm_Title']}
             </div>
-
-            <div class="flex w-full justify-between dy-modal-action">
-                <div class="message-buttons">
-                    <button class="dy-btn message-button" id="no">
-                        {$t['Button_No']}
-                    </button>
-                    <button class="dy-btn message-button" id="yes" onclick={() => handleYes()}>
-                        {$t['Button_Yes']}
-                    </button>
-                </div>
+            <div class="message-text">
+                {$t['Plans_Stop_Plan_Confirm_Message']}
             </div>
         </div>
-    {/snippet}
+
+        <div class="flex w-full justify-between dy-modal-action">
+            <div class="message-buttons">
+                <button class="dy-btn message-button" id="no">
+                    {$t['Button_No']}
+                </button>
+                <button class="dy-btn message-button" id="yes" onclick={() => handleYes()}>
+                    {$t['Button_Yes']}
+                </button>
+            </div>
+        </div>
+    </div>
 </Modal>

--- a/src/lib/components/TextAppearanceSelector.svelte
+++ b/src/lib/components/TextAppearanceSelector.svelte
@@ -106,98 +106,96 @@ The navbar component. We have sliders that update reactively to both font size a
 {#if showTextAppearence}
     <!-- svelte-ignore a11y_consider_explicit_label -->
     <Modal bind:this={modalThis} id={modalId} addCSS={positioningCSS}>
-        {#snippet content()}
-            <div class="grid gap-4">
-                <!-- Sliders for when text appearence text size is implemented place holder no functionality-->
-                {#if showFontSize}
-                    <div class="grid gap-4 items-center range-row m-2">
-                        <TextAppearanceIcon color={$monoIconColor} />
-                        {#if contentsMode}
-                            <Slider
-                                bind:value={$contentsFontSize}
-                                {barColor}
-                                {progressColor}
-                                min={config.mainFeatures['text-size-min']}
-                                max={config.mainFeatures['text-size-max']}
-                            />
-                        {:else}
-                            <Slider
-                                bind:value={$bodyFontSize}
-                                {barColor}
-                                {progressColor}
-                                min={config.mainFeatures['text-size-min']}
-                                max={config.mainFeatures['text-size-max']}
-                            />
-                        {/if}
-                        <div class="text-md text-{$monoIconColor} place-self-end">
-                            {contentsMode ? $contentsFontSize : $bodyFontSize}
-                        </div>
-                    </div>
-                {/if}
-                {#if showLineHeight}
-                    <div class="grid gap-4 items-center range-row m-2">
-                        <ImageIcon.FormatLineSpacing color={$monoIconColor} />
+        <div class="grid gap-4">
+            <!-- Sliders for when text appearence text size is implemented place holder no functionality-->
+            {#if showFontSize}
+                <div class="grid gap-4 items-center range-row m-2">
+                    <TextAppearanceIcon color={$monoIconColor} />
+                    {#if contentsMode}
                         <Slider
-                            bind:value={$bodyLineHeight}
+                            bind:value={$contentsFontSize}
                             {barColor}
                             {progressColor}
-                            min="100"
-                            max="250"
+                            min={config.mainFeatures['text-size-min']}
+                            max={config.mainFeatures['text-size-max']}
                         />
-                        <div class="text-md text-{$monoIconColor} place-self-end">
-                            {formatLineHeight($bodyLineHeight)}
-                        </div>
+                    {:else}
+                        <Slider
+                            bind:value={$bodyFontSize}
+                            {barColor}
+                            {progressColor}
+                            min={config.mainFeatures['text-size-min']}
+                            max={config.mainFeatures['text-size-max']}
+                        />
+                    {/if}
+                    <div class="text-md text-{$monoIconColor} place-self-end">
+                        {contentsMode ? $contentsFontSize : $bodyFontSize}
                     </div>
-                {/if}
-                {#if showFonts}
-                    <div class="grid gap-4 items-center range-row m-2">
-                        <ImageIcon.FontChoice color={$monoIconColor} />
-                        <button
-                            class="dy-btn-sm col-span-2 rounded"
-                            style:border="1px dotted"
-                            style:font-family={$currentFont}
-                            style:font-size="large"
-                            style:color={$monoIconColor}
-                            on:click={() => modal.open(MODAL_FONT)}
-                            >{config.fonts.find((x) => x.family === $currentFont).name}</button
-                        >
+                </div>
+            {/if}
+            {#if showLineHeight}
+                <div class="grid gap-4 items-center range-row m-2">
+                    <ImageIcon.FormatLineSpacing color={$monoIconColor} />
+                    <Slider
+                        bind:value={$bodyLineHeight}
+                        {barColor}
+                        {progressColor}
+                        min="100"
+                        max="250"
+                    />
+                    <div class="text-md text-{$monoIconColor} place-self-end">
+                        {formatLineHeight($bodyLineHeight)}
                     </div>
-                {/if}
-                <!-- Theme Selction buttons-->
-                {#if showThemes}
-                    <div
-                        class="grid gap-2 m-2"
-                        class:grid-cols-2={themes.length === 2}
-                        class:grid-cols-3={themes.length === 3}
+                </div>
+            {/if}
+            {#if showFonts}
+                <div class="grid gap-4 items-center range-row m-2">
+                    <ImageIcon.FontChoice color={$monoIconColor} />
+                    <button
+                        class="dy-btn-sm col-span-2 rounded"
+                        style:border="1px dotted"
+                        style:font-family={$currentFont}
+                        style:font-size="large"
+                        style:color={$monoIconColor}
+                        on:click={() => modal.open(MODAL_FONT)}
+                        >{config.fonts.find((x) => x.family === $currentFont).name}</button
                     >
-                        {#if themes.includes('Normal')}
-                            <button
-                                class="dy-btn-sm"
-                                style:background-color={buttonBackground('Normal')}
-                                style:border={buttonBorder('Normal', $theme)}
-                                on:click={() => ($theme = 'Normal')}
-                            ></button>
-                        {/if}
-                        {#if themes.includes('Sepia')}
-                            <button
-                                class="dy-btn-sm"
-                                style:background-color={buttonBackground('Sepia')}
-                                style:border={buttonBorder('Sepia', $theme)}
-                                on:click={() => ($theme = 'Sepia')}
-                            ></button>
-                        {/if}
-                        {#if themes.includes('Dark')}
-                            <button
-                                class="dy-btn-sm"
-                                style:background-color={buttonBackground('Dark')}
-                                style:border={buttonBorder('Dark', $theme)}
-                                on:click={() => ($theme = 'Dark')}
-                            ></button>
-                        {/if}
-                    </div>
-                {/if}
-            </div>
-        {/snippet}
+                </div>
+            {/if}
+            <!-- Theme Selction buttons-->
+            {#if showThemes}
+                <div
+                    class="grid gap-2 m-2"
+                    class:grid-cols-2={themes.length === 2}
+                    class:grid-cols-3={themes.length === 3}
+                >
+                    {#if themes.includes('Normal')}
+                        <button
+                            class="dy-btn-sm"
+                            style:background-color={buttonBackground('Normal')}
+                            style:border={buttonBorder('Normal', $theme)}
+                            on:click={() => ($theme = 'Normal')}
+                        ></button>
+                    {/if}
+                    {#if themes.includes('Sepia')}
+                        <button
+                            class="dy-btn-sm"
+                            style:background-color={buttonBackground('Sepia')}
+                            style:border={buttonBorder('Sepia', $theme)}
+                            on:click={() => ($theme = 'Sepia')}
+                        ></button>
+                    {/if}
+                    {#if themes.includes('Dark')}
+                        <button
+                            class="dy-btn-sm"
+                            style:background-color={buttonBackground('Dark')}
+                            style:border={buttonBorder('Dark', $theme)}
+                            on:click={() => ($theme = 'Dark')}
+                        ></button>
+                    {/if}
+                </div>
+            {/if}
+        </div>
     </Modal>
 {/if}
 


### PR DESCRIPTION
This commit changes Modal to use the default children snippet, which makes creating Modal elements cleaner and more intuitive.

Previously content had to be declared inside the content() snippet, which is a needless level of encapsulation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified modal content structure across multiple dialogs by removing unnecessary snippet wrappers.
  - Streamlined property handling and iteration in several selectors for improved template clarity.
  - Unified slider configuration in text appearance settings for consistent font size adjustment.
  - Updated event handler syntax and prop structure in the note dialog for improved maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->