### PR TITLE
Update svelte to 5.36.14.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3485,6 +3485,15 @@
                 "win32"
             ]
         },
+        "node_modules/@sveltejs/acorn-typescript": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
+            "integrity": "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==",
+            "dev": true,
+            "peerDependencies": {
+                "acorn": "^8.9.0"
+            }
+        },
         "node_modules/@sveltejs/adapter-static": {
             "version": "3.0.8",
             "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.8.tgz",
@@ -3960,15 +3969,6 @@
             "dev": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-            }
-        },
-        "node_modules/acorn-typescript": {
-            "version": "1.4.13",
-            "resolved": "https://registry.npmjs.org/acorn-typescript/-/acorn-typescript-1.4.13.tgz",
-            "integrity": "sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==",
-            "dev": true,
-            "peerDependencies": {
-                "acorn": ">=8.9.0"
             }
         },
         "node_modules/acorn-walk": {
@@ -5585,9 +5585,9 @@
             }
         },
         "node_modules/esrap": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.3.tgz",
-            "integrity": "sha512-Xddc1RsoFJ4z9nR7W7BFaEPIp4UXoeQ0+077UdWLxbafMQFyU79sQJMk7kxNgRwQ9/aVgaKacCHC2pUACGwmYw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.1.0.tgz",
+            "integrity": "sha512-yzmPNpl7TBbMRC5Lj2JlJZNPml0tzqoqP5B1JXycNUwtqma9AKCO0M2wHrdgsHcy1WRW7S9rJknAMtByg3usgA==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -7644,9 +7644,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-            "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+            "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
             "dev": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -7671,9 +7671,9 @@
             }
         },
         "node_modules/prettier-plugin-svelte": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.3.3.tgz",
-            "integrity": "sha512-yViK9zqQ+H2qZD1w/bH7W8i+bVfKrD8GIFjkFe4Thl6kCT9SlAsXVNmt3jCvQOCsnOhcvYgsoVlRV/Eu6x5nNw==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.4.0.tgz",
+            "integrity": "sha512-pn1ra/0mPObzqoIQn/vUTR3ZZI6UuZ0sHqMK5x2jMLGrs53h0sXhkVuDcrlssHwIMk7FYrMjHBPoUSyyEEDlBQ==",
             "dev": true,
             "peerDependencies": {
                 "prettier": "^3.0.0",
@@ -8747,21 +8747,21 @@
             }
         },
         "node_modules/svelte": {
-            "version": "5.19.0",
-            "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.19.0.tgz",
-            "integrity": "sha512-qvd2GvvYnJxS/MteQKFSMyq8cQrAAut28QZ39ySv9k3ggmhw4Au4Rfcsqva74i0xMys//OhbhVCNfXPrDzL/Bg==",
+            "version": "5.36.14",
+            "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.36.14.tgz",
+            "integrity": "sha512-okgNwfVa4FfDGOgd0ndooKjQz1LknUFDGfEJp6QNjYP6B4hDG0KktOP+Pta3ZtE8s+JELsYP+7nqMrJzQLkf5A==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.3.0",
                 "@jridgewell/sourcemap-codec": "^1.5.0",
+                "@sveltejs/acorn-typescript": "^1.0.5",
                 "@types/estree": "^1.0.5",
                 "acorn": "^8.12.1",
-                "acorn-typescript": "^1.4.13",
                 "aria-query": "^5.3.1",
                 "axobject-query": "^4.1.0",
                 "clsx": "^2.1.1",
                 "esm-env": "^1.2.1",
-                "esrap": "^1.4.3",
+                "esrap": "^2.1.0",
                 "is-reference": "^3.0.3",
                 "locate-character": "^3.0.0",
                 "magic-string": "^0.30.11",


### PR DESCRIPTION
This will allow use of newer features such as @attach, which connects a function call to an HTML update.