### PR TITLE
Use AppBuilders Version in key for project_data cache

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,9 @@ jobs:
     setup:
         runs-on: ubuntu-latest
 
+        outputs:
+            appbuilder_version: ${{ steps.get_version.outputs.appbuilder_version }}
+
         steps:
             - uses: actions/checkout@v4
 
@@ -40,12 +43,24 @@ jobs:
                   path: node_modules
                   key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
 
+            - name: Get AppBuilder Version
+              id: get_version
+              run: |
+                  # Get tag from GHCR
+                  TOKEN_JSON=$(curl https://ghcr.io/token\?scope\="repository:sillsdev/app-builders:pull")
+                  TOKEN=$(echo "$TOKEN_JSON" | jq -r ".token")
+                  TAG_DATA=$(curl -H "Authorization: Bearer $TOKEN" https://ghcr.io/v2/sillsdev/app-builders/tags/list)
+                  NUM_TAGS=$(echo "$TAG_DATA" | jq -r '.tags | length')
+                  FROM_GHCR=$(echo "$TAG_DATA" | jq -r ".tags[$(("$NUM_TAGS" - 1))]")
+                  echo "Latest tag of sillsdev/app-builders is: $FROM_GHCR"
+                  echo "appbuilder_version=$FROM_GHCR" >> $GITHUB_OUTPUT
+
             - name: Restore Projects cache
               id: restore-projects-cache
               uses: actions/cache@v4
               with:
                   path: project_data
-                  key: ${{ runner.os }}-projects-${{ hashFiles('test_data/projects', 'convert/*.ts') }}
+                  key: ${{ runner.os }}-projects-${{ hashFiles('test_data/projects', 'convert/*.ts') }}-${{ steps.get_version.outputs.appbuilder_version }}
 
             - name: Setup Java
               if: steps.restore-projects-cache.outputs.cache-hit != 'true'
@@ -118,7 +133,7 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: project_data
-                  key: ${{ runner.os }}-projects-${{ hashFiles('test_data/projects', 'convert/*.ts') }}
+                  key: ${{ runner.os }}-projects-${{ hashFiles('test_data/projects', 'convert/*.ts') }}-${{ steps.get_version.outputs.appbuilder_version }}
 
     lint:
         runs-on: ubuntu-latest
@@ -140,7 +155,7 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: project_data
-                  key: ${{ runner.os }}-projects-${{ hashFiles('test_data/projects', 'convert/*.ts') }}
+                  key: ${{ runner.os }}-projects-${{ hashFiles('test_data/projects', 'convert/*.ts') }}-${{ needs.setup.outputs.appbuilder_version }}
 
             - name: Convert minimal project
               run: |
@@ -180,7 +195,7 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: project_data
-                  key: ${{ runner.os }}-projects-${{ hashFiles('test_data/projects', 'convert/*.ts') }}
+                  key: ${{ runner.os }}-projects-${{ hashFiles('test_data/projects', 'convert/*.ts') }}-${{ needs.setup.outputs.appbuilder_version }}
 
             - name: Run Tests
               run: |


### PR DESCRIPTION
Tests were broken when app-builders added some new features. This does not fix those tests. This allows broken tests to be caught earlier by making sure that the latest version of app-builders is used to extract the project data for testing. Some of this was delayed by the fact that we were caching the extracted data to save time during the testing process. Using the version number as part of the cache key bypasses this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to include version detection and caching optimization for improved build consistency and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->