### PR TITLE
Use TS to fetch tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,14 +46,7 @@ jobs:
             - name: Get AppBuilder Version
               id: get_version
               run: |
-                  # Get tag from GHCR
-                  TOKEN_JSON=$(curl https://ghcr.io/token\?scope\="repository:sillsdev/app-builders:pull")
-                  TOKEN=$(echo "$TOKEN_JSON" | jq -r ".token")
-                  TAG_DATA=$(curl -H "Authorization: Bearer $TOKEN" https://ghcr.io/v2/sillsdev/app-builders/tags/list)
-                  NUM_TAGS=$(echo "$TAG_DATA" | jq -r '.tags | length')
-                  FROM_GHCR=$(echo "$TAG_DATA" | jq -r ".tags[$(("$NUM_TAGS" - 1))]")
-                  echo "Latest tag of sillsdev/app-builders is: $FROM_GHCR"
-                  echo "appbuilder_version=$FROM_GHCR" >> $GITHUB_OUTPUT
+                  npx ts-node convert/fetchTags >> $GITHUB_OUTPUT
 
             - name: Restore Projects cache
               id: restore-projects-cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
             - name: Get AppBuilder Version
               id: get_version
               run: |
-                  npx ts-node convert/fetchTags >> $GITHUB_OUTPUT
+                  npx ts-node convert/fetchTags.ts >> $GITHUB_OUTPUT
 
             - name: Restore Projects cache
               id: restore-projects-cache

--- a/convert/fetchTags.ts
+++ b/convert/fetchTags.ts
@@ -1,0 +1,22 @@
+import { compareVersions } from './stringUtils';
+
+const verNumRegExp = /\d+(\.\d+){0,2}/;
+
+(async () => {
+    const tokenJSON = await fetch(
+        'https://ghcr.io/token?scope=repository:sillsdev/app-builders:pull'
+    ).then((r) => r.json());
+    const token = tokenJSON.token;
+    const tagJSON = await fetch('https://ghcr.io/v2/sillsdev/app-builders/tags/list', {
+        headers: { Authorization: `Bearer ${token}` }
+    }).then((r) => r.json());
+
+    const tags = tagJSON.tags as string[];
+
+    const latest = tags
+        .filter((t) => t.match(verNumRegExp))
+        .sort(compareVersions)
+        .at(-1);
+
+    console.log(`appbuilder_version=${latest}`);
+})();

--- a/convert/fetchTags.ts
+++ b/convert/fetchTags.ts
@@ -1,3 +1,4 @@
+import { exit } from 'node:process';
 import { compareVersions } from './stringUtils';
 
 const verNumRegExp = /^\d+(\.\d+){0,2}$/;
@@ -11,28 +12,36 @@ async function getDigest(token: string, ref: string) {
 }
 
 (async () => {
-    const token = (
-        await fetch('https://ghcr.io/token?scope=repository:sillsdev/app-builders:pull').then((r) =>
-            r.json()
-        )
-    ).token as string;
+    try {
+        const token = (
+            await fetch('https://ghcr.io/token?scope=repository:sillsdev/app-builders:pull').then(
+                (r) => r.json()
+            )
+        ).token as string;
 
-    const tags = (
-        await fetch('https://ghcr.io/v2/sillsdev/app-builders/tags/list', {
-            headers: { Authorization: `Bearer ${token}` }
-        }).then((r) => r.json())
-    ).tags as string[];
+        const tags = (
+            await fetch('https://ghcr.io/v2/sillsdev/app-builders/tags/list', {
+                headers: { Authorization: `Bearer ${token}` }
+            }).then((r) => r.json())
+        ).tags as string[];
 
-    const sortedTags = tags.filter((t) => t.match(verNumRegExp)).sort(compareVersions);
+        const sortedTags = tags.filter((t) => t.match(verNumRegExp)).sort(compareVersions);
 
-    const latestDigest = await getDigest(token, 'latest');
+        const latestDigest = await getDigest(token, 'latest');
 
-    let i = sortedTags.length;
-    let digest = '';
-    do {
-        i--;
-        digest = await getDigest(token, sortedTags[i]);
-    } while (i > 0 && latestDigest !== digest);
+        let i = sortedTags.length;
+        let digest = '';
+        do {
+            i--;
+            digest = await getDigest(token, sortedTags[i]);
+        } while (i > 0 && latestDigest !== digest);
 
-    console.log(`appbuilder_version=${sortedTags[i]}`);
-})();
+        console.log(`appbuilder_version=${sortedTags[i]}`);
+    } catch (e) {
+        console.error(e);
+        exit(1);
+    }
+})().catch((r) => {
+    console.error(r);
+    exit(1);
+});

--- a/convert/fetchTags.ts
+++ b/convert/fetchTags.ts
@@ -1,22 +1,38 @@
 import { compareVersions } from './stringUtils';
 
-const verNumRegExp = /\d+(\.\d+){0,2}/;
+const verNumRegExp = /^\d+(\.\d+){0,2}$/;
+
+async function getDigest(token: string, ref: string) {
+    return (
+        await fetch(`https://ghcr.io/v2/sillsdev/app-builders/manifests/${ref}`, {
+            headers: { Authorization: `Bearer ${token}` }
+        }).then((r) => r.json())
+    ).config.digest as string;
+}
 
 (async () => {
-    const tokenJSON = await fetch(
-        'https://ghcr.io/token?scope=repository:sillsdev/app-builders:pull'
-    ).then((r) => r.json());
-    const token = tokenJSON.token;
-    const tagJSON = await fetch('https://ghcr.io/v2/sillsdev/app-builders/tags/list', {
-        headers: { Authorization: `Bearer ${token}` }
-    }).then((r) => r.json());
+    const token = (
+        await fetch('https://ghcr.io/token?scope=repository:sillsdev/app-builders:pull').then((r) =>
+            r.json()
+        )
+    ).token as string;
 
-    const tags = tagJSON.tags as string[];
+    const tags = (
+        await fetch('https://ghcr.io/v2/sillsdev/app-builders/tags/list', {
+            headers: { Authorization: `Bearer ${token}` }
+        }).then((r) => r.json())
+    ).tags as string[];
 
-    const latest = tags
-        .filter((t) => t.match(verNumRegExp))
-        .sort(compareVersions)
-        .at(-1);
+    const sortedTags = tags.filter((t) => t.match(verNumRegExp)).sort(compareVersions);
 
-    console.log(`appbuilder_version=${latest}`);
+    const latestDigest = await getDigest(token, 'latest');
+
+    let i = sortedTags.length;
+    let digest = '';
+    do {
+        i--;
+        digest = await getDigest(token, sortedTags[i]);
+    } while (i > 0 && latestDigest !== digest);
+
+    console.log(`appbuilder_version=${sortedTags[i]}`);
 })();


### PR DESCRIPTION
Uses a script written in TS to find the latest AppBuilders version number. The GHCR recently added the tag `staging` to the list of tags, which invalidated prior assumptions about getting the latest version number tag from GHCR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined the CI/CD process for detecting the latest app builder version by consolidating tag retrieval into a dedicated automation step. Improves maintainability and reliability of version discovery without changing user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->