### PR TITLE
Books colors theme may be missing

### DIFF
--- a/src/lib/data/stores/theme.js
+++ b/src/lib/data/stores/theme.js
@@ -16,14 +16,14 @@ theme.subscribe((value) => (localStorage.theme = value));
 
 export const themeColors = derived(theme, ($theme) => {
     const theme = config.themes.find((x) => x.name == $theme);
-    const colorSet = theme.colorSets.find((x) => x.type === 'main');
-    return colorSet.colors;
+    const colorSet = theme?.colorSets.find((x) => x.type === 'main');
+    return colorSet?.colors ?? {};
 });
 
 export const themeBookColors = derived(theme, ($theme) => {
     const theme = config.themes.find((x) => x.name == $theme);
-    const colorSet = theme.colorSets.find((x) => x.type === 'books');
-    return colorSet.colors;
+    const colorSet = theme?.colorSets.find((x) => x.type === 'books');
+    return colorSet?.colors ?? {};
 });
 
 export const monoIconColor = derived(theme, ($theme) => {


### PR DESCRIPTION
In 13.4, when I create a new project, the `<colors type="books">` is not created and default colors are used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme system stability by gracefully handling missing or incomplete theme data. The application now returns safe defaults when theme configuration is incomplete, preventing potential failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->