### PR TITLE
Implementing BookTabs

### DIFF
--- a/config/index.d.ts
+++ b/config/index.d.ts
@@ -18,6 +18,34 @@ export type StyleConfig = {
     verseNumbers: string;
 };
 
+export type BookTabConfig = {
+    //Other properties that it might need:
+    //Possibly format
+    //Possibly quizFeatures, but I doubt it
+    type: string;
+    file: string;
+    features: any;
+    chapters?: number;
+    chaptersN?: string;
+    style?: StyleConfig;
+    styles?: {
+        name: string;
+        category?: string;
+        properties: {
+            [key: string]: string;
+        };
+    }[];
+    fonts?: string[];
+    audio: BookCollectionAudioConfig[];
+    footer?: HTML;
+};
+
+export type BookTabsConfig = {
+    mainType: string;
+    tabs: BookTabConfig[];
+
+};
+
 export type BookConfig = {
     id: string;
     type?: string;
@@ -47,6 +75,7 @@ export type BookConfig = {
             [key: string]: string;
         };
     }[];
+    bookTabs?: BookTabsConfig;
 };
 
 export type BookCollectionConfig = {

--- a/config/index.d.ts
+++ b/config/index.d.ts
@@ -43,7 +43,6 @@ export type BookTabConfig = {
 export type BookTabsConfig = {
     mainType: string;
     tabs: BookTabConfig[];
-
 };
 
 export type BookConfig = {

--- a/config/index.d.ts
+++ b/config/index.d.ts
@@ -19,9 +19,6 @@ export type StyleConfig = {
 };
 
 export type BookTabConfig = {
-    //Other properties that it might need:
-    //Possibly format
-    //Possibly quizFeatures, but I doubt it
     type: string;
     file: string;
     features: any;

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -4,8 +4,8 @@ import type {
     AppConfig,
     BookCollectionAudioConfig,
     BookCollectionConfig,
-    BookTabsConfig,
     BookTabConfig,
+    BookTabsConfig,
     DictionaryConfig,
     DictionaryWritingSystemConfig,
     ScriptureConfig,
@@ -578,8 +578,8 @@ export function parseBookCollections(document: Document, verbose: number) {
             const fontChoiceTag = book.querySelector('font-choice');
             const fonts = fontChoiceTag
                 ? Array.from(fontChoiceTag.getElementsByTagName('font-choice-family'))
-                    .filter((x) => fontFamilies.includes(x.innerHTML))
-                    .map((x) => x.innerHTML)
+                      .filter((x) => fontFamilies.includes(x.innerHTML))
+                      .map((x) => x.innerHTML)
                 : [];
             const bkAdditionalNames = book.querySelector('additional-names');
             const additionalNames = bkAdditionalNames
@@ -613,13 +613,16 @@ export function parseBookCollections(document: Document, verbose: number) {
                     tabs: []
                 };
                 for (const bookTab of bookTabsTag.getElementsByTagName('book-tab')) {
-                    const tabFeaturesTag = bookTab.querySelector('features[type=book]')
+                    const tabFeaturesTag = bookTab
+                        .querySelector('features[type=book]')
                         ?.getElementsByTagName('e');
                     const tabFeatures: any = {};
                     if (tabFeaturesTag) {
                         for (const tabFeature of tabFeaturesTag) {
                             tabFeatures[tabFeature.attributes.getNamedItem('name')!.value] =
-                                parseConfigValue(tabFeature.attributes.getNamedItem('value')!.value);
+                                parseConfigValue(
+                                    tabFeature.attributes.getNamedItem('value')!.value
+                                );
                         }
                     }
                     let tabChapters;
@@ -642,8 +645,8 @@ export function parseBookCollections(document: Document, verbose: number) {
                     const fontChoiceTag = bookTab.querySelector('font-choice');
                     const fonts = fontChoiceTag
                         ? Array.from(fontChoiceTag.getElementsByTagName('font-choice-family'))
-                            .filter((x) => fontFamilies.includes(x.innerHTML))
-                            .map((x) => x.innerHTML)
+                              .filter((x) => fontFamilies.includes(x.innerHTML))
+                              .map((x) => x.innerHTML)
                         : [];
 
                     const audio: BookCollectionAudioConfig[] = [];
@@ -671,7 +674,7 @@ export function parseBookCollections(document: Document, verbose: number) {
 
                     bookTabs.tabs.push({
                         type: bookTab.attributes.getNamedItem('type')!.value,
-                        file: bookTab.getElementsByTagName('f')[0]?.innerHTML,//If format ends up needing to be part of BookTabs, this will need to change a little bit (See below in books.push).
+                        file: bookTab.getElementsByTagName('f')[0]?.innerHTML, //If format ends up needing to be part of BookTabs, this will need to change a little bit (See below in books.push).
                         features: tabFeatures,
                         chapters: tabChapters,
                         chaptersN: tabChaptersN,
@@ -683,7 +686,6 @@ export function parseBookCollections(document: Document, verbose: number) {
                     });
                 }
             }
-
 
             books.push({
                 portions: book.getElementsByTagName('portions')[0]?.attributes.getNamedItem('value')
@@ -722,8 +724,8 @@ export function parseBookCollections(document: Document, verbose: number) {
         if (verbose >= 3) console.log(`.... fontChoice: `, JSON.stringify(fontChoiceTag));
         const fonts = fontChoiceTag
             ? Array.from(fontChoiceTag.getElementsByTagName('font-choice-family'))
-                .filter((x) => fontFamilies.includes(x.innerHTML))
-                .map((x) => x.innerHTML)
+                  .filter((x) => fontFamilies.includes(x.innerHTML))
+                  .map((x) => x.innerHTML)
             : [];
 
         const writingSystem = tag.getElementsByTagName('writing-system')[0];
@@ -1085,10 +1087,10 @@ export function parseVideos(document: Document, verbose: number) {
             const placementTag = tag.getElementsByTagName('placement')[0];
             const placement = placementTag
                 ? {
-                    pos: placementTag.attributes.getNamedItem('pos')!.value,
-                    ref: placementTag.attributes.getNamedItem('ref')!.value.split('|')[1],
-                    collection: placementTag.attributes.getNamedItem('ref')!.value.split('|')[0]
-                }
+                      pos: placementTag.attributes.getNamedItem('pos')!.value,
+                      ref: placementTag.attributes.getNamedItem('ref')!.value.split('|')[1],
+                      collection: placementTag.attributes.getNamedItem('ref')!.value.split('|')[0]
+                  }
                 : undefined;
 
             const width = tag.getAttribute('width') ? parseInt(tag.getAttribute('width')!) : 0;
@@ -1141,11 +1143,11 @@ export function parseIllustrations(document: Document, verbose: number) {
                     const placementTag = image.getElementsByTagName('placement')[0];
                     const placement = placementTag
                         ? {
-                            pos: placementTag.getAttribute('pos')! || '',
-                            ref: placementTag.getAttribute('ref')?.split('|')[1] || '',
-                            caption: placementTag.getAttribute('caption') || '',
-                            collection: placementTag.getAttribute('ref')?.split('|')[0] || ''
-                        }
+                              pos: placementTag.getAttribute('pos')! || '',
+                              ref: placementTag.getAttribute('ref')?.split('|')[1] || '',
+                              caption: placementTag.getAttribute('caption') || '',
+                              collection: placementTag.getAttribute('ref')?.split('|')[0] || ''
+                          }
                         : undefined;
 
                     illustrations.push({ filename, width, height, placement });
@@ -1182,8 +1184,8 @@ export function parseLayouts(document: Document, bookCollections: any, verbose: 
             const layoutCollections =
                 layoutCollectionElements.length > 0
                     ? Array.from(layoutCollectionElements).map((element) => {
-                        return element.attributes.getNamedItem('id')!.value;
-                    })
+                          return element.attributes.getNamedItem('id')!.value;
+                      })
                     : [bookCollections[0].id];
 
             layouts.push({

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -632,7 +632,7 @@ export function parseBookCollections(document: Document, verbose: number) {
                     }
 
                     let tabChaptersN;
-                    const tabCnTag = book.getElementsByTagName('cn')[0];
+                    const tabCnTag = bookTab.getElementsByTagName('cn')[0];
                     if (tabCnTag) {
                         tabChaptersN = tabCnTag.attributes.getNamedItem('value')!.value;
                     }

--- a/convert/tests/sab/convertConfigSAB.test.ts
+++ b/convert/tests/sab/convertConfigSAB.test.ts
@@ -132,25 +132,29 @@ if (programType === 'DAB') {
                     for (const bookTab in bkk.bookTabs.tabs) {
                         const bt = bkk.bookTabs.tabs[bookTab];
                         expect(bt.type).not.toSatisfy((r) => r === '' || r === undefined);
-                        expect(bt.file).not.toSatisfy(
-                            (r) => r === '' || r === undefined
-                        );
+                        expect(bt.file).not.toSatisfy((r) => r === '' || r === undefined);
                         for (const audio in bt.audio) {
-                            expect(bt.audio[audio].num).not.toSatisfy((r) => r === '' || r === undefined);
+                            expect(bt.audio[audio].num).not.toSatisfy(
+                                (r) => r === '' || r === undefined
+                            );
                             expect(bt.audio[audio].filename).not.toSatisfy(
                                 (r) => r === '' || r === undefined
                             );
-                            expect(bt.audio[audio].len).not.toSatisfy((r) => r === '' || r === undefined);
-                            expect(bt.audio[audio].size).not.toSatisfy((r) => r === '' || r === undefined);
-                            expect(bt.audio[audio].src).not.toSatisfy((r) => r === '' || r === undefined);
+                            expect(bt.audio[audio].len).not.toSatisfy(
+                                (r) => r === '' || r === undefined
+                            );
+                            expect(bt.audio[audio].size).not.toSatisfy(
+                                (r) => r === '' || r === undefined
+                            );
+                            expect(bt.audio[audio].src).not.toSatisfy(
+                                (r) => r === '' || r === undefined
+                            );
                             expect(bt.audio[audio].timingFile).not.toSatisfy(
                                 (r) => r === '' || r === undefined
                             );
                         }
-
                     }
                 }
-
             }
 
             expect(Object.keys(bc.style)).toHaveLength(6);

--- a/convert/tests/sab/convertConfigSAB.test.ts
+++ b/convert/tests/sab/convertConfigSAB.test.ts
@@ -126,6 +126,31 @@ if (programType === 'DAB') {
                         (r) => r === '' || r === undefined
                     );
                 }
+                if (bkk.bookTabs) {
+                    expect(bkk.bookTabs.mainType).not.toSatisfy((r) => r === '' || r === undefined);
+                    expect(bkk.bookTabs.tabs).not.toHaveLength(0);
+                    for (const bookTab in bkk.bookTabs.tabs) {
+                        const bt = bkk.bookTabs.tabs[bookTab];
+                        expect(bt.type).not.toSatisfy((r) => r === '' || r === undefined);
+                        expect(bt.file).not.toSatisfy(
+                            (r) => r === '' || r === undefined
+                        );
+                        for (const audio in bt.audio) {
+                            expect(bt.audio[audio].num).not.toSatisfy((r) => r === '' || r === undefined);
+                            expect(bt.audio[audio].filename).not.toSatisfy(
+                                (r) => r === '' || r === undefined
+                            );
+                            expect(bt.audio[audio].len).not.toSatisfy((r) => r === '' || r === undefined);
+                            expect(bt.audio[audio].size).not.toSatisfy((r) => r === '' || r === undefined);
+                            expect(bt.audio[audio].src).not.toSatisfy((r) => r === '' || r === undefined);
+                            expect(bt.audio[audio].timingFile).not.toSatisfy(
+                                (r) => r === '' || r === undefined
+                            );
+                        }
+
+                    }
+                }
+
             }
 
             expect(Object.keys(bc.style)).toHaveLength(6);


### PR DESCRIPTION
Per #852 

This PR updates convertConfig to parse the data relevant to book tabs so that the data will be available in src/lib/data/config.js
It also updates convertConfigSAB.test.ts to add tests related to parsing the book tab data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for books with tabbed configurations, allowing each book to include multiple tabs with distinct features, styles, fonts, audio, and footers.

* **Tests**
  * Enhanced tests to validate the new tabbed book configurations, ensuring all tab and audio properties are present and correctly structured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->