### PR TITLE
DAB: Allow no reversals

### DIFF
--- a/src/routes/lexicon/+page.svelte
+++ b/src/routes/lexicon/+page.svelte
@@ -36,7 +36,7 @@
     const { vernacularAlphabet, reversalAlphabets, reversalLanguages, reversalIndexes } = data;
 
     const alphabets = {
-        reversal: Object.values(reversalAlphabets[0])[0],
+        reversal: reversalAlphabets.length > 0 ? Object.values(reversalAlphabets[0])[0] : [],
         vernacular: vernacularAlphabet
     };
 
@@ -82,7 +82,9 @@
     async function loadLetterData(letter: string) {
         let newWords: ReversalWord[] = [];
 
-        const reversalKey = currentReversal.languageId || Object.keys(reversalAlphabets[0])[0];
+        const reversalKey =
+            currentReversal.languageId ||
+            (reversalAlphabets.length > 0 ? Object.keys(reversalAlphabets[0])[0] : '');
 
         const index = reversalIndexes[reversalKey];
         if (!index) {

--- a/src/routes/lexicon/+page.ts
+++ b/src/routes/lexicon/+page.ts
@@ -43,10 +43,6 @@ export async function load({ fetch }) {
         ([_, ws]) => 'reversalFilename' in ws
     );
 
-    if (!reversalWritingSystems.length) {
-        throw new Error('Reversal language(s) not found');
-    }
-
     const reversalAlphabets = reversalWritingSystems.map(([key, ws]) => ({ [key]: ws.alphabet }));
     const reversalLanguages = reversalWritingSystems.map(([key, _]) => key);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when no reversal languages are configured: the app now gracefully defaults to empty values instead of requiring at least one reversal language, avoiding lookup errors and allowing the lexicon page to load and operate normally even without reversal data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->