### PR TITLE
Show node version on version check failure

### DIFF
--- a/convert/checkVersion.ts
+++ b/convert/checkVersion.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { exit } from 'node:process';
 import { compareVersions } from './stringUtils';
 
-const verNumRegExp = /[\d]+(\.[\d]+){0,2}/;
+const verNumRegExp = /\d+(\.\d+){0,2}/;
 
 const fromCLI = execSync('node --version').toString().match(verNumRegExp)?.at(0) ?? '';
 const fromPackage =


### PR DESCRIPTION
<img width="766" height="378" alt="Screenshot 2025-11-21 at 3 15 47 PM" src="https://github.com/user-attachments/assets/b290659e-f432-4c1b-bb2b-65c858ac5625" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages to show the actual environment Node version and the required minimum when version checks fail.
  * Ensures a consistent success exit code for the version check command.

* **Chores**
  * Improved version-detection reliability and minor formatting/structure updates under the hood.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->