### PR TITLE
Filter Message when BUILD_ENV=appbuilders

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -42,7 +42,7 @@ const matchers = [
 /** @type {(msg: string, options: any) => void} */
 logger.warn = (msg, options) => {
     // suppress specific warning messages on build
-    if (process.env.NODE_ENV === 'development' || !matchers.some((m) => m(msg))) {
+    if (process.env.BUILD_ENV !== 'appbuilders' || !matchers.some((m) => m(msg))) {
         loggerWarn(msg, options);
     }
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted build environment warning suppression logic to use BUILD_ENV instead of NODE_ENV, refining when warnings appear during the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->