### PR TITLE
Migrate Quizzes to Svelte 5 and TS (with minor improvements)

### DIFF
--- a/config/index.d.ts
+++ b/config/index.d.ts
@@ -63,7 +63,7 @@ export type BookConfig = {
     hashedFileName?: string; // currently just for HTML books
     audio: BookCollectionAudioConfig[];
     features: any;
-    quizFeatures?: any;
+    quizFeatures?: Record<string, string>;
     footer?: HTML;
     style?: StyleConfig;
     styles?: {
@@ -334,4 +334,46 @@ export type DictionaryConfig = AppConfig & {
             [key: string]: string;
         };
     }[];
+};
+
+export type QuizExplanation = {
+    text?: string;
+    audio?: string;
+};
+
+export type QuizAnswer = {
+    //\aw or \ar
+    correct: boolean;
+    text?: string;
+    image?: string;
+    audio?: string;
+    explanation?: QuizExplanation;
+};
+
+export type QuizQuestion = {
+    //\qu
+    text: string;
+    image?: string;
+    audio?: string;
+    columns?: number; //\ac
+    explanation?: QuizExplanation;
+    answers: QuizAnswer[];
+};
+
+export type Quiz = {
+    id: string; //\id
+    name?: string; //\qn
+    shortName?: string; //\qs
+    rightAnswerAudio?: string[]; //\ra
+    wrongAnswerAudio?: string[]; //\wa
+    questions: QuizQuestion[];
+    scoreMessageBefore?: string; //\sb
+    scoreMessageAfter?: string; //\sa
+    commentary?: {
+        //\sc
+        rangeMin: number;
+        rangeMax?: number;
+        message: string;
+    }[];
+    passScore?: number; //\pm
 };

--- a/config/index.d.ts
+++ b/config/index.d.ts
@@ -63,7 +63,7 @@ export type BookConfig = {
     hashedFileName?: string; // currently just for HTML books
     audio: BookCollectionAudioConfig[];
     features: any;
-    quizFeatures?: Record<string, string>;
+    quizFeatures?: Record<string, string | boolean | number>;
     footer?: HTML;
     style?: StyleConfig;
     styles?: {

--- a/config/index.d.ts
+++ b/config/index.d.ts
@@ -348,6 +348,8 @@ export type QuizAnswer = {
     image?: string;
     audio?: string;
     explanation?: QuizExplanation;
+    // field is used extensively in UI, adding here for type-safety
+    clicked?: boolean;
 };
 
 export type QuizQuestion = {

--- a/convert/convertBooks.ts
+++ b/convert/convertBooks.ts
@@ -3,7 +3,15 @@
 
 import * as fs from 'fs';
 import path, { basename, extname, join } from 'path';
-import type { BookConfig, BookTabConfig, ScriptureConfig } from '$config';
+import type {
+    BookConfig,
+    BookTabConfig,
+    Quiz,
+    QuizAnswer,
+    QuizExplanation,
+    QuizQuestion,
+    ScriptureConfig
+} from '$config';
 import { freeze, postQueries, queries } from '../sab-proskomma-tools';
 import { SABProskomma } from '../src/lib/sab-proskomma';
 import type { ConfigTaskOutput } from './convertConfig';
@@ -598,48 +606,6 @@ export async function convertBooks(
         taskName: 'ConvertBooks'
     };
 }
-
-export type QuizExplanation = {
-    text?: string;
-    audio?: string;
-};
-
-export type QuizAnswer = {
-    //\aw or \ar
-    correct: boolean;
-    text?: string;
-    image?: string;
-    audio?: string;
-    explanation?: QuizExplanation;
-};
-
-export type QuizQuestion = {
-    //\qu
-    text: string;
-    image?: string;
-    audio?: string;
-    columns?: number; //\ac
-    explanation?: QuizExplanation;
-    answers: QuizAnswer[];
-};
-
-export type Quiz = {
-    id: string; //\id
-    name?: string; //\qn
-    shortName?: string; //\qs
-    rightAnswerAudio?: string[]; //\ra
-    wrongAnswerAudio?: string[]; //\wa
-    questions: QuizQuestion[];
-    scoreMessageBefore?: string; //\sb
-    scoreMessageAfter?: string; //\sa
-    commentary?: {
-        //\sc
-        rangeMin: number;
-        rangeMax?: number;
-        message: string;
-    }[];
-    passScore?: number; //\pm
-};
 
 function convertHtmlBook(context: ConvertBookContext, book: BookConfig, files: any[]) {
     const srcFile = path.join(context.dataDir, 'books', context.bcId, book.file);

--- a/src/lib/data/quiz.ts
+++ b/src/lib/data/quiz.ts
@@ -80,7 +80,7 @@ export async function findQuiz(item: { collection: string; book: string }) {
     const quiz = await openQuiz();
     const tx = quiz.transaction('quiz', 'readonly');
     const index = tx.store.index('collection, book');
-    // I have no clue how to make the type system happy here... -Aidan
+    // @ts-expect-error I have no clue how to make the type system happy here... -Aidan
     const result = await index.getAll([item.collection, item.book]);
     await tx.done;
     return result;

--- a/src/lib/data/quiz.ts
+++ b/src/lib/data/quiz.ts
@@ -1,3 +1,4 @@
+import type { ScriptureConfig } from '$config';
 import config from '$lib/data/config';
 import { openDB, type DBSchema } from 'idb';
 
@@ -22,7 +23,7 @@ interface Quiz extends DBSchema {
     };
 }
 
-let quizDB = null;
+let quizDB: Awaited<ReturnType<typeof openDB<Quiz>>> | null = null;
 async function openQuiz() {
     if (!quizDB) {
         quizDB = await openDB<Quiz>('quiz', 1, {
@@ -53,15 +54,18 @@ export async function addQuiz(item: {
             return;
         }
         const date = new Date()[Symbol.toPrimitive]('number');
-        const bookCollection = config.bookCollections.find((x) => x.id === item.collection);
-        const bookIndex = bookCollection.books.findIndex((x) => x.id === item.book);
+        const scriptConfig = config as ScriptureConfig;
+        const bookCollection = scriptConfig.bookCollections?.find((x) => x.id === item.collection);
+        const bookIndex = bookCollection?.books.findIndex((x) => x.id === item.book);
 
-        const nextItem = {
-            ...item,
-            date: date,
-            bookIndex: bookIndex
-        };
-        await quiz.add('quiz', nextItem);
+        if (bookIndex) {
+            const nextItem = {
+                ...item,
+                date: date,
+                bookIndex: bookIndex
+            };
+            await quiz.add('quiz', nextItem);
+        }
     } catch (error) {
         console.error('Error adding quiz result:', error);
     }
@@ -76,13 +80,14 @@ export async function findQuiz(item: { collection: string; book: string }) {
     const quiz = await openQuiz();
     const tx = quiz.transaction('quiz', 'readonly');
     const index = tx.store.index('collection, book');
+    // I have no clue how to make the type system happy here... -Aidan
     const result = await index.getAll([item.collection, item.book]);
     await tx.done;
     return result;
 }
 
-export async function checkQuizAccess(quizId) {
+export async function checkQuizAccess(quizId: string) {
     const quiz = await openQuiz();
-    const result = await quiz.getAllFromIndex('quiz', 'collection, book');
+    const result: QuizScore[] = await quiz.getAllFromIndex('quiz', 'collection, book');
     return result.some((item) => item.book === quizId && item.pass);
 }

--- a/src/lib/data/quiz.ts
+++ b/src/lib/data/quiz.ts
@@ -17,7 +17,7 @@ interface Quiz extends DBSchema {
         key: number;
         value: QuizScore;
         indexes: {
-            'collection, book': string;
+            'collection, book': [string, string];
             date: number;
         };
     };
@@ -58,7 +58,7 @@ export async function addQuiz(item: {
         const bookCollection = scriptConfig.bookCollections?.find((x) => x.id === item.collection);
         const bookIndex = bookCollection?.books.findIndex((x) => x.id === item.book);
 
-        if (bookIndex) {
+        if (bookIndex !== undefined && bookIndex >= 0) {
             const nextItem = {
                 ...item,
                 date: date,
@@ -80,7 +80,6 @@ export async function findQuiz(item: { collection: string; book: string }) {
     const quiz = await openQuiz();
     const tx = quiz.transaction('quiz', 'readonly');
     const index = tx.store.index('collection, book');
-    // @ts-expect-error I have no clue how to make the type system happy here... -Aidan
     const result = await index.getAll([item.collection, item.book]);
     await tx.done;
     return result;

--- a/src/routes/quiz/[collection]/[id]/+page.svelte
+++ b/src/routes/quiz/[collection]/[id]/+page.svelte
@@ -1,7 +1,7 @@
-<script>
+<script lang="ts">
     import { beforeNavigate } from '$app/navigation';
     import { base } from '$app/paths';
-    import { page } from '$app/state';
+    import type { Quiz, QuizAnswer, QuizQuestion, ScriptureConfig } from '$config';
     import BookSelector from '$lib/components/BookSelector.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
     import config from '$lib/data/config';
@@ -18,63 +18,63 @@
     import { ArrowForwardIcon, AudioIcon, TextAppearanceIcon } from '$lib/icons';
     import { compareVersions } from '$lib/scripts/stringUtils';
     import { onDestroy } from 'svelte';
+    import type { PageData } from './$types.js';
 
-    const illustrations = import.meta.glob('./*', {
+    const scriptConfig: ScriptureConfig = config;
+
+    const illustrations: Record<string, string> = import.meta.glob('./*', {
         import: 'default',
         eager: true,
         query: '?url',
         base: '/src/gen-assets/illustrations'
     });
 
-    const clips = import.meta.glob('./*', {
+    const clips: Record<string, string> = import.meta.glob('./*', {
         import: 'default',
         eager: true,
         query: '?url',
         base: '/src/gen-assets/clips'
     });
 
-    const quizAssets = import.meta.glob('./*', {
+    const quizAssets: Record<string, string> = import.meta.glob('./*', {
         import: 'default',
         eager: true,
         query: '?url',
         base: '/src/gen-assets/quiz'
     });
 
-    /**
-     * @typedef {Object} Props
-     * @property {import('./$types').PageData} data
-     */
-
-    /** @type {Props} */
-    let { data } = $props();
+    interface Props {
+        data: PageData;
+    }
+    let { data }: Props = $props();
 
     let textHighlightIndex = $state(-1);
     let quizSaved = $state(false);
-    let shuffledAnswers = $state([]);
-    let quizQuestions = $state([]);
+    let shuffledAnswers: QuizAnswer[] = $state([]);
+    let quizQuestions: QuizQuestion[] = $state([]);
     let score = $state(0);
     let questionNum = $state(0);
-    let currentQuizQuestion = $state();
+    let currentQuizQuestion: QuizQuestion | undefined = $state();
     let clicked = $state(false);
     let displayCorrect = $state(false);
-    let currentQuestionAudio = null;
-    let currentAnswerAudio = null;
-    let currentExplanationAudio = null;
+    let currentQuestionAudio: HTMLAudioElement | null = null;
+    let currentAnswerAudio: HTMLAudioElement | null = null;
+    let currentExplanationAudio: HTMLAudioElement | null = null;
     let explanation = $state('');
     let commentaryMessage = '';
 
     const staticAssets = compareVersions(config.programVersion, '12.0') < 0;
 
-    function getQuizAssetAudio(file) {
+    function getQuizAssetAudio(file: string) {
         return staticAssets ? 'assets/' + file : quizAssets[`./${file}`].replace(/^\//, '');
     }
 
-    function getRandomAudio(audioArray) {
+    function getRandomAudio(audioArray: string[]) {
         const randomIndex = Math.floor(Math.random() * audioArray.length);
         return audioArray[randomIndex];
     }
 
-    function playSound(path, callback, type = 'answer') {
+    function playSound(path: string, callback: null | (() => void), type = 'answer') {
         let audio = new Audio();
         if (type === 'question') {
             currentQuestionAudio = audio;
@@ -88,9 +88,7 @@
 
         audio.src = path;
         audio.onended = function () {
-            if (callback) {
-                callback();
-            }
+            callback?.();
         };
         audio.play();
     }
@@ -130,11 +128,11 @@
         stopCurrentExplanationAudio();
     }
 
-    function getImageSource(image) {
-        return illustrations[`./${page.params.collection}-${quiz.id}-${image}`] ?? '';
+    function getImageSource(image: string) {
+        return illustrations[`./${data.collection}-${quiz?.id}-${image}`] ?? '';
     }
 
-    function shuffleAnswers(answerArray) {
+    function shuffleAnswers(answerArray: QuizAnswer[]) {
         let currentIndex = answerArray.length,
             randomIndex;
         while (currentIndex != 0) {
@@ -148,7 +146,7 @@
         return answerArray;
     }
 
-    function shuffleArray(array) {
+    function shuffleArray<T>(array: T[]) {
         let currentIndex = array.length,
             randomIndex;
 
@@ -176,10 +174,13 @@
         }
     }
 
-    function getCommentary(score) {
+    function getCommentary(score: number) {
         let result = '';
-        for (const commentary of quiz.commentary) {
-            if (score >= commentary.rangeMin && score <= commentary.rangeMax) {
+        for (const commentary of quiz?.commentary ?? []) {
+            if (
+                score >= commentary.rangeMin &&
+                (!commentary.rangeMax || score <= commentary.rangeMax)
+            ) {
                 result = commentary.message;
                 break;
             }
@@ -201,23 +202,27 @@
         displayCorrect = false;
         shuffledAnswers = [];
         explanation = '';
+        score = 0;
+        quizQuestions = [];
+        quizSaved = false;
+        questionNum = 0;
     }
 
-    function getAnswerAudio(quiz, correct) {
+    function getAnswerAudio(quiz: Quiz | null, correct: boolean) {
         let sound;
         if (correct) {
-            sound = quiz.rightAnswerAudio
+            sound = quiz?.rightAnswerAudio
                 ? clips[`./${getRandomAudio(quiz.rightAnswerAudio)}`]
                 : getQuizAssetAudio('quiz-right-answer.mp3');
         } else {
-            sound = quiz.wrongAnswerAudio
+            sound = quiz?.wrongAnswerAudio
                 ? clips[`./${getRandomAudio(quiz.wrongAnswerAudio)}`]
                 : getQuizAssetAudio('quiz-wrong-answer.mp3');
         }
         return sound;
     }
 
-    function onQuestionAnswered(answer) {
+    function onQuestionAnswered(answer: QuizAnswer) {
         textHighlightIndex = -1;
         stopAudioPlayback();
         if (!clicked) {
@@ -229,11 +234,7 @@
                     if (answer.explanation.audio) {
                         playSound(clips[`./${answer.explanation.audio}`], null, 'explanation');
                     }
-                } else if (
-                    !answer.correct &&
-                    currentQuizQuestion.explanation &&
-                    currentQuizQuestion.explanation.text
-                ) {
+                } else if (!answer.correct && currentQuizQuestion?.explanation?.text) {
                     explanation = currentQuizQuestion.explanation.text;
                     if (currentQuizQuestion.explanation.audio) {
                         playSound(
@@ -278,7 +279,7 @@
         }
     }
 
-    function playQuizAnswerAudio(answerIndex) {
+    function playQuizAnswerAudio(answerIndex: number) {
         if (currentQuizQuestion && $quizAudioActive) {
             if (answerIndex < currentQuizQuestion.answers.length) {
                 const answer = currentQuizQuestion.answers[answerIndex];
@@ -305,39 +306,21 @@
     });
     let { locked, quiz, quizId, quizName, passScore } = $derived(data);
     let book = $derived(
-        config.bookCollections
-            .find((x) => x.id === $refs.collection)
-            .books.find((x) => x.id === quizId)
+        scriptConfig.bookCollections
+            ?.find((x) => x.id === $refs.collection)
+            ?.books.find((x) => x.id === quizId)
     );
     let displayLabel = $derived(quizName || 'Quiz');
-    effect(() => {
-        const { locked, quiz, quizId, quizName, passScore } = data;
-        setBook(
-            config.bookCollections
-                .find((x) => x.id === $refs.collection)
-                .books.find((x) => x.id === quizId)
-        );
-        setDisplayLabel(quizName || 'Quiz');
-
+    $effect(() => {
+        resetQuizState();
         if (quiz) {
-            resetQuizState();
-            setScore(0);
-            setQuestionNum(0);
-            setShuffledAnswers([]);
-            const q = book.quizFeatures['shuffle-questions']
+            quizQuestions = book?.quizFeatures?.['shuffle-questions']
                 ? shuffleArray([...quiz.questions])
                 : [...quiz.questions];
-            setQuizQuestions(q);
-            handleQuestionChange(q, 0);
+            handleQuestionChange();
             playQuizQuestionAudio();
-            setQuizSaved(false);
         } else {
             stopAudioPlayback();
-            setScore(0);
-            setQuestionNum(0);
-            setShuffledAnswers([]);
-            setQuizQuestions([]);
-            setQuizSaved(false);
         }
     });
 </script>
@@ -403,7 +386,7 @@
         </div>
         {#if !quizSaved}
             {@const pass = score >= passScore}
-            {#await addQuiz( { collection: page.params.collection, book: quizId, score, passScore, pass } ) then _}
+            {#await addQuiz( { collection: data.collection, book: quizId, score, passScore, pass } ) then _}
                 <p>Quiz result saved!</p>
             {:catch error}
                 <p>Error saving quiz result: {error.message}</p>
@@ -415,7 +398,7 @@
                 <div class="quiz-question-number" style:line-height="{$bodyLineHeight}%">
                     {questionNum + 1}
                 </div>
-                {#if currentQuizQuestion.answers}
+                {#if currentQuizQuestion?.answers}
                     {#if currentQuizQuestion.answers.some((answer) => answer.text)}
                         <div class="quiz-question-block">
                             <div class="quiz-question" style:line-height="{$bodyLineHeight}%">
@@ -464,7 +447,7 @@
                             {/if}
                         </div>
                     {/if}
-                    {#if currentQuizQuestion.answers.some((answer) => answer.image)}
+                    {#if currentQuizQuestion?.answers.some((answer) => answer.image)}
                         <div class="quiz-question-block">
                             <div class="quiz-question">
                                 {currentQuizQuestion.text}
@@ -489,7 +472,7 @@
                                             <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
                                             <img
                                                 class="cursor-pointer"
-                                                src={getImageSource(answer.image)}
+                                                src={getImageSource(answer.image ?? '')}
                                                 alt={answer.text}
                                                 onclick={() => {
                                                     onQuestionAnswered(answer);

--- a/src/routes/quiz/[collection]/[id]/+page.svelte
+++ b/src/routes/quiz/[collection]/[id]/+page.svelte
@@ -1,4 +1,4 @@
-<script module>
+<script lang="ts" module>
     function getRandomItem<T>(array: T[]) {
         return array[Math.floor(Math.random() * array.length)];
     }
@@ -20,7 +20,7 @@
 
 <script lang="ts">
     import { beforeNavigate } from '$app/navigation';
-    import type { Quiz, QuizAnswer, QuizQuestion, ScriptureConfig } from '$config';
+    import type { QuizAnswer, QuizQuestion, ScriptureConfig } from '$config';
     import BookSelector from '$lib/components/BookSelector.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
     import config from '$lib/data/config';
@@ -289,7 +289,7 @@
             </div>
             <div class="quiz-locked-name">{data.dependentQuizName || data.dependentQuizId}</div>
         </div>
-    {:else if currentQuestionIdx == questions.length}
+    {:else if currentQuestionIdx === questions.length}
         <div class="score">
             <div id="content" class="text-center">
                 <div class="quiz-score-before">{$t['Quiz_Score_Page_Message_Before']}</div>
@@ -297,7 +297,7 @@
                     <span class="quiz-score">{score}</span>
                 </div>
                 <div class="quiz-score-after">
-                    {$t['Quiz_Score_Page_Message_After'].replace('%n%', currentQuestionIdx)}
+                    {$t['Quiz_Score_Page_Message_After'].replace('%n%', String(currentQuestionIdx))}
                 </div>
                 <div class="quiz-score-commentary">
                     {getCommentary(score)}
@@ -306,7 +306,7 @@
         </div>
         {#if !saved}
             {@const pass = score >= passScore}
-            {#await addQuiz({ collection, book: quizId, score, passScore, pass }) then _}
+            {#await addQuiz( { collection, book: quizId, score, passScore, pass } ).then(() => (saved = true)) then _}
                 <p>Quiz result saved!</p>
             {:catch error}
                 <p>Error saving quiz result: {error.message}</p>
@@ -320,7 +320,7 @@
                 </div>
                 {#if currentQuestion?.answers}
                     {@const imgFormat = currentQuestion.answers.some((answer) => answer.image)}
-                    {@const cols = (currentQuestion.columns ?? imgFormat) ? 2 : 1}
+                    {@const cols = currentQuestion.columns ?? (imgFormat ? 2 : 1)}
                     <div class="quiz-question-block">
                         <div class="quiz-question" style:line-height="{$bodyLineHeight}%">
                             {currentQuestion.text}

--- a/src/routes/quiz/[collection]/[id]/+page.svelte
+++ b/src/routes/quiz/[collection]/[id]/+page.svelte
@@ -14,6 +14,7 @@
         quizAudioActive,
         t
     } from '$lib/data/stores';
+    import { refs } from '$lib/data/stores/scripture';
     import { ArrowForwardIcon, AudioIcon, TextAppearanceIcon } from '$lib/icons';
     import { compareVersions } from '$lib/scripts/stringUtils';
     import { onDestroy } from 'svelte';
@@ -39,52 +40,27 @@
         base: '/src/gen-assets/quiz'
     });
 
-    /** @type {import('./$types').PageData} */
-    export let data;
+    /**
+     * @typedef {Object} Props
+     * @property {import('./$types').PageData} data
+     */
 
-    $: ({ locked, quiz, quizId, quizName, passScore } = data);
+    /** @type {Props} */
+    let { data } = $props();
 
-    $: book = config.bookCollections
-        .find((x) => x.id === page.params.collection)
-        .books.find((x) => x.id === quizId);
-
-    $: displayLabel = quizName || 'Quiz';
-
-    $: if (quiz) {
-        resetQuizState();
-
-        score = 0;
-        questionNum = 0;
-        shuffledAnswers = [];
-        quizQuestions = book.quizFeatures['shuffle-questions']
-            ? shuffleArray([...quiz.questions])
-            : [...quiz.questions];
-        handleQuestionChange();
-        playQuizQuestionAudio();
-        quizSaved = false;
-    } else {
-        stopAudioPlayback();
-
-        score = 0;
-        questionNum = 0;
-        shuffledAnswers = [];
-        quizQuestions = [];
-        quizSaved = false;
-    }
-
-    let textHighlightIndex = -1;
-    let quizSaved = false;
-    let shuffledAnswers = [];
-    let quizQuestions = [];
-    let score = 0;
-    let questionNum = 0;
-    let currentQuizQuestion;
-    let clicked = false;
-    let displayCorrect = false;
+    let textHighlightIndex = $state(-1);
+    let quizSaved = $state(false);
+    let shuffledAnswers = $state([]);
+    let quizQuestions = $state([]);
+    let score = $state(0);
+    let questionNum = $state(0);
+    let currentQuizQuestion = $state();
+    let clicked = $state(false);
+    let displayCorrect = $state(false);
     let currentQuestionAudio = null;
     let currentAnswerAudio = null;
     let currentExplanationAudio = null;
-    let explanation = '';
+    let explanation = $state('');
     let commentaryMessage = '';
 
     const staticAssets = compareVersions(config.programVersion, '12.0') < 0;
@@ -327,6 +303,43 @@
     onDestroy(() => {
         stopAudioPlayback();
     });
+    let { locked, quiz, quizId, quizName, passScore } = $derived(data);
+    let book = $derived(
+        config.bookCollections
+            .find((x) => x.id === $refs.collection)
+            .books.find((x) => x.id === quizId)
+    );
+    let displayLabel = $derived(quizName || 'Quiz');
+    effect(() => {
+        const { locked, quiz, quizId, quizName, passScore } = data;
+        setBook(
+            config.bookCollections
+                .find((x) => x.id === $refs.collection)
+                .books.find((x) => x.id === quizId)
+        );
+        setDisplayLabel(quizName || 'Quiz');
+
+        if (quiz) {
+            resetQuizState();
+            setScore(0);
+            setQuestionNum(0);
+            setShuffledAnswers([]);
+            const q = book.quizFeatures['shuffle-questions']
+                ? shuffleArray([...quiz.questions])
+                : [...quiz.questions];
+            setQuizQuestions(q);
+            handleQuestionChange(q, 0);
+            playQuizQuestionAudio();
+            setQuizSaved(false);
+        } else {
+            stopAudioPlayback();
+            setScore(0);
+            setQuestionNum(0);
+            setShuffledAnswers([]);
+            setQuizQuestions([]);
+            setQuizSaved(false);
+        }
+    });
 </script>
 
 <div class="grid grid-rows-[auto,1fr] h-screen" style:font-size="{$bodyFontSize}px">
@@ -340,7 +353,7 @@
                     <div class="flex">
                         <button
                             class="dy-btn dy-btn-ghost dy-btn-circle"
-                            on:click={() => {
+                            onclick={() => {
                                 $quizAudioActive = !$quizAudioActive;
                             }}
                         >
@@ -351,12 +364,12 @@
                             {/if}
                         </button>
                     </div>
-                    <!-- svelte-ignore a11y-click-events-have-key-events -->
-                    <!-- svelte-ignore a11y-label-has-associated-control -->
-                    <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+                    <!-- svelte-ignore a11y_click_events_have_key_events -->
+                    <!-- svelte-ignore a11y_label_has_associated_control -->
+                    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
                     <label
                         class="dy-btn dy-btn-ghost p-0.5 dy-no-animation"
-                        on:click={() => modal.open(MODAL_TEXT_APPEARANCE)}
+                        onclick={() => modal.open(MODAL_TEXT_APPEARANCE)}
                     >
                         <TextAppearanceIcon color="white" />
                     </label>
@@ -408,7 +421,7 @@
                             <div class="quiz-question" style:line-height="{$bodyLineHeight}%">
                                 {currentQuizQuestion.text}
                                 {#if currentQuizQuestion.image}
-                                    <!-- svelte-ignore a11y-missing-attribute -->
+                                    <!-- svelte-ignore a11y_missing_attribute -->
                                     <img
                                         class="quiz-question-image h-40"
                                         src={getImageSource(currentQuizQuestion.image)}
@@ -423,7 +436,7 @@
                                     {#each shuffledAnswers as answer, currentIndex}
                                         <button
                                             class="w-5/6 md:w-64 lg:w-[20rem] mt-2"
-                                            on:click={() => {
+                                            onclick={() => {
                                                 onQuestionAnswered(answer);
                                             }}
                                         >
@@ -472,13 +485,13 @@
                                             class:textHighlight={textHighlightIndex ===
                                                 currentIndex}
                                         >
-                                            <!-- svelte-ignore a11y-click-events-have-key-events -->
-                                            <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+                                            <!-- svelte-ignore a11y_click_events_have_key_events -->
+                                            <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
                                             <img
                                                 class="cursor-pointer"
                                                 src={getImageSource(answer.image)}
                                                 alt={answer.text}
-                                                on:click={() => {
+                                                onclick={() => {
                                                     onQuestionAnswered(answer);
                                                 }}
                                             />
@@ -501,7 +514,7 @@
                     >
                         <button
                             class="dy-btn dy-btn-active p-2 px-8 mt-4"
-                            on:click={() => {
+                            onclick={() => {
                                 onNextQuestion();
                             }}
                         >

--- a/src/routes/quiz/[collection]/[id]/+page.svelte
+++ b/src/routes/quiz/[collection]/[id]/+page.svelte
@@ -1,6 +1,25 @@
+<script module>
+    function getRandomItem<T>(array: T[]) {
+        return array[Math.floor(Math.random() * array.length)];
+    }
+
+    function shuffle<T>(array: T[]) {
+        let currentIndex = array.length;
+        let randomIndex = 0;
+
+        while (currentIndex !== 0) {
+            randomIndex = Math.floor(Math.random() * currentIndex);
+            currentIndex--;
+
+            [array[currentIndex], array[randomIndex]] = [array[randomIndex], array[currentIndex]];
+        }
+
+        return array;
+    }
+</script>
+
 <script lang="ts">
     import { beforeNavigate } from '$app/navigation';
-    import { base } from '$app/paths';
     import type { Quiz, QuizAnswer, QuizQuestion, ScriptureConfig } from '$config';
     import BookSelector from '$lib/components/BookSelector.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
@@ -18,6 +37,7 @@
     import { ArrowForwardIcon, AudioIcon, TextAppearanceIcon } from '$lib/icons';
     import { compareVersions } from '$lib/scripts/stringUtils';
     import { onDestroy } from 'svelte';
+    import type { ClassValue } from 'svelte/elements';
     import type { PageData } from './$types.js';
 
     const scriptConfig: ScriptureConfig = config;
@@ -48,200 +68,111 @@
     }
     let { data }: Props = $props();
 
-    let textHighlightIndex = $state(-1);
-    let quizSaved = $state(false);
-    let shuffledAnswers: QuizAnswer[] = $state([]);
-    let quizQuestions: QuizQuestion[] = $state([]);
+    let { locked, quiz, quizId, displayLabel, passScore, collection } = $derived(data);
+
+    let highlightIdx = $state(-1);
     let score = $state(0);
-    let questionNum = $state(0);
-    let currentQuizQuestion: QuizQuestion | undefined = $state();
+    let currentQuestionIdx = $state(0);
+
+    let saved = $state(false);
     let clicked = $state(false);
-    let displayCorrect = $state(false);
-    let currentQuestionAudio: HTMLAudioElement | null = null;
-    let currentAnswerAudio: HTMLAudioElement | null = null;
-    let currentExplanationAudio: HTMLAudioElement | null = null;
+    let showCorrectAnswer = $state(false);
+
+    let currentAudio: HTMLAudioElement | null = null;
+
     let explanation = $state('');
-    let commentaryMessage = '';
+
+    const book = $derived(
+        scriptConfig.bookCollections
+            ?.find((x) => x.id === $refs.collection)
+            ?.books.find((x) => x.id === quizId)
+    );
+    const questions: QuizQuestion[] = $derived(
+        book?.quizFeatures?.['shuffle-questions']
+            ? shuffle([...(quiz?.questions ?? [])])
+            : [...(quiz?.questions ?? [])]
+    );
+    const currentQuestion: QuizQuestion | undefined = $derived(questions[currentQuestionIdx]);
+    const shuffledAnswers: QuizAnswer[] = $derived(
+        shuffle(currentQuestion?.answers.map((a) => ({ ...a, clicked: false })) ?? [])
+    );
 
     const staticAssets = compareVersions(config.programVersion, '12.0') < 0;
-
     function getQuizAssetAudio(file: string) {
         return staticAssets ? 'assets/' + file : quizAssets[`./${file}`].replace(/^\//, '');
     }
 
-    function getRandomAudio(audioArray: string[]) {
-        const randomIndex = Math.floor(Math.random() * audioArray.length);
-        return audioArray[randomIndex];
-    }
-
-    function playSound(path: string, callback: null | (() => void), type = 'answer') {
-        let audio = new Audio();
-        if (type === 'question') {
-            currentQuestionAudio = audio;
-        }
-        if (type === 'answer') {
-            currentAnswerAudio = audio;
-        }
-        if (type === 'explanation') {
-            currentExplanationAudio = audio;
-        }
-
-        audio.src = path;
-        audio.onended = function () {
-            callback?.();
-        };
-        audio.play();
-    }
-
-    beforeNavigate(() => {
+    function playSound(path: string, onended: null | (() => void) = null) {
         stopAudioPlayback();
-        resetQuizState();
-    });
-
-    function stopCurrentQuestionAudio() {
-        if (currentQuestionAudio) {
-            currentQuestionAudio.pause();
-            currentQuestionAudio.currentTime = 0;
-            currentQuestionAudio = null;
-        }
-    }
-
-    function stopCurrentAnswerAudio() {
-        if (currentAnswerAudio) {
-            currentAnswerAudio.pause();
-            currentAnswerAudio.currentTime = 0;
-            currentAnswerAudio = null;
-        }
-    }
-
-    function stopCurrentExplanationAudio() {
-        if (currentExplanationAudio) {
-            currentExplanationAudio.pause();
-            currentExplanationAudio.currentTime = 0;
-            currentExplanationAudio = null;
-        }
+        currentAudio = new Audio(path);
+        currentAudio.onended = onended;
+        currentAudio.play();
     }
 
     function stopAudioPlayback() {
-        stopCurrentQuestionAudio();
-        stopCurrentAnswerAudio();
-        stopCurrentExplanationAudio();
+        try {
+            if (currentAudio) {
+                currentAudio.pause();
+                currentAudio.currentTime = 0;
+                currentAudio = null;
+            }
+        } catch {
+            // swallow play interrupt error
+        }
     }
 
     function getImageSource(image: string) {
         return illustrations[`./${data.collection}-${quiz?.id}-${image}`] ?? '';
     }
 
-    function shuffleAnswers(answerArray: QuizAnswer[]) {
-        let currentIndex = answerArray.length,
-            randomIndex;
-        while (currentIndex != 0) {
-            randomIndex = Math.floor(Math.random() * currentIndex);
-            currentIndex--;
-            [answerArray[currentIndex], answerArray[randomIndex]] = [
-                answerArray[randomIndex],
-                answerArray[currentIndex]
-            ];
-        }
-        return answerArray;
-    }
-
-    function shuffleArray<T>(array: T[]) {
-        let currentIndex = array.length,
-            randomIndex;
-
-        while (currentIndex !== 0) {
-            randomIndex = Math.floor(Math.random() * currentIndex);
-            currentIndex--;
-
-            [array[currentIndex], array[randomIndex]] = [array[randomIndex], array[currentIndex]];
-        }
-
-        return array;
-    }
-
-    function handleQuestionChange() {
-        explanation = '';
-        if (questionNum == quizQuestions.length) {
-            shuffledAnswers = [];
-            commentaryMessage = getCommentary(score);
-        } else {
-            currentQuizQuestion = quizQuestions[questionNum];
-            for (const answer of currentQuizQuestion.answers) {
-                answer.clicked = false;
-            }
-            shuffledAnswers = shuffleAnswers(currentQuizQuestion.answers);
-        }
-    }
-
     function getCommentary(score: number) {
-        let result = '';
-        for (const commentary of quiz?.commentary ?? []) {
-            if (
-                score >= commentary.rangeMin &&
-                (!commentary.rangeMax || score <= commentary.rangeMax)
-            ) {
-                result = commentary.message;
-                break;
-            }
-        }
-        return result;
+        return (
+            quiz?.commentary?.find(
+                (c) => score >= c.rangeMin && (!c.rangeMax || score <= c.rangeMax)
+            )?.message ?? ''
+        );
     }
 
-    function onNextQuestion() {
-        stopAudioPlayback();
-        questionNum++;
-        clicked = false;
-        displayCorrect = false;
-        handleQuestionChange();
-        playQuizQuestionAudio();
+    function nextQuestion() {
+        clearQuestion();
+        currentQuestionIdx++;
+        startQuestionAudio();
     }
 
-    function resetQuizState() {
+    function clearQuestion() {
         clicked = false;
-        displayCorrect = false;
-        shuffledAnswers = [];
+        showCorrectAnswer = false;
         explanation = '';
-        score = 0;
-        quizQuestions = [];
-        quizSaved = false;
-        questionNum = 0;
     }
 
-    function getAnswerAudio(quiz: Quiz | null, correct: boolean) {
-        let sound;
-        if (correct) {
-            sound = quiz?.rightAnswerAudio
-                ? clips[`./${getRandomAudio(quiz.rightAnswerAudio)}`]
-                : getQuizAssetAudio('quiz-right-answer.mp3');
-        } else {
-            sound = quiz?.wrongAnswerAudio
-                ? clips[`./${getRandomAudio(quiz.wrongAnswerAudio)}`]
-                : getQuizAssetAudio('quiz-wrong-answer.mp3');
-        }
-        return sound;
-    }
-
-    function onQuestionAnswered(answer: QuizAnswer) {
-        textHighlightIndex = -1;
+    function reset() {
         stopAudioPlayback();
+        clearQuestion();
+        score = 0;
+        saved = false;
+        currentQuestionIdx = 0;
+    }
+
+    function getAnswerAudio(correct: boolean) {
+        const key = correct ? 'rightAnswerAudio' : 'wrongAnswerAudio';
+        return quiz?.[key]?.length
+            ? clips[`./${getRandomItem(quiz[key])}`]
+            : getQuizAssetAudio(correct ? 'quiz-right-answer.mp3' : 'quiz-wrong-answer.mp3');
+    }
+
+    function answerQuestion(answer: QuizAnswer) {
+        highlightIdx = -1;
         if (!clicked) {
-            const answerAudio = getAnswerAudio(quiz, answer.correct);
-            const audioPath = `${base}/${answerAudio}`;
-            playSound(audioPath, () => {
-                if (!answer.correct && answer.explanation && answer.explanation.text) {
-                    explanation = answer.explanation.text;
-                    if (answer.explanation.audio) {
-                        playSound(clips[`./${answer.explanation.audio}`], null, 'explanation');
-                    }
-                } else if (!answer.correct && currentQuizQuestion?.explanation?.text) {
-                    explanation = currentQuizQuestion.explanation.text;
-                    if (currentQuizQuestion.explanation.audio) {
-                        playSound(
-                            clips[`./${currentQuizQuestion.explanation.audio}`],
-                            null,
-                            'explanation'
-                        );
+            const answerAudio = getAnswerAudio(answer.correct);
+            const currentIndex = currentQuestionIdx;
+            playSound(answerAudio, () => {
+                if (!answer.correct) {
+                    const e = answer.explanation || currentQuestion?.explanation;
+                    if (e?.text && currentIndex === currentQuestionIdx) {
+                        explanation = e.text;
+                        if (e.audio) {
+                            playSound(clips[`./${e.audio}`]);
+                        }
                     }
                 }
             });
@@ -253,79 +184,68 @@
                 answer.clicked = true;
                 clicked = true;
                 if (answer.correct) {
-                    displayCorrect = true;
+                    showCorrectAnswer = true;
                 } else {
                     setTimeout(() => {
-                        displayCorrect = true;
+                        showCorrectAnswer = true;
                     }, 1000);
                 }
             }, 0);
         }
     }
 
-    function playQuizQuestionAudio() {
+    function startQuestionAudio() {
         if ($quizAudioActive) {
-            const question = getCurrentQuizQuestion();
-            if (question) {
-                if (question.audio) {
+            if (currentQuestion) {
+                if (currentQuestion.audio) {
                     const listener = () => {
-                        playQuizAnswerAudio(0);
+                        playAnswerAudio(0);
                     };
-                    playSound(clips[`./${question.audio}`], listener, 'question');
+                    playSound(clips[`./${currentQuestion.audio}`], listener);
                 } else {
-                    playQuizAnswerAudio(0);
+                    playAnswerAudio(0);
                 }
             }
         }
     }
 
-    function playQuizAnswerAudio(answerIndex: number) {
-        if (currentQuizQuestion && $quizAudioActive) {
-            if (answerIndex < currentQuizQuestion.answers.length) {
-                const answer = currentQuizQuestion.answers[answerIndex];
+    function playAnswerAudio(answerIndex: number) {
+        if (currentQuestion && $quizAudioActive) {
+            if (answerIndex < shuffledAnswers.length) {
+                const answer = shuffledAnswers[answerIndex];
                 if (answer.audio) {
                     const listener = () => {
-                        textHighlightIndex = -1;
-                        playQuizAnswerAudio(answerIndex + 1);
+                        highlightIdx = -1;
+                        playAnswerAudio(answerIndex + 1);
                     };
-                    textHighlightIndex = answerIndex;
-                    playSound(clips[`./${answer.audio}`], listener, 'answer');
+                    highlightIdx = answerIndex;
+                    playSound(clips[`./${answer.audio}`], listener);
                 }
             } else {
-                textHighlightIndex = -1;
+                highlightIdx = -1;
             }
         }
     }
 
-    function getCurrentQuizQuestion() {
-        return quizQuestions[questionNum];
-    }
+    beforeNavigate(() => {
+        reset();
+    });
 
     onDestroy(() => {
         stopAudioPlayback();
     });
-    let { locked, quiz, quizId, quizName, passScore } = $derived(data);
-    let book = $derived(
-        scriptConfig.bookCollections
-            ?.find((x) => x.id === $refs.collection)
-            ?.books.find((x) => x.id === quizId)
-    );
-    let displayLabel = $derived(quizName || 'Quiz');
+
     $effect(() => {
-        resetQuizState();
         if (quiz) {
-            quizQuestions = book?.quizFeatures?.['shuffle-questions']
-                ? shuffleArray([...quiz.questions])
-                : [...quiz.questions];
-            handleQuestionChange();
-            playQuizQuestionAudio();
+            explanation = '';
+            startQuestionAudio();
         } else {
-            stopAudioPlayback();
+            reset();
         }
     });
 </script>
 
-<div class="grid grid-rows-[auto,1fr] h-screen" style:font-size="{$bodyFontSize}px">
+<div class="grid grid-rows-[auto,1fr] h-screen overflow-y-auto" style:font-size="{$bodyFontSize}px">
     <div class="navbar">
         <Navbar>
             {#snippet start()}
@@ -363,13 +283,13 @@
 
     {#if locked}
         <div class="quiz-locked">
-            <div class="quiz-locked-title">{data.quizId}</div>
+            <div class="quiz-locked-title">{quizId}</div>
             <div class="quiz-locked-message">
-                Before accessing this quiz, you need to pass the following quiz:
+                {$t['Quiz_Access_After_Message']}
             </div>
             <div class="quiz-locked-name">{data.dependentQuizName || data.dependentQuizId}</div>
         </div>
-    {:else if questionNum == quizQuestions.length}
+    {:else if currentQuestionIdx == questions.length}
         <div class="score">
             <div id="content" class="text-center">
                 <div class="quiz-score-before">{$t['Quiz_Score_Page_Message_Before']}</div>
@@ -377,16 +297,16 @@
                     <span class="quiz-score">{score}</span>
                 </div>
                 <div class="quiz-score-after">
-                    {$t['Quiz_Score_Page_Message_After'].replace('%n%', questionNum)}
+                    {$t['Quiz_Score_Page_Message_After'].replace('%n%', currentQuestionIdx)}
                 </div>
                 <div class="quiz-score-commentary">
                     {getCommentary(score)}
                 </div>
             </div>
         </div>
-        {#if !quizSaved}
+        {#if !saved}
             {@const pass = score >= passScore}
-            {#await addQuiz( { collection: data.collection, book: quizId, score, passScore, pass } ) then _}
+            {#await addQuiz({ collection, book: quizId, score, passScore, pass }) then _}
                 <p>Quiz result saved!</p>
             {:catch error}
                 <p>Error saving quiz result: {error.message}</p>
@@ -396,109 +316,61 @@
         <div class="quiz">
             <div id="content">
                 <div class="quiz-question-number" style:line-height="{$bodyLineHeight}%">
-                    {questionNum + 1}
+                    {currentQuestionIdx + 1}
                 </div>
-                {#if currentQuizQuestion?.answers}
-                    {#if currentQuizQuestion.answers.some((answer) => answer.text)}
-                        <div class="quiz-question-block">
-                            <div class="quiz-question" style:line-height="{$bodyLineHeight}%">
-                                {currentQuizQuestion.text}
-                                {#if currentQuizQuestion.image}
-                                    <!-- svelte-ignore a11y_missing_attribute -->
-                                    <img
-                                        class="quiz-question-image h-40"
-                                        src={getImageSource(currentQuizQuestion.image)}
-                                    />
-                                {/if}
-                            </div>
-                            <div class="quiz-answer-block">
-                                <div
-                                    class="grid grid-cols-{currentQuizQuestion.columns ??
-                                        1} justify-items-center"
-                                >
-                                    {#each shuffledAnswers as answer, currentIndex}
-                                        <button
-                                            class="w-5/6 md:w-64 lg:w-[20rem] mt-2"
-                                            onclick={() => {
-                                                onQuestionAnswered(answer);
-                                            }}
-                                        >
-                                            <div
-                                                class="quiz-answer"
-                                                class:textCorrectSelect={clicked &&
-                                                    answer.correct &&
-                                                    (answer.clicked || displayCorrect)}
-                                                class:textWrongSelect={clicked &&
-                                                    answer.clicked &&
-                                                    !answer.correct}
-                                                class:textHighlight={textHighlightIndex ===
-                                                    currentIndex}
-                                            >
-                                                {answer.text}
-                                            </div>
-                                        </button>
-                                    {/each}
-                                </div>
-                            </div>
-                            {#if explanation}
-                                <div class="quiz-answer-explanation mt-4">
-                                    {explanation}
-                                </div>
+                {#if currentQuestion?.answers}
+                    {@const imgFormat = currentQuestion.answers.some((answer) => answer.image)}
+                    {@const cols = (currentQuestion.columns ?? imgFormat) ? 2 : 1}
+                    <div class="quiz-question-block">
+                        <div class="quiz-question" style:line-height="{$bodyLineHeight}%">
+                            {currentQuestion.text}
+                            {#if currentQuestion.image && !imgFormat}
+                                <!-- svelte-ignore a11y_missing_attribute -->
+                                <img
+                                    class="quiz-question-image h-40"
+                                    src={getImageSource(currentQuestion.image)}
+                                />
                             {/if}
                         </div>
-                    {/if}
-                    {#if currentQuizQuestion?.answers.some((answer) => answer.image)}
-                        <div class="quiz-question-block">
-                            <div class="quiz-question">
-                                {currentQuizQuestion.text}
+                        <div class={[imgFormat ? 'flex justify-center' : 'quiz-answer-block']}>
+                            <div class="grid grid-cols-{cols} gap-2 justify-items-center">
+                                {#each shuffledAnswers as answer, currentIndex}
+                                    {@const classes: ClassValue = [
+                                        clicked && answer.correct && (answer.clicked || showCorrectAnswer) && 'correct', 
+                                        clicked && answer.clicked && !answer.correct && 'wrong', 
+                                        highlightIdx === currentIndex && 'highlight']}
+                                    <button
+                                        class={[
+                                            imgFormat
+                                                ? 'w-full flex justify-center p-[4%]'
+                                                : 'w-5/6 md:w-64 lg:w-[20rem] mt-2',
+                                            imgFormat && classes
+                                        ]}
+                                        onclick={() => {
+                                            answerQuestion(answer);
+                                        }}
+                                    >
+                                        {@render (imgFormat ? imgAnswer : textAnswer)(
+                                            answer,
+                                            classes
+                                        )}
+                                    </button>
+                                {/each}
                             </div>
-                            <div class="flex justify-center">
-                                <div
-                                    class="grid grid-cols-{currentQuizQuestion.columns ?? 2} gap-2"
-                                >
-                                    {#each shuffledAnswers as answer, currentIndex}
-                                        <div
-                                            class="w-full flex justify-center p-[4%]"
-                                            class:imageCorrectSelect={clicked &&
-                                                answer.correct &&
-                                                (answer.clicked || displayCorrect)}
-                                            class:imageWrongSelect={clicked &&
-                                                answer.clicked &&
-                                                !answer.correct}
-                                            class:textHighlight={textHighlightIndex ===
-                                                currentIndex}
-                                        >
-                                            <!-- svelte-ignore a11y_click_events_have_key_events -->
-                                            <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
-                                            <img
-                                                class="cursor-pointer"
-                                                src={getImageSource(answer.image ?? '')}
-                                                alt={answer.text}
-                                                onclick={() => {
-                                                    onQuestionAnswered(answer);
-                                                }}
-                                            />
-                                        </div>
-                                    {/each}
-                                </div>
-                            </div>
-                            {#if explanation}
-                                <div class="quiz-answer-explanation mt-4">
-                                    {explanation}
-                                </div>
-                            {/if}
+                        </div>
+                    </div>
+                    {#if explanation}
+                        <div class="quiz-answer-explanation mt-4">
+                            {explanation}
                         </div>
                     {/if}
                 {/if}
-                {#if displayCorrect}
-                    <div
-                        class="quiz-next-button arrow-ltr flex justify-center items-center"
-                        style="cursor: pointer;"
-                    >
+                {#if showCorrectAnswer}
+                    <div class="flex justify-center items-center">
                         <button
                             class="dy-btn dy-btn-active p-2 px-8 mt-4"
                             onclick={() => {
-                                onNextQuestion();
+                                nextQuestion();
                             }}
                         >
                             <ArrowForwardIcon />
@@ -510,26 +382,28 @@
     {/if}
 </div>
 
+{#snippet textAnswer(answer: QuizAnswer, classes: ClassValue)}
+    <div class={['quiz-answer', classes]}>
+        {answer.text}
+    </div>
+{/snippet}
+
+{#snippet imgAnswer(answer: QuizAnswer, _classes: ClassValue)}
+    <img src={getImageSource(answer.image ?? '')} alt={answer.text} />
+{/snippet}
+
 <style>
-    .imageWrongSelect {
-        color: rgb(255, 255, 255);
-        background-color: rgb(193, 27, 23);
+    .wrong {
+        color: var(--QuizWrongAnswerTextColor);
+        background-color: var(--QuizWrongAnswerBackgroundColor);
     }
-    .imageCorrectSelect {
-        color: rgb(255, 255, 255);
-        background-color: rgb(0, 128, 0);
+    .correct {
+        color: var(--QuizRightAnswerTextColor);
+        background-color: var(--QuizRightAnswerBackgroundColor);
     }
-    .textWrongSelect {
-        color: rgb(255, 255, 255);
-        background-color: rgb(193, 27, 23);
-    }
-    .textCorrectSelect {
-        color: rgb(255, 255, 255);
-        background-color: rgb(0, 128, 0);
-    }
-    .textHighlight {
-        color: rgb(0, 0, 0);
-        background-color: rgb(212, 212, 238);
+    .highlight {
+        color: var(--QuizAnswerTextColor);
+        background-color: var(--QuizAnswerHighlightBackgroundColor);
     }
     .quiz-question-block img {
         max-width: 100%;

--- a/src/routes/quiz/[collection]/[id]/+page.ts
+++ b/src/routes/quiz/[collection]/[id]/+page.ts
@@ -23,8 +23,8 @@ export const load: PageLoad = async ({ params, fetch }) => {
     let dependentQuizId: string | null = null;
     let dependentQuizName: string | null = null;
 
-    if (book?.quizFeatures?.['access-type'] === 'after') {
-        dependentQuizId = book.quizFeatures['access-after'];
+    if (book?.quizFeatures?.['access-type'] === 'after' && book.quizFeatures['access-after']) {
+        dependentQuizId = book.quizFeatures['access-after'] as string;
         const accessGranted = await checkQuizAccess(dependentQuizId);
         locked = !accessGranted;
     }

--- a/src/routes/quiz/[collection]/[id]/+page.ts
+++ b/src/routes/quiz/[collection]/[id]/+page.ts
@@ -1,39 +1,40 @@
+import type { Quiz, ScriptureConfig } from '$config';
 import config from '$lib/data/config';
 import { checkQuizAccess } from '$lib/data/quiz';
+import type { PageLoad } from './$types';
 
-/** @type {Record<string, string>} */
-const quizzes = import.meta.glob('./**/quizzes/*.json', {
+const quizzes: Record<string, string> = import.meta.glob('./**/quizzes/*.json', {
     import: 'default',
     eager: true,
     base: '/src/gen-assets/collections',
     query: '?url'
 });
 
-/** @type {import('./$types').PageLoad} */
-export async function load({ params, fetch }) {
+export const load: PageLoad = async ({ params, fetch }) => {
     const id = params.id;
     const collection = params.collection;
 
-    const bookCollection = config.bookCollections.find((x) => x.id === collection);
-    const book = bookCollection.books.find((x) => x.id === id);
+    const scriptConfig = config as ScriptureConfig;
+
+    const bookCollection = scriptConfig.bookCollections?.find((x) => x.id === collection);
+    const book = bookCollection?.books.find((x) => x.id === id);
 
     let locked = false;
-    let dependentQuizId = null;
-    let dependentQuizName = null;
+    let dependentQuizId: string | null = null;
+    let dependentQuizName: string | null = null;
 
-    if (book.quizFeatures['access-type'] === 'after') {
+    if (book?.quizFeatures?.['access-type'] === 'after') {
         dependentQuizId = book.quizFeatures['access-after'];
         const accessGranted = await checkQuizAccess(dependentQuizId);
         locked = !accessGranted;
     }
 
     if (locked && dependentQuizId) {
-        const dependentBook = bookCollection.books.find((x) => x.id === dependentQuizId);
+        const dependentBook = bookCollection?.books.find((x) => x.id === dependentQuizId);
         dependentQuizName = dependentBook ? dependentBook.name : dependentQuizId;
     }
 
-    let quizData;
-    let passScore = 0;
+    let quizData: Quiz | null = null;
     if (!locked) {
         try {
             const key = `./${collection}/quizzes/${id}.json`;
@@ -47,7 +48,6 @@ export async function load({ params, fetch }) {
             }
 
             quizData = await response.json();
-            passScore = quizData.passScore;
         } catch (error) {
             console.error('Error fetching quiz JSON file:', error);
         }
@@ -57,9 +57,9 @@ export async function load({ params, fetch }) {
         quiz: quizData,
         locked,
         quizId: id,
-        quizName: book.name,
+        quizName: book?.name,
         dependentQuizId,
         dependentQuizName,
-        passScore
+        passScore: quizData?.passScore ?? 0
     };
-}
+};

--- a/src/routes/quiz/[collection]/[id]/+page.ts
+++ b/src/routes/quiz/[collection]/[id]/+page.ts
@@ -56,6 +56,7 @@ export const load: PageLoad = async ({ params, fetch }) => {
     return {
         quiz: quizData,
         locked,
+        collection: params.collection,
         quizId: id,
         quizName: book?.name,
         dependentQuizId,

--- a/src/routes/quiz/[collection]/[id]/+page.ts
+++ b/src/routes/quiz/[collection]/[id]/+page.ts
@@ -58,7 +58,7 @@ export const load: PageLoad = async ({ params, fetch }) => {
         locked,
         collection: params.collection,
         quizId: id,
-        quizName: book?.name,
+        displayLabel: book?.name || 'Quiz',
         dependentQuizId,
         dependentQuizName,
         passScore: quizData?.passScore ?? 0

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -3,6 +3,7 @@ module.exports = {
     theme: {
         extend: {}
     },
+    safelist: [{ pattern: /grid-cols-/ }],
     //tailwind typography: https://daisyui.com/docs/layout-and-typography/
     //daisyui: https://daisyui.com/docs/use/
     plugins: [require('@tailwindcss/typography'), require('daisyui')],


### PR DESCRIPTION
Rebase of #888 with some improvements.

Original PR comment from #888:
- Replaces run() with effect() for reactivity
- Uses $state and $derived for all dynamic values
- Handles audio playback, quiz progression, and result saving
- Ensures full client-side functionality without server code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated quiz type handling and improved data loading for more reliable quizzes.
  * Reworked quiz page and state management for clearer question flow and score handling.

* **New / Improved UI**
  * Enhanced audio playback sequencing, answer highlighting, and explanation display.
  * Cleaner start/stop routines and more consistent saved/locked/score states.

* **Style**
  * Ensured dynamic grid column classes are preserved during CSS builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sillsdev/appbuilder-pwa/pull/958)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->