### PR TITLE
Fix parsing of fonts on windows

### DIFF
--- a/convert/convertBooks.ts
+++ b/convert/convertBooks.ts
@@ -262,10 +262,11 @@ function trimTrailingWhitespace(
     _bookId: string,
     _ctx: ConvertBookContext
 ): string {
+    const eol = text.includes('\r\n') ? '\r\n' : '\n';
     return text
-        .split('\n') // Split the text into lines
+        .split(/\r?\n/) // Split the text into lines
         .map((line) => line.trimEnd()) // Trim trailing whitespace from each line
-        .join('\n'); // Join the lines back together
+        .join(eol); // Join the lines back together
 }
 
 // Function to check if an image is missing
@@ -293,8 +294,9 @@ function moveFigureToNextNonVerseMarker(
 ): string {
     const result = [];
     let carryOverFigures: string[] = [];
+    const eol = text.includes('\r\n') ? '\r\n' : '\n';
 
-    const lines = text.split('\n');
+    const lines = text.split(/\r?\n/);
     for (let line of lines) {
         // Add any figures that were carried over from the previous lines
         if (carryOverFigures.length > 0) {
@@ -326,7 +328,7 @@ function moveFigureToNextNonVerseMarker(
     }
 
     // Join the lines back together
-    return result.join('\n');
+    return result.join(eol);
 }
 
 type FilterFunction = (
@@ -778,7 +780,8 @@ function updateExplanation(
 }
 
 function firstFiveLines(text: string): string {
-    return text.split('\n').slice(0, 5).join('\n');
+    const eol = text.includes('\r\n') ? '\r\n' : '\n';
+    return text.split(/\r?\n/).slice(0, 5).join(eol);
 }
 
 function convertScriptureBook(
@@ -798,7 +801,7 @@ function convertScriptureBook(
         content = applyFilters(content, usfmFilterFunctions, context.bcId, id, context);
         if (bookTab) {
             //The book tab ID in the sfm file gets cut off, which results in it having the same ID as the book. Generate a new ID based on the book ID and book tab ID.
-            const firstLine = content.split('\n')[0];
+            const firstLine = content.split(/\r?\n/)[0];
             const remainingLines = content.slice(content.indexOf('\n'));
             content =
                 firstLine.replace(/\\id [^\s]+/g, `\\id ${book.id}${bookTab.bookTabID}`) +

--- a/convert/convertManifest.ts
+++ b/convert/convertManifest.ts
@@ -16,7 +16,8 @@ export function convertManifest(dataDir: string, verbose: number) {
     if (existing) {
         mkdirSync(path.join('static', 'icons'), { recursive: true });
         const fileContents = readFileSync(srcFile).toString();
-        const lines = fileContents.split('\n');
+        const lines = fileContents.split(/\r?\n/);
+        const eol = fileContents.includes('\r\n') ? '\r\n' : '\n';
         contents = lines
             .map((line) => {
                 if (line.includes('start_url')) {
@@ -49,7 +50,7 @@ export function convertManifest(dataDir: string, verbose: number) {
                 }
                 return line;
             })
-            .join('\n');
+            .join(eol);
     } else {
         // If no manifest exists, we need to at least have a minimum manifest to build.
         const manifest = {

--- a/convert/convertReverseIndex.ts
+++ b/convert/convertReverseIndex.ts
@@ -44,7 +44,7 @@ export function convertReverseIndex(
 
     const content = readFileSync(indexFilePath, 'utf-8');
     const indexEntries = content
-        .split('\n')
+        .split(/\r?\n/)
         .map((line) => line.trim().split('\t'))
         .filter(([gloss]) => gloss?.length > 0);
 

--- a/convert/convertStyles.ts
+++ b/convert/convertStyles.ts
@@ -28,7 +28,8 @@ export function convertStyles(dataDir: string, configData: ConfigTaskOutput, ver
         let swapped = false;
 
         const fileContents = readFileSync(srcFile).toString();
-        const lines = fileContents.split('\n');
+        const lines = fileContents.split(/\r?\n/);
+        const eol = fileContents.includes('\r\n') ? '\r\n' : '\n';
         // Until App Builders 12.0 is released, then add these styles
         const tempStyles = srcFile.endsWith('-app.css') ? getTempStyles(configData, verbose) : '';
         const updatedFileContents =
@@ -103,7 +104,7 @@ export function convertStyles(dataDir: string, configData: ConfigTaskOutput, ver
                     }
                     return line;
                 })
-                .join('\n');
+                .join(eol);
         writeFileSync(dstFile, updatedFileContents);
     });
 }


### PR DESCRIPTION
EOL was not being handled correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed line ending inconsistencies in conversion utilities to properly handle both Unix (LF) and Windows (CRLF) file formats.
  * Enhanced file processing to preserve original line ending conventions throughout the conversion pipeline.
  * Output files now maintain consistent line endings with input files, preventing unintended formatting alterations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->