### PR TITLE
Fix ordering of words with special chars

### DIFF
--- a/convert/convertReverseIndex.ts
+++ b/convert/convertReverseIndex.ts
@@ -72,7 +72,9 @@ export function convertReverseIndex(
 
     Object.entries(entriesByLetter).forEach(([letter, entries]) => {
         const fileLetter = letter.toLowerCase();
-        entries.sort(([a], [b]) => a.replace(noCompareRE, '').localeCompare(b.replace(noCompareRE, ''), language));
+        entries.sort(([a], [b]) =>
+            a.replace(noCompareRE, '').localeCompare(b.replace(noCompareRE, ''), language)
+        );
 
         let currentChunk: { [key: string]: ReversalEntry[] } = {};
         let currentCount = 0;

--- a/src/routes/lexicon/+page.svelte
+++ b/src/routes/lexicon/+page.svelte
@@ -74,10 +74,7 @@
                 reversalWords[currentReversal.languageId] || []
             ).sort((a, b) => {
                 const alphabet = currentAlphabet;
-                return (
-                    alphabet.indexOf(a.letter) -
-                    alphabet.indexOf(b.letter)
-                );
+                return alphabet.indexOf(a.letter) - alphabet.indexOf(b.letter);
             });
         }
     }


### PR DESCRIPTION
Words with smart quotes were being sorted ahead of words without. As far as I can tell, this problem only affected reversals.

Questions:
- Are smart quotes the only characters we should be worried about?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sorting of lexicon entries to properly handle special characters, including smart quotes
  * Enhanced word ordering to maintain language context through improved locale-aware comparison

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->