### PR TITLE
Add query: '?url' parameter to all glob imports

### DIFF
--- a/src/lib/components/BookTabs.svelte
+++ b/src/lib/components/BookTabs.svelte
@@ -18,6 +18,7 @@ A component that displays the book tabs and allows the user to switch between th
     const tabIcons = import.meta.glob('./*', {
         import: 'default',
         eager: true,
+        query: '?url',
         base: '/src/gen-assets/icons/tabs'
     });
 

--- a/src/lib/components/BottomNavigationBar.svelte
+++ b/src/lib/components/BottomNavigationBar.svelte
@@ -11,6 +11,7 @@
     const menuIcons = import.meta.glob('./*', {
         import: 'default',
         eager: true,
+        query: '?url',
         base: '/src/gen-assets/icons/menu-items'
     });
 

--- a/src/lib/components/CollectionList.svelte
+++ b/src/lib/components/CollectionList.svelte
@@ -8,6 +8,7 @@ Custom list of collections for the LayoutOptions menu
     const illustrations = import.meta.glob('./*', {
         import: 'default',
         eager: true,
+        query: '?url',
         base: '/src/gen-assets/illustrations'
     }) as Record<string, string>;
 

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -62,6 +62,7 @@ LOGGING:
     const illustrations = import.meta.glob('./*', {
         import: 'default',
         eager: true,
+        query: '?url',
         base: '/src/gen-assets/illustrations'
     }) as Record<string, string>;
 

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -43,6 +43,7 @@ The sidebar/drawer.
     const menuIcons = import.meta.glob('./*', {
         import: 'default',
         eager: true,
+        query: '?url',
         base: '/src/gen-assets/icons/menu-items'
     });
 

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -19,12 +19,14 @@ import { logAudioDuration, logAudioPlay } from './analytics';
 const audioSources = import.meta.glob('./*', {
     import: 'default',
     eager: true,
+    query: '?url',
     base: '/src/gen-assets/audio'
 }) as Record<string, string>;
 
 const timings = import.meta.glob('./*', {
     import: 'default',
     eager: true,
+    query: '?url',
     base: '/src/gen-assets/timings'
 }) as Record<string, string>;
 

--- a/src/lib/scripts/milestoneLinks.ts
+++ b/src/lib/scripts/milestoneLinks.ts
@@ -4,6 +4,7 @@ import { filenameWithoutPath, padWithInitialZeros } from './stringUtils';
 const clips = import.meta.glob('./*', {
     import: 'default',
     eager: true,
+    query: '?url',
     base: '/src/gen-assets/clips'
 }) as Record<string, string>;
 

--- a/src/lib/video/index.ts
+++ b/src/lib/video/index.ts
@@ -4,12 +4,14 @@ import config from '$lib/data/config';
 const thumbnails = import.meta.glob('./*', {
     import: 'default',
     eager: true,
+    query: '?url',
     base: '/src/gen-assets/images'
 }) as Record<string, string>;
 
 const videos = import.meta.glob('./*', {
     import: 'default',
     eager: true,
+    query: '?url',
     base: '/src/gen-assets/videos'
 }) as Record<string, string>;
 

--- a/src/routes/about/+page.js
+++ b/src/routes/about/+page.js
@@ -1,6 +1,7 @@
 const illustrations = import.meta.glob('./*', {
     eager: true,
     import: 'default',
+    query: '?url',
     base: '/src/gen-assets/illustrations'
 });
 

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -12,11 +12,13 @@
             ? import.meta.glob('./*', {
                   eager: true,
                   import: 'default',
+                  query: '?url',
                   base: '/src/gen-assets/illustrations'
               })
             : import.meta.glob(['./*', '!./*.json'], {
                   eager: true,
                   import: 'default',
+                  query: '?url',
                   base: '/src/gen-assets/plans'
               });
 

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -32,11 +32,13 @@
             ? import.meta.glob('./*', {
                   eager: true,
                   import: 'default',
+                  query: '?url',
                   base: '/src/gen-assets/illustrations'
               })
             : import.meta.glob(['./*', '!./*.json'], {
                   eager: true,
                   import: 'default',
+                  query: '?url',
                   base: '/src/gen-assets/plans'
               });
 

--- a/src/routes/quiz/[collection]/[id]/+page.svelte
+++ b/src/routes/quiz/[collection]/[id]/+page.svelte
@@ -21,18 +21,21 @@
     const illustrations = import.meta.glob('./*', {
         import: 'default',
         eager: true,
+        query: '?url',
         base: '/src/gen-assets/illustrations'
     });
 
     const clips = import.meta.glob('./*', {
         import: 'default',
         eager: true,
+        query: '?url',
         base: '/src/gen-assets/clips'
     });
 
     const quizAssets = import.meta.glob('./*', {
         import: 'default',
         eager: true,
+        query: '?url',
         base: '/src/gen-assets/quiz'
     });
 

--- a/src/routes/share/+page.svelte
+++ b/src/routes/share/+page.svelte
@@ -10,6 +10,7 @@
     const badges = import.meta.glob('./*', {
         import: 'default',
         eager: true,
+        query: '?url',
         base: '/src/gen-assets/badges'
     }) as Record<string, string>;
 

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -62,6 +62,7 @@
     const borders = import.meta.glob('./*', {
         import: 'default',
         eager: true,
+        query: '?url',
         base: '/src/gen-assets/borders'
     });
 


### PR DESCRIPTION
This forces svelte to use the url for the resource, rather than aggressively optimizing by building some data into the page itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized static asset resolution across the application, including icons, images, audio files, videos, and illustrations. Updated asset loading mechanisms across multiple components and pages for consistent and efficient resource handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->