### PR TITLE
Collection List: selectedLayouts may be null

### DIFF
--- a/src/lib/components/CollectionList.svelte
+++ b/src/lib/components/CollectionList.svelte
@@ -30,9 +30,10 @@ Custom list of collections for the LayoutOptions menu
         <li>
             <!-- svelte-ignore a11y_click_events_have_key_events -->
             <!-- svelte-ignore a11y_interactive_supports_focus -->
+
             <a
                 onclick={() => handleClick(d)}
-                style:background-color={selectedLayouts.id === d.id
+                style:background-color={selectedLayouts?.id === d.id
                     ? $themeColors['LayoutItemSelectedBackgroundColor']
                     : ''}
                 class="flex justify-between"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an intermittent error on the Collection List when no layout is selected, preventing possible crashes and console warnings.
  * Ensures the selected item highlighting behaves reliably without affecting the view when nothing is selected.
  * Improves overall stability and visual consistency during navigation and initial load scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->