### PR TITLE
Feature/migrate plans

### DIFF
--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -1,6 +1,5 @@
 <script>
     import { base } from '$app/paths';
-    import { page } from '$app/stores';
     import BottomNavigationBar from '$lib/components/BottomNavigationBar.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
     import config from '$lib/data/config';
@@ -17,204 +16,45 @@
     } from '$lib/data/stores';
     import { gotoRoute } from '$lib/navigate';
     import { compareVersions } from '$lib/scripts/stringUtils';
+    import { effect, state } from 'svelte';
 
     const imageFolder =
         compareVersions(config.programVersion, '12.0') < 0 ? 'illustrations' : 'plans';
 
-    //filter out the ones that are in $data.plans, looking at id
-    // $: availablePlans =
-    // //what plans are viewed based on what tab is selected
-    // $: viewedPlans =
-
-    let selectedTab = 'available';
-
-    let availablePlans = [];
-    let completedPlans = [];
-    let usedPlans = [];
-    let allPlans = config.plans.plans || [];
-    let plansInUse = [];
-    const promises = allPlans.map((plan) =>
-        getLastPlanState(plan.id)
-            .then((planState) => {
-                if (planState && planState === 'started') {
-                    plansInUse = [...plansInUse, plan];
-                }
-                if (planState && planState === 'completed') {
-                    completedPlans = [...completedPlans, plan];
-                }
-            })
-            .catch(console.error)
-    );
-    Promise.all(promises).then(() => {
-        if (plansInUse.length > 0) {
-            selectedTab = 'in-use';
-        }
+    const { selectedTab, availablePlans, completedPlans, usedPlans, allPlans, plansInUse } = state({
+        selectedTab: 'available',
+        availablePlans: [],
+        completedPlans: [],
+        usedPlans: [],
+        allPlans: config.plans.plans || [],
+        plansInUse: []
     });
 
-    $: {
-        availablePlans = allPlans.filter(
-            (plan) => !plansInUse.some((usedPlan) => usedPlan.id === plan.id)
+    effect(async () => {
+        const promises = $allPlans.map((plan) =>
+            getLastPlanState(plan.id)
+                .then((planState) => {
+                    if (planState === 'started') {
+                        plansInUse.set([...$plansInUse, plan]);
+                    }
+                    if (planState === 'completed') {
+                        completedPlans.set([...$completedPlans, plan]);
+                    }
+                })
+                .catch(console.error)
         );
-        usedPlans = plansInUse;
-    }
+
+        await Promise.all(promises);
+        if ($plansInUse.length > 0) {
+            selectedTab.set('in-use');
+        }
+
+        availablePlans.set(
+            $allPlans.filter((plan) => !$plansInUse.some((usedPlan) => usedPlan.id === plan.id))
+        );
+        usedPlans.set($plansInUse);
+    });
+
     const bottomNavBarEnabled = config?.bottomNavBarItems && config?.bottomNavBarItems.length > 0;
     const barType = 'plans';
 </script>
-
-<div class="grid grid-rows-[auto,1fr]" style="height:100vh;height:100dvh;">
-    <div class="navbar">
-        <Navbar>
-            {#snippet center()}
-                <label for="sidebar">
-                    <div class="btn btn-ghost normal-case text-xl">{$t['Menu_Plans']}</div>
-                </label>
-            {/snippet}
-        </Navbar>
-    </div>
-
-    <div class="overflow-y-auto mx-auto max-w-screen-md w-full">
-        <div
-            role="tablist"
-            class="dy-tabs dy-tabs-bordered"
-            style={convertStyle($s['ui.plans.tabs'])}
-        >
-            {#if plansInUse.length > 0}
-                <input
-                    type="radio"
-                    name="my_tabs_1"
-                    role="tab"
-                    class="dy-tab dy-tab-bordered {selectedTab === 'in-use' ? 'dy-tab-active' : ''}"
-                    on:click={() => (selectedTab = 'in-use')}
-                    aria-label={$t['Plans_Tab_My_Plans']}
-                    style={convertStyle($s['ui.plans.tabs.text'])}
-                />
-            {/if}
-            <input
-                type="radio"
-                name="my_tabs_1"
-                role="tab"
-                class="dy-tab {selectedTab === 'available' ? 'dy-tab-active' : ''}"
-                on:click={() => (selectedTab = 'available')}
-                aria-label={$t['Plans_Tab_Choose_Plan']}
-                style={convertStyle($s['ui.plans.tabs.text'])}
-            />
-            {#if completedPlans.length > 0}
-                <input
-                    type="radio"
-                    name="my_tabs_1"
-                    role="tab"
-                    class="dy-tab dy-tab-bordered {selectedTab === 'completed'
-                        ? 'dy-tab-active'
-                        : ''}"
-                    on:click={() => (selectedTab = 'completed')}
-                    aria-label={$t['Plans_Tab_Completed_Plans']}
-                    style={convertStyle($s['ui.plans.tabs.text'])}
-                />
-            {/if}
-        </div>
-
-        <div id="container" class="plan-chooser">
-            {#if selectedTab === 'available'}
-                <ul>
-                    {#each availablePlans as plan}
-                        <!-- add on click -->
-                        <!-- svelte-ignore a11y-click-events-have-key-events -->
-                        <!-- svelte-ignore a11y-no-static-element-interactions -->
-                        <div
-                            class="plan-chooser-plan plan-chooser-link"
-                            id={plan.id}
-                            on:click={() => gotoRoute(`/plans/${plan.id}`)}
-                        >
-                            {#if plan.image}
-                                <div class="plan-image-block">
-                                    <img
-                                        class="plan-image"
-                                        src="{base}/{imageFolder}/{plan.image.file}"
-                                        alt={plan.image.file}
-                                        width={plan.image.width}
-                                        height={plan.image.height}
-                                    />
-                                </div>
-                            {/if}
-                            <div class="plan-text-block">
-                                <div class="plan-chooser-title">
-                                    {plan.title[$language] ?? plan.title.default ?? ''}
-                                </div>
-                                <div class="plan-chooser-days">
-                                    {$t['Plans_Number_Days'].replace('%d', plan.days)}
-                                </div>
-                            </div>
-                        </div>
-                    {/each}
-                </ul>
-            {:else if selectedTab === 'in-use'}
-                <ul>
-                    {#each usedPlans as plan}
-                        <!-- svelte-ignore a11y-click-events-have-key-events -->
-                        <!-- svelte-ignore a11y-no-static-element-interactions -->
-                        <div
-                            class="plan-chooser-plan plan-chooser-link"
-                            id={plan.id}
-                            on:click={() => gotoRoute(`/plans/${plan.id}`)}
-                        >
-                            {#if plan.image}
-                                <div class="plan-image-block">
-                                    <img
-                                        class="plan-image"
-                                        src="{base}/{imageFolder}/{plan.image.file}"
-                                        alt={plan.image.file}
-                                        width={plan.image.width}
-                                        height={plan.image.height}
-                                    />
-                                </div>
-                            {/if}
-                            <div class="plan-text-block">
-                                <div class="plan-chooser-title">
-                                    {plan.title[$language] ?? plan.title.default ?? ''}
-                                </div>
-                                <div class="plan-chooser-days">
-                                    {$t['Plans_Number_Days'].replace('%d', plan.days)}
-                                </div>
-                            </div>
-                        </div>
-                    {/each}
-                </ul>
-            {:else if selectedTab === 'completed'}
-                <ul>
-                    {#each completedPlans as plan}
-                        <!-- svelte-ignore a11y-click-events-have-key-events -->
-                        <!-- svelte-ignore a11y-no-static-element-interactions -->
-                        <div
-                            class="plan-chooser-plan plan-chooser-link"
-                            id={plan.id}
-                            on:click={() => gotoRoute(`/plans/${plan.id}`)}
-                        >
-                            {#if plan.image}
-                                <div class="plan-image-block">
-                                    <img
-                                        class="plan-image"
-                                        src="{base}/{imageFolder}/{plan.image.file}"
-                                        alt={plan.image.file}
-                                        width={plan.image.width}
-                                        height={plan.image.height}
-                                    />
-                                </div>
-                            {/if}
-                            <div class="plan-text-block">
-                                <div class="plan-chooser-title">
-                                    {plan.title[$language] ?? plan.title.default ?? ''}
-                                </div>
-                                <div class="plan-chooser-days">
-                                    {$t['Plans_Number_Days'].replace('%d', plan.days)}
-                                </div>
-                            </div>
-                        </div>
-                    {/each}
-                </ul>
-            {/if}
-        </div>
-    </div>
-    {#if bottomNavBarEnabled}
-        <BottomNavigationBar {barType} />
-    {/if}
-</div>

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -16,7 +16,7 @@
     } from '$lib/data/stores';
     import { gotoRoute } from '$lib/navigate';
     import { compareVersions } from '$lib/scripts/stringUtils';
-    import { effect, state } from 'svelte';
+    import { effect, state } from 'svelte/effects';
 
     const imageFolder =
         compareVersions(config.programVersion, '12.0') < 0 ? 'illustrations' : 'plans';

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -34,13 +34,13 @@
     //need some way to know the status of the plan
     //for now assume it's from choose plans
 
-    let selectedTab = 'info';
-    let inUse = false;
+    let selectedTab = $state('info');
+    let inUse = $state(false);
     //could be info or calendar for a plan thats not in use, if the plan is in use, there is a settings tab
     checkPlanState();
-    let selectedDay = $page.data.planData.items[0];
+    let selectedDay = $state($page.data.planData.items[0]);
     let planId = $page.data.planData.id;
-    let currentPlanStatus = '';
+    let currentPlanStatus = $state('');
     let currentStatusDateString = '';
     async function checkPlanState() {
         const planStateRecord = await getLastPlanStateRecord($page.data.planData.id);
@@ -209,18 +209,18 @@
                 />
             </div>
         {/if}
-        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
         <div
             role="tablist"
             class="dy-tabs dy-tabs-bordered"
             style={convertStyle($s['ui.plans.tabs'])}
         >
-            <!-- svelte-ignore a11y-no-static-element-interactions -->
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
 
             <div
                 name="my_tabs_1"
                 class="dy-tab dy-tab-bordered {selectedTab === 'info' ? 'dy-tab-active' : ''}"
-                on:click={() => (selectedTab = 'info')}
+                onclick={() => (selectedTab = 'info')}
                 aria-label="info icon"
                 style={convertStyle($s['ui.plans.tabs.text'])}
             >
@@ -228,11 +228,11 @@
                 ></InfoIcon>
             </div>
 
-            <!-- svelte-ignore a11y-no-static-element-interactions -->
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
             <div
                 name="my_tabs_1"
                 class="dy-tab {selectedTab === 'calendar' ? 'dy-tab-active' : ''}"
-                on:click={() => (selectedTab = 'calendar')}
+                onclick={() => (selectedTab = 'calendar')}
                 aria-label="calendar logo"
             >
                 <CalendarMonthIcon
@@ -240,12 +240,12 @@
                     style={convertStyle($s['ui.plans.tabs.icon'])}
                 ></CalendarMonthIcon>
             </div>
-            <!-- svelte-ignore a11y-no-static-element-interactions -->
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
             {#if inUse === true}
                 <div
                     name="my_tabs_1"
                     class="dy-tab {selectedTab === 'settings' ? 'dy-tab-active' : ''}"
-                    on:click={() => (selectedTab = 'settings')}
+                    onclick={() => (selectedTab = 'settings')}
                     aria-label="settings icon"
                 >
                     <SettingsIcon
@@ -280,19 +280,19 @@
                     {#if inUse === true}
                         <div class="plan-button-block">
                             <div class="plan-button" id="PLAN-continue">
-                                <button on:click={() => (selectedTab = 'calendar')}>
+                                <button onclick={() => (selectedTab = 'calendar')}>
                                     {$t['Plans_Button_Continue_Reading']}
                                 </button>
                             </div>
                         </div>
                     {:else}
                         <div class="plan-button-block">
-                            <!-- svelte-ignore a11y-click-events-have-key-events -->
-                            <!-- svelte-ignore a11y-no-static-element-interactions -->
+                            <!-- svelte-ignore a11y_click_events_have_key_events -->
+                            <!-- svelte-ignore a11y_no_static_element_interactions -->
                             <div
                                 class="plan-button"
                                 id="PLAN-start"
-                                on:click={() =>
+                                onclick={() =>
                                     gotoRoute(`/plans/${$page.data.planData.id}/settings`)}
                             >
                                 {$t['Plans_Button_Start_Plan']}
@@ -302,21 +302,21 @@
                 </div>
             {/if}
             {#if selectedTab === 'calendar'}
-                <!-- svelte-ignore a11y-no-static-element-interactions -->
+                <!-- svelte-ignore a11y_no_static_element_interactions -->
                 <div
                     class="plan-days-scroller"
                     id="scroller"
-                    on:mousedown={handleMouseDown}
-                    on:mousemove={handleMouseMove}
-                    on:mouseup={handleMouseUp}
-                    on:mouseleave={handleMouseUp}
+                    onmousedown={handleMouseDown}
+                    onmousemove={handleMouseMove}
+                    onmouseup={handleMouseUp}
+                    onmouseleave={handleMouseUp}
                 >
                     <ul class="dy-menu-horizontal bg-base-200 rounded-box">
                         {#each $page.data.planData.items as item}
                             <!-- plan-day-box selected plan-day-box-selected plan-day-box-uncompleted or
                          plan-day-box plan-day-box-unselected plan-day-box-uncompleted -->
-                            <!-- svelte-ignore a11y-click-events-have-key-events -->
-                            <!-- svelte-ignore a11y-no-static-element-interactions -->
+                            <!-- svelte-ignore a11y_click_events_have_key_events -->
+                            <!-- svelte-ignore a11y_no_static_element_interactions -->
                             <!-- the class plan-day-box in particular does not seem to work-->
                             <li>
                                 <div
@@ -325,7 +325,7 @@
                                         ? 'selected plan-day-box-selected'
                                         : 'plan-day-box-unselected'}"
                                     id="D-1"
-                                    on:click={() => (selectedDay = item)}
+                                    onclick={() => (selectedDay = item)}
                                 >
                                     <div class="plan-day-box-content">
                                         <div class="plan-day-box-weekday">{$t['Plans_Day']}</div>
@@ -344,7 +344,7 @@
                                 <tr
                                     class="plan-item"
                                     id={'R-' + index}
-                                    on:click={goToDailyReference(selectedDay, ref, index)}
+                                    onclick={goToDailyReference(selectedDay, ref, index)}
                                 >
                                     <td class="plan-item-checkbox plan-checkbox-image">
                                         {#if referenceCompleted(selectedDay.day, index) === true}
@@ -369,12 +369,12 @@
                     <div class="plan-config-info">
                         {$t['Plans_Config_Stop_Plan_info']}
                     </div>
-                    <!-- svelte-ignore a11y-click-events-have-key-events -->
-                    <!-- svelte-ignore a11y-no-static-element-interactions -->
+                    <!-- svelte-ignore a11y_click_events_have_key_events -->
+                    <!-- svelte-ignore a11y_no_static_element_interactions -->
                     <div
                         class="plan-button plan-config-button"
                         id="PLAN-stop"
-                        on:click={() => modal.open(MODAL_STOP_PLAN, planId)}
+                        onclick={() => modal.open(MODAL_STOP_PLAN, planId)}
                     >
                         {$t['Plans_Button_Stop_Plan']}
                     </div>

--- a/src/routes/plans/[id]/settings/+page.svelte
+++ b/src/routes/plans/[id]/settings/+page.svelte
@@ -40,12 +40,12 @@
             <div class="plan-setup-title">
                 {$t['Plans_Setup_Start_Completed_Message']}
             </div>
-            <!-- svelte-ignore a11y-click-events-have-key-events -->
-            <!-- svelte-ignore a11y-no-static-element-interactions -->
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
             <div
                 class="plan-button"
                 id="plan-continue"
-                on:click={async function () {
+                onclick={async function () {
                     await startPlan($page.data.planConfig.id);
                 }}
             >


### PR DESCRIPTION
- Replaced reactive declarations with `state`
- Avoided use of deprecated `let` reactivity and removed `$:` reactive blocks
- Ensured client-side behavior remains unchanged