### PR TITLE
Convert styles to use `var(--color)` correctly

### DIFF
--- a/convert/convertStyles.ts
+++ b/convert/convertStyles.ts
@@ -104,7 +104,10 @@ export function convertStyles(dataDir: string, configData: ConfigTaskOutput, ver
                     // fix CSS color var usage that doesn't use `var(--var)` syntax
                     const colorMatch = line.match(/(color): ((?!var\(--|current).*Color)/i);
                     if (colorMatch) {
-                        line = line.replace(colorMatch[0], `${colorMatch[1]}: var(--${colorMatch[2]})`);
+                        line = line.replace(
+                            colorMatch[0],
+                            `${colorMatch[1]}: var(--${colorMatch[2]})`
+                        );
                     }
                     return line;
                 })

--- a/convert/convertStyles.ts
+++ b/convert/convertStyles.ts
@@ -102,7 +102,7 @@ export function convertStyles(dataDir: string, configData: ConfigTaskOutput, ver
                         line = line.replace('/fonts', joinUrlPath('$assets', finalPath));
                     }
                     // fix CSS color var usage that doesn't use `var(--var)` syntax
-                    const colorMatch = line.match(/color: ((?!var\(--).*Color)/i);
+                    const colorMatch = line.match(/color: ((?!var\(--|current).*Color)/i);
                     if (colorMatch) {
                         line = line.replace(colorMatch[1], `var(--${colorMatch[1]})`);
                     }

--- a/convert/convertStyles.ts
+++ b/convert/convertStyles.ts
@@ -101,6 +101,11 @@ export function convertStyles(dataDir: string, configData: ConfigTaskOutput, ver
                         }
                         line = line.replace('/fonts', joinUrlPath('$assets', finalPath));
                     }
+                    // fix CSS color var usage that doesn't use `var(--var)` syntax
+                    const colorMatch = line.match(/color: ((?!var\(--).*Color)/i);
+                    if (colorMatch) {
+                        line = line.replace(colorMatch[1], `var(--${colorMatch[1]})`);
+                    }
                     return line;
                 })
                 .join(eol);

--- a/convert/convertStyles.ts
+++ b/convert/convertStyles.ts
@@ -102,9 +102,9 @@ export function convertStyles(dataDir: string, configData: ConfigTaskOutput, ver
                         line = line.replace('/fonts', joinUrlPath('$assets', finalPath));
                     }
                     // fix CSS color var usage that doesn't use `var(--var)` syntax
-                    const colorMatch = line.match(/color: ((?!var\(--|current).*Color)/i);
+                    const colorMatch = line.match(/(color): ((?!var\(--|current).*Color)/i);
                     if (colorMatch) {
-                        line = line.replace(colorMatch[1], `var(--${colorMatch[1]})`);
+                        line = line.replace(colorMatch[0], `${colorMatch[1]}: var(--${colorMatch[2]})`);
                     }
                     return line;
                 })

--- a/convert/convertStyles.ts
+++ b/convert/convertStyles.ts
@@ -102,7 +102,7 @@ export function convertStyles(dataDir: string, configData: ConfigTaskOutput, ver
                         line = line.replace('/fonts', joinUrlPath('$assets', finalPath));
                     }
                     // fix CSS color var usage that doesn't use `var(--var)` syntax
-                    const colorMatch = line.match(/(color): ((?!var\(--|current).*Color)/i);
+                    const colorMatch = line.match(/(color): ((?!var\(--|current)[^;]*Color[^;]*)/i);
                     if (colorMatch) {
                         line = line.replace(
                             colorMatch[0],


### PR DESCRIPTION
SAB/DAB output styles that set color to some variable, but omit the required CSS syntax (I assume there is a difference in how Android handles CSS variables...)

Before:
```css
div.onboarding-top-text-subtitle {
    font-size: 80%;
    color: OnboardingSubtitleColor;
    text-align: center;
}
```

After:
```css
div.onboarding-top-text-subtitle {
    font-size: 80%;
    color: var(--OnboardingSubtitleColor);
    text-align: center;
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * CSS color declarations are now automatically standardized to use CSS variables, ensuring consistent color application throughout the application.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sillsdev/appbuilder-pwa/pull/954)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->