### PR TITLE
Add missing change from PR#937

### DIFF
--- a/convert/convertMedia.ts
+++ b/convert/convertMedia.ts
@@ -175,7 +175,7 @@ export class ConvertMedia extends Task {
                     await sharp(androidIcon)
                         .resize(180, 180)
                         .toFile(path.join('src', 'gen-assets', 'icons', 'apple-touch-icon.png'));
-                } else if (verbose) {
+                } else {
                     throw new Error('No Android icon found to generate apple-touch-icon.png');
                 }
             }


### PR DESCRIPTION
This change was still in my local changes. I had thought it was included in #937 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling for missing Android icons during apple-touch-icon.png generation. The system now consistently reports errors instead of selectively based on verbosity settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->