### PR TITLE
Issue #948 - Footnotes not scrolling properly

### DIFF
--- a/src/lib/components/Dropdown.svelte
+++ b/src/lib/components/Dropdown.svelte
@@ -46,7 +46,7 @@ A simple dropdown menu from DaisyUI.
     <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
     <div
         bind:this={container}
-        class="dy-dropdown-content dy-menu drop-shadow-lg mt-2.5 bg-base-100 z-10 max-sm:absolute max-sm:start-1.5"
+        class="dy-dropdown-content dy-menu shadow-lg mt-2.5 bg-base-100 z-10 max-sm:absolute max-sm:start-1.5"
         class:min-w-[22rem]={cols == 6}
         class:min-w-[18rem]={cols == 5}
         style={convertStyle($s['ui.background'])}

--- a/src/lib/components/StackView.svelte
+++ b/src/lib/components/StackView.svelte
@@ -106,7 +106,7 @@
         <!-- svelte-ignore a11y-no-static-element-interactions -->
         <div
             id="container"
-            class="footnote rounded h-40 drop-shadow-lg overflow-y-auto"
+            class="footnote rounded h-40 shadow-lg overflow-y-auto"
             on:click|stopPropagation={insideClick}
         >
             <div


### PR DESCRIPTION
Footnotes that needed to be scrolled did not display properly on Safari.   They showed blank areas under the initially displayed text when scrolled.  On a phone, when I scrolled up and back it would eventually paint the text correctly in Safari.

Changed drop-shadow-lg to shadow-lg

According to chatGPT:
drop-shadow-lg uses filter: drop-shadow(...)
In safari:
filter + overrflow + dynamic content = known repaint bug
Especially inside:
- flex layouts (which we have)
- positioned elements (absolute, bottom-8)
- scrolling containers (overflow-y-auto)

So the recommendation was to use shadow-lg unless we really needed it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated shadow effects on dropdown menus and stack view components for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->