### PR TITLE
Feature/Migrate annotation files to Svelte 5

### DIFF
--- a/src/routes/bookmarks/+page.svelte
+++ b/src/routes/bookmarks/+page.svelte
@@ -43,7 +43,7 @@
         actions: [$t['Annotation_Sort_Order_Reference'], $t['Annotation_Sort_Order_Date']]
     };
 
-    let sortOrder = SORT_DATE;
+    let sortOrder = $state(SORT_DATE);
 </script>
 
 <div class="grid grid-rows-[auto,1fr]" style="height:100vh;height:100dvh;">

--- a/src/routes/highlights/+page.svelte
+++ b/src/routes/highlights/+page.svelte
@@ -49,7 +49,7 @@
         ]
     };
 
-    let sortOrder = SORT_DATE;
+    let sortOrder = $state(SORT_DATE);
 </script>
 
 <div class="grid grid-rows-[auto,1fr]" style="height:100vh;height:100dvh;">
@@ -63,7 +63,7 @@
                 </label>
             {/snippet}
 
-            <!-- svelte-ignore a11y-label-has-associated-control -->
+            <!-- svelte-ignore a11y_label_has_associated_control -->
             {#snippet end()}
                 <button
                     class="dy-btn dy-btn-ghost dy-btn-circle"

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -5,17 +5,12 @@
     import { bodyFontSize, t } from '$lib/data/stores';
     import DeleteSweepIcon from '$lib/icons/DeleteSweepIcon.svelte';
 
-    // Use "export let data" instead of $page so that local data can
+    let { data } = $props();
+    let history = $state([...data.history].reverse());
 
-    interface Props {
-        // be cleared during onClearHistory.
-        data: any;
-    }
-
-    let { data = $bindable() }: Props = $props();
     async function onClearHistory() {
         await clearHistory();
-        data.history = [];
+        history = [];
     }
 </script>
 
@@ -40,11 +35,11 @@
         class="overflow-y-auto p-2.5 max-w-screen-md mx-auto w-full"
         style:font-size="{$bodyFontSize}px"
     >
-        {#if data.history.length === 0}
+        {#if history.length === 0}
             <div class="history-message-none">{$t['History_None']}</div>
             <div class="history-message-none-info">{$t['History_None_Info']}</div>
         {:else}
-            {#each data.history.reverse() as h}
+            {#each history as h}
                 <HistoryCard history={h} />
             {/each}
         {/if}

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -6,8 +6,13 @@
     import DeleteSweepIcon from '$lib/icons/DeleteSweepIcon.svelte';
 
     // Use "export let data" instead of $page so that local data can
-    // be cleared during onClearHistory.
-    export let data;
+
+    interface Props {
+        // be cleared during onClearHistory.
+        data: any;
+    }
+
+    let { data = $bindable() }: Props = $props();
     async function onClearHistory() {
         await clearHistory();
         data.history = [];
@@ -24,7 +29,7 @@
             {/snippet}
 
             {#snippet end()}
-                <button class="dy-btn dy-btn-ghost dy-btn-circle" on:click={onClearHistory}>
+                <button class="dy-btn dy-btn-ghost dy-btn-circle" onclick={onClearHistory}>
                     <DeleteSweepIcon color="white" />
                 </button>
             {/snippet}

--- a/src/routes/notes/+page.svelte
+++ b/src/routes/notes/+page.svelte
@@ -46,7 +46,7 @@
         actions: [$t['Annotation_Sort_Order_Reference'], $t['Annotation_Sort_Order_Date']]
     };
 
-    let sortOrder = SORT_DATE;
+    let sortOrder = $state(SORT_DATE);
 </script>
 
 <div class="grid grid-rows-[auto,1fr]" style="height:100vh;height:100dvh;">

--- a/src/routes/notes/edit/[noteid]/+page.svelte
+++ b/src/routes/notes/edit/[noteid]/+page.svelte
@@ -5,12 +5,12 @@
     import { CheckIcon, DeleteIcon } from '$lib/icons';
     import { onMount } from 'svelte';
 
-    export let data;
+    let { data } = $props();
 
-    let textarea;
+    let textarea = $state();
     let note = data.note;
     let isNew = note ? false : true;
-    let text = note?.text ?? '';
+    let text = $state(note?.text ?? '');
     let reference = note?.reference ?? $selectedVerses[0]?.reference;
     const title = isNew ? 'Annotation_Note_Add' : 'Annotation_Note_Edit';
 
@@ -83,10 +83,10 @@
 
         {#snippet end()}
             <div class="dy-join">
-                <button on:click={deleteNote} class="dy-join-item dy-btn dy-btn-ghost dy-btn-circle"
+                <button onclick={deleteNote} class="dy-join-item dy-btn dy-btn-ghost dy-btn-circle"
                     ><DeleteIcon color="white" /></button
                 >
-                <button on:click={action} class="dy-join-item dy-btn dy-btn-ghost p-1"
+                <button onclick={action} class="dy-join-item dy-btn dy-btn-ghost p-1"
                     ><CheckIcon color="white" /></button
                 >
             </div>


### PR DESCRIPTION
- Migrated bookmarks, highlights, history, and notes to Svelte 5
- Replaced on:click with onclick
- Replaced reactive declarations with `state`
- Avoided use of deprecated `let` reactivity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Converted several page variables to reactive local state to improve UI reactivity and consistency (including sort order and local data/text handling).
  * Switched some event bindings from framework-specific directives to standard HTML onclick handlers.
  * Adjusted an accessibility lint directive format.

* **Style**
  * Minor code-structure tidy-ups for maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->