### PR TITLE
Check for if the tag has the attribute lang

### DIFF
--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -29,7 +29,7 @@ function decodeFromXml(input: string): string {
         .replace('&amp;', '&');
 }
 
-function langAttrCheck(element: Element): string {
+export function parseLangAttribute(element: Element): string {
     if (!element.hasAttribute('lang')) return 'default';
     return element.attributes.getNamedItem('lang')!.value;
 }
@@ -291,7 +291,7 @@ function convertConfig(dataDir: string, verbose: number) {
         const indexesTag = document.getElementsByTagName('indexes')[0];
         const indexTags = indexesTag.getElementsByTagName('index');
         for (const tag of indexTags) {
-            const lang: string = langAttrCheck(tag);
+            const lang: string = parseLangAttribute(tag);
             const displayed: boolean = tag.attributes.getNamedItem('displayed')!.value === 'true';
             indexes[lang] = { displayed };
         }
@@ -846,7 +846,7 @@ export function parseWritingSystem(element: Element, verbose: number): WritingSy
     const displaynamesTag = element.getElementsByTagName('display-names')[0];
     const displayNames: Record<string, string> = {};
     for (const form of displaynamesTag.getElementsByTagName('form')) {
-        displayNames[langAttrCheck(form)] = form.innerHTML;
+        displayNames[parseLangAttribute(form)] = form.innerHTML;
     }
     const writingSystem: WritingSystemConfig = {
         type,
@@ -927,7 +927,9 @@ export function parseMenuLocalizations(document: Document, verbose: number) {
             if (verbose >= 2) console.log(`.. translationMapping: ${tag.id}`);
             const localizations: Record<string, string> = {};
             for (const localization of tag.getElementsByTagName('t')) {
-                localizations[langAttrCheck(localization)] = decodeFromXml(localization.innerHTML);
+                localizations[parseLangAttribute(localization)] = decodeFromXml(
+                    localization.innerHTML
+                );
             }
             if (verbose >= 3) console.log(`....`, JSON.stringify(localizations));
             translationMappings.mappings[tag.id] = localizations;
@@ -1241,7 +1243,7 @@ export function parseTabTypes(document: Document, verbose: number) {
         const nameTags = tab.getElementsByTagName('tab-name')[0].getElementsByTagName('t');
         const name: { [lang: string]: string } = {};
         for (const nameTag of nameTags) {
-            name[langAttrCheck(nameTag)] = nameTag.innerHTML;
+            name[parseLangAttribute(nameTag)] = nameTag.innerHTML;
 
             if (verbose >= 3) console.log(name);
         }
@@ -1318,14 +1320,14 @@ export function parseMenuItems(document: Document, type: string, verbose: number
             const titleTags = menuItem.getElementsByTagName('title')[0].getElementsByTagName('t');
             const title: { [lang: string]: string } = {};
             for (const titleTag of titleTags) {
-                title[langAttrCheck(titleTag)] = titleTag.innerHTML;
+                title[parseLangAttribute(titleTag)] = titleTag.innerHTML;
             }
 
             const linkTags = menuItem.getElementsByTagName('link')[0]?.getElementsByTagName('t');
             const link: { [lang: string]: string } = {};
             if (linkTags) {
                 for (const linkTag of linkTags) {
-                    link[langAttrCheck(linkTag)] = linkTag.innerHTML;
+                    link[parseLangAttribute(linkTag)] = linkTag.innerHTML;
                 }
             }
 
@@ -1335,7 +1337,7 @@ export function parseMenuItems(document: Document, type: string, verbose: number
             const linkId: { [lang: string]: string } = {};
             if (linkIdTags) {
                 for (const linkIdTag of linkIdTags) {
-                    linkId[langAttrCheck(linkIdTag)] = linkIdTag.innerHTML;
+                    linkId[parseLangAttribute(linkIdTag)] = linkIdTag.innerHTML;
                 }
             }
 
@@ -1399,7 +1401,7 @@ export function parsePlans(document: Document, verbose: number) {
                 const titleTags = tag.getElementsByTagName('title')[0].getElementsByTagName('t');
                 const title: { [lang: string]: string } = {};
                 for (const titleTag of titleTags) {
-                    title[langAttrCheck(titleTag)] = titleTag.innerHTML;
+                    title[parseLangAttribute(titleTag)] = titleTag.innerHTML;
                 }
                 // Image
                 const imageTag = tag.getElementsByTagName('image')[0];

--- a/convert/convertContents.ts
+++ b/convert/convertContents.ts
@@ -2,7 +2,7 @@ import { cpSync, existsSync, mkdirSync, readFileSync, rmSync } from 'fs';
 import path from 'path';
 import { ScriptureConfig } from '$config';
 import jsdom from 'jsdom';
-import { ConfigTaskOutput } from './convertConfig';
+import { ConfigTaskOutput, parseLangAttribute } from './convertConfig';
 import { createHashedFile } from './fileUtils';
 import { Task, TaskOutput } from './Task';
 
@@ -104,7 +104,7 @@ export function convertContents(
     if (titleTags?.length > 0) {
         data.title = {};
         for (const titleTag of titleTags) {
-            const lang = titleTag.attributes.getNamedItem('lang')!.value;
+            const lang = parseLangAttribute(titleTag);
             data.title[lang] = decodeFromXml(titleTag.innerHTML);
         }
     }
@@ -133,7 +133,7 @@ export function convertContents(
             const titleTags = itemTag.getElementsByTagName('title');
             if (titleTags?.length > 0) {
                 for (const titleTag of titleTags) {
-                    const lang = titleTag.attributes.getNamedItem('lang')!.value;
+                    const lang = parseLangAttribute(titleTag);
                     title[lang] = decodeFromXml(titleTag.innerHTML);
                 }
             }
@@ -142,7 +142,7 @@ export function convertContents(
             const subtitleTags = itemTag.getElementsByTagName('subtitle');
             if (subtitleTags?.length > 0) {
                 for (const subtitleTag of subtitleTags) {
-                    const lang = subtitleTag.attributes.getNamedItem('lang')!.value;
+                    const lang = parseLangAttribute(subtitleTag);
                     subtitle[lang] = decodeFromXml(subtitleTag.innerHTML);
                 }
             }
@@ -151,7 +151,7 @@ export function convertContents(
             const audioTags = itemTag.getElementsByTagName('audio');
             if (audioTags?.length > 0) {
                 for (const audioTag of audioTags) {
-                    const lang = audioTag.attributes.getNamedItem('lang')!.value;
+                    const lang = parseLangAttribute(audioTag);
                     audioFilename[lang] = decodeFromXml(audioTag.innerHTML);
                     if (hasContentsDir) {
                         if (existsSync(path.join(contentsDir, audioFilename[lang]))) {
@@ -256,7 +256,7 @@ export function convertContents(
             const titleTags = screenTag.getElementsByTagName('title');
             if (titleTags?.length > 0) {
                 for (const titleTag of titleTags) {
-                    const lang = titleTag.attributes.getNamedItem('lang')!.value;
+                    const lang = parseLangAttribute(titleTag);
                     title[lang] = titleTag.innerHTML;
                 }
             }


### PR DESCRIPTION
SAB 13.4 not putting the lang attribute on tabType tagNames. This caused the convertConfig to fail with:

```
/Users/david/code/appbuilder-pwa/convert/convertConfig.ts:1241
            name[nameTag.attributes.getNamedItem('lang')!.value] = nameTag.innerHTML;
```

Added a check to ensure that the attribute exists before trying to pull it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent handling of missing language tags across configuration and content parsing so the app now falls back gracefully instead of failing.
  * Unified language parsing ensures titles, menus, plans, and writing-system displays behave consistently when language info is absent.

* **Chores**
  * Added targeted verbose diagnostics for tab name mappings at high verbosity to aid troubleshooting without affecting normal runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->