### PR TITLE
Issue #894 Plan Scrolls not working

### DIFF
--- a/src/lib/data/stores/view.js
+++ b/src/lib/data/stores/view.js
@@ -15,8 +15,6 @@ export const isFirstLaunch = derived(
     ([$firstLaunchTime, $launchTime]) => $firstLaunchTime === $launchTime
 );
 
-/**a group of writable stores to store the top visible verse in a group*/
-export const scrolls = groupStore(writable, 'title');
 /**the current view/layout mode*/
 export const LAYOUT_SINGLE = 'single';
 export const LAYOUT_TWO = 'two';

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -344,7 +344,7 @@
                                 <tr
                                     class="plan-item"
                                     id={'R-' + index}
-                                    on:click={goToDailyReference(selectedDay, ref, index)}
+                                    on:click={() => goToDailyReference(selectedDay, ref, index)}
                                 >
                                     <td class="plan-item-checkbox plan-checkbox-image">
                                         {#if referenceCompleted(selectedDay.day, index) === true}

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -38,7 +38,6 @@
         notes,
         refs,
         s,
-        scrolls,
         selectedVerses,
         showDesktopSidebar,
         t,
@@ -218,31 +217,22 @@
         showOverlowMenu = false;
     }
 
-    /**unique key to use for groupStore modifier*/
-    const key = {};
-
-    let group = 'default';
-    let scrollId;
-    let scrollMod;
-    const unSub = scrolls.subscribe((val, mod) => {
-        scrollId = val;
-        scrollMod = mod;
-    }, group);
-    onDestroy(unSub);
-
     /**scrolls element with id into view*/
     const scrollTo = (id) => {
-        if (scrollMod === key) return;
-        if (!id) return;
+        let verseId = id === 'start-none' ? '1-a' : id;
+        if (!verseId) return;
         let el = document.querySelector(
-            `div[data-verse="${id.split('-')[0]}"][data-phrase="${id.split('-')[1]}"]`
+            `div[data-verse="${verseId.split('-')[0]}"][data-phrase="${verseId.split('-')[1]}"]`
         );
         makeElementVisible(el);
     };
-    $effect(() => {
-        scrollTo(scrollId);
-    });
-
+    function delayedScroll(id) {
+        let updateTimer;
+        clearTimeout(updateTimer);
+        updateTimer = setTimeout(() => {
+            scrollTo(id);
+        }, 100);
+    }
     function delayedSeek(id) {
         let updateTimer;
         clearTimeout(updateTimer);
@@ -258,11 +248,11 @@
             updateTimer = setTimeout(() => {
                 let verse = $refs.verse;
                 if (verse === '' || verse === '1') {
-                    scrolls.set('start-none');
+                    delayedScroll('start-none');
                 } else {
                     let verseID = verse + '-a';
                     let audioID = verse + 'a';
-                    scrolls.set(verseID);
+                    delayedScroll(verseID);
                     updateAudioPlayer($refs);
                     delayedSeek(audioID);
                 }


### PR DESCRIPTION
There were other issues with scrolling not related to plans when a new reference was selected, especially a different in the same chapter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Smoother, more reliable scrolling in the text view with debounced, ID-based targeting for verses.
  * Improved verse targeting accuracy (e.g., consistent handling of start-of-text positions).

* **Bug Fixes**
  * Fixed issue where clicking a plan item could trigger navigation prematurely; actions now occur only on actual clicks.
  * Resolved intermittent scroll-to-verse synchronization issues, improving alignment with audio playback and reference changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->