### PR TITLE
Issue #900 - Plan doesn't work with verse range

### DIFF
--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -824,7 +824,7 @@ LOGGING:
         return planEntryInChapter;
     };
     function addPlanDiv(workspace, verseNumber) {
-        if (planDivInChapter() && $plan.planToVerse.toString() === verseNumber) {
+        if (planDivInChapter() && matchesVerse($plan.planToVerse, verseNumber)) {
             const planDiv = document.createElement('div');
             planDiv.id = 'plan-progress';
             planDiv.classList.add('plan-progress-block');
@@ -1006,6 +1006,26 @@ LOGGING:
         } else {
             gotoPlanReference();
         }
+    }
+    function matchesVerse(planToVerse: number, verseNumber: string): boolean {
+        // If end of plan range is -1, then only match verseNumber '-1'
+        if (planToVerse === -1) {
+            return verseNumber === '-1';
+        }
+
+        // If it's just a single number string, compare directly
+        if (/^\d+$/.test(verseNumber)) {
+            return planToVerse === Number(verseNumber);
+        }
+
+        // If it's a range like "3-5"
+        if (/^\d+-\d+$/.test(verseNumber)) {
+            const [start, end] = verseNumber.split('-').map(Number);
+            return planToVerse >= start && planToVerse <= end;
+        }
+
+        // If verseNumber is something unexpected, return false
+        return false;
     }
     function findBookmarkElementForVerse(verse, verseRangeSeparator) {
         const elements = document.querySelectorAll('[id^="bookmarks"]');

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -221,9 +221,7 @@
     const scrollTo = (id) => {
         let verseId = id === 'start-none' ? '1-a' : id;
         if (!verseId) return;
-        let el = document.querySelector(
-            `div[data-verse="${verseId.split('-')[0]}"][data-phrase="${verseId.split('-')[1]}"]`
-        );
+        let el = findVerseElement(verseId);
         makeElementVisible(el);
     };
     function delayedScroll(id) {
@@ -281,6 +279,32 @@
                 }
             }
         }
+    }
+    function findVerseElement(verseId) {
+        const [verseNumStr, phrase] = verseId.split('-');
+        const verseNum = Number(verseNumStr);
+
+        // Try direct match first
+        let el = document.querySelector(
+            `div[data-verse="${verseNumStr}"][data-phrase="${phrase}"]`
+        );
+        if (el) return el;
+        // Fall back: look for ranges
+        const candidates = document.querySelectorAll(`div[data-phrase="${phrase}"]`);
+
+        for (const candidate of candidates) {
+            const verseAttr = candidate.getAttribute('data-verse');
+            if (!verseAttr) continue;
+
+            if (/^\d+-\d+$/.test(verseAttr)) {
+                const [start, end] = verseAttr.split('-').map(Number);
+                if (verseNum >= start && verseNum <= end) {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
     }
     const highlightColor = $derived($themeColors['TextHighlightColor']);
     let currentVerse = '';


### PR DESCRIPTION
If the plan segment end verse references a verse that is included as a combination verse (with something like data-verse="3-7"), the end of segment block is not included.  If trying to go to a reference that includes this kind of verse, the scroll to make it visible can't find it.