### PR TITLE
Removed loading animation after page loads

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,17 +1,19 @@
 <!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8" />
-        <link rel="icon" href="%sveltekit.assets%/icons/favicon.png" />
-        <link rel="apple-touch-icon" href="%sveltekit.assets%/icons/apple-touch-icon.png" />
-        <link rel="manifest" href="%sveltekit.assets%/manifest.json" />
-        <link rel="stylesheet" type="text/css" href="%sveltekit.assets%/spinner.css" />
-        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-        %sveltekit.head%
-    </head>
 
-    <body>
-        <span class="spin" />
-        <div>%sveltekit.body%</div>
-    </body>
+<head>
+    <meta charset="utf-8" />
+    <link rel="icon" href="%sveltekit.assets%/icons/favicon.png" />
+    <link rel="apple-touch-icon" href="%sveltekit.assets%/icons/apple-touch-icon.png" />
+    <link rel="manifest" href="%sveltekit.assets%/manifest.json" />
+    <link rel="stylesheet" type="text/css" href="%sveltekit.assets%/spinner.css" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+    %sveltekit.head%
+</head>
+
+<body>
+    <span class="spin" id="loading-bar"></span>
+    <div>%sveltekit.body%</div>
+</body>
+
 </html>

--- a/src/app.html
+++ b/src/app.html
@@ -11,7 +11,7 @@
     </head>
 
     <body>
-        <span class="spin" id="loading-bar"></span>
+        <span class="spin" id="loading-spinner"></span>
         <div>%sveltekit.body%</div>
     </body>
 </html>

--- a/src/app.html
+++ b/src/app.html
@@ -1,19 +1,17 @@
 <!doctype html>
 <html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <link rel="icon" href="%sveltekit.assets%/icons/favicon.png" />
+        <link rel="apple-touch-icon" href="%sveltekit.assets%/icons/apple-touch-icon.png" />
+        <link rel="manifest" href="%sveltekit.assets%/manifest.json" />
+        <link rel="stylesheet" type="text/css" href="%sveltekit.assets%/spinner.css" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+        %sveltekit.head%
+    </head>
 
-<head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%sveltekit.assets%/icons/favicon.png" />
-    <link rel="apple-touch-icon" href="%sveltekit.assets%/icons/apple-touch-icon.png" />
-    <link rel="manifest" href="%sveltekit.assets%/manifest.json" />
-    <link rel="stylesheet" type="text/css" href="%sveltekit.assets%/spinner.css" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
-    %sveltekit.head%
-</head>
-
-<body>
-    <span class="spin" id="loading-bar"></span>
-    <div>%sveltekit.body%</div>
-</body>
-
+    <body>
+        <span class="spin" id="loading-bar"></span>
+        <div>%sveltekit.body%</div>
+    </body>
 </html>

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -2440,7 +2440,7 @@ LOGGING:
         performance.measure('cl-render-duration', 'cl-render-start', 'cl-render-end');
         loading = false;
         let loadingBarNode = document.getElementById('loading-bar');
-        loadingBarNode.remove();
+        loadingBarNode?.remove();
         if (scriptureLogs?.root) {
             console.log('DONE %o', bookRoot);
         }

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -2439,6 +2439,8 @@ LOGGING:
         performance.mark('cl-render-end');
         performance.measure('cl-render-duration', 'cl-render-start', 'cl-render-end');
         loading = false;
+        let loadingBarNode = document.getElementById('loading-bar');
+        loadingBarNode.remove();
         if (scriptureLogs?.root) {
             console.log('DONE %o', bookRoot);
         }

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -2439,8 +2439,6 @@ LOGGING:
         performance.mark('cl-render-end');
         performance.measure('cl-render-duration', 'cl-render-start', 'cl-render-end');
         loading = false;
-        let loadingBarNode = document.getElementById('loading-bar');
-        loadingBarNode?.remove();
         if (scriptureLogs?.root) {
             console.log('DONE %o', bookRoot);
         }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -26,6 +26,7 @@
     import '$lib/app.css';
     import AudioPlaybackSpeed from '$lib/components/AudioPlaybackSpeed.svelte';
     import PlanStopDialog from '$lib/components/PlanStopDialog.svelte';
+    import { onMount } from 'svelte';
     import { fromStore } from 'svelte/store';
 
     let { children } = $props();
@@ -80,6 +81,16 @@
             modal.clear();
         }
     }
+
+    onMount(() => {
+        const spinner = document.getElementById('loading-spinner');
+        if (spinner) {
+            spinner.classList.add('fade-out');
+            setTimeout(() => {
+                spinner.remove();
+            }, 500);
+        }
+    });
 
     let textAppearanceSelector: TextAppearanceSelector = $state();
     let collectionSelector: CollectionSelector = $state();


### PR DESCRIPTION
Per #492

This PR causes the loading animation in app.html to be removed when the page finishes loading.
I did this by giving it an id and then using document.getElementById in ScriptureViewSofria and then just using .remove() to remove the element completely. I'm not sure if this is a bad practice. If it is, please tell me so I can find another way to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a fade-out animation to the loading spinner, which now disappears smoothly after the page loads.

- **Style**
  - Updated the loading spinner to support targeted animations and removal using a unique identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->