### PR TITLE
Calculate phrase indices above 26 with double letters

### DIFF
--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -391,7 +391,7 @@ LOGGING:
         }
 
         if (callerSymbol === '+') {
-            callerSymbol = fnc.charAt(workspace.footnoteIndex % 26);
+            callerSymbol = createLetterIndex(workspace.footnoteIndex);
             workspace.footnoteIndex++;
         }
 


### PR DESCRIPTION
This issue was first discovered in multiple verses in the Nambikwara project:
Scriptoria: https://app.scriptoria.io/projects/567
ScriptureEarth: https://scriptureearth.org/data/nab/sab/nab/#/text

Certain verses, e.g. 1 Peter 3:1-2, were long enough that the automatic phrase division resulted in more than 26 phrases, causing the rendering method to fail when attempting to query the DOM with a non-existent phrase index due to being out of bounds of the 26 character array used to generate the phrase indicator used in the DOM.

The method to generate said phrase indicator has been updated to generate two-letter indicators once the initial single-letter ones have been exhausted.

i.e. 0-25 => a-z
26+ => aa, ab, ... zz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Verse and phrase labels now use multi-letter identifiers (aa, ab, etc.), enabling correct indexing beyond 26 items.
  * Footnote markers now follow the same multi-letter scheme so annotations remain unique and consistent in long passages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->