### PR TITLE
Fixed bug with verse selection

### DIFF
--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -237,9 +237,8 @@ LOGGING:
 
     const stateSelectedVerses = fromStore(selectedVerses);
     $effect(() => {
-        if ((stateSelectedVerses.current as any[]).length > 0) {
-            updateSelections(selectedVerses);
-        }
+        stateSelectedVerses.current;
+        updateSelections(selectedVerses);
     });
 
     const countSubheadingPrefixes = (subHeadings: [string], labelPrefix: string) => {


### PR DESCRIPTION
Per #871:
This PR fixes an issue that caused the highlight style to not be removed when the last selected verse was deselected.
I'm not certain that what I did is best practice to get the desired reactive behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the responsiveness of verse selection updates, ensuring selections are updated consistently regardless of the number of selected verses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->