### PR TITLE
#489 Navigation properly hiding and displaying for empty chapters based on user selection

### DIFF
--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -261,7 +261,7 @@ The navbar component.
                         .filter(
                             (y) =>
                                 typeof chapters[y] === 'object' &&
-                                Object.keys(chapters[y]).length > 1
+                                Object.keys(chapters[y]).length > 0
                         )
                         .map((x) => ({
                             label: getChapterLabel(x),

--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -341,7 +341,7 @@ The navbar component.
                   bookLabel: 'abbreviation'
               })
             : bcv === c
-              ? chapterGridGroup(chapters)
+              ? chapterGridGroup()
               : verseGridGroup(chapter)}
         {menuaction}
     />

--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -248,9 +248,9 @@ The navbar component.
         return groups;
     };
 
-    let chapterGridGroup = (chapters: Record<string, unknown>) => {
+    let chapterGridGroup = () => {
         let hasIntroduction = books.find((x) => x.bookCode === book)?.hasIntroduction;
-
+        console.log(chapters);
         if (hideEmptyChapters) {
             return [
                 {
@@ -258,11 +258,7 @@ The navbar component.
                         ? [{ label: $t['Chapter_Introduction_Title'], id: 'i' }]
                         : null,
                     cells: Object.keys(chapters)
-                        .filter(
-                            (y) =>
-                                typeof chapters[y] === 'object' &&
-                                Object.keys(chapters[y]).length > 0
-                        )
+                        .filter((y) => Object.keys(chapters[y]).length > 0)
                         .map((x) => ({
                             label: getChapterLabel(x),
                             id: x

--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -250,7 +250,6 @@ The navbar component.
 
     let chapterGridGroup = () => {
         let hasIntroduction = books.find((x) => x.bookCode === book)?.hasIntroduction;
-        console.log(chapters);
         if (hideEmptyChapters) {
             return [
                 {

--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -36,6 +36,7 @@ The navbar component.
     const listView = $derived($userSettingsOrDefault['book-selection'] === 'list');
     const showVerseSelector = $derived($userSettingsOrDefault['verse-selection'] as boolean);
     const showSelectors = $derived(config.mainFeatures['book-select'] !== 'none');
+    const hideEmptyChapters = $derived(config.mainFeatures['hide-empty-chapters'] as boolean);
 
     // Translated book, chapter, and verse tab labels
     const b = $derived($t.Selector_Book);
@@ -249,17 +250,38 @@ The navbar component.
 
     let chapterGridGroup = (chapters: Record<string, unknown>) => {
         let hasIntroduction = books.find((x) => x.bookCode === book)?.hasIntroduction;
-        return [
-            {
-                rows: hasIntroduction
-                    ? [{ label: $t['Chapter_Introduction_Title'], id: 'i' }]
-                    : null,
-                cells: Object.keys(chapters).map((x) => ({
-                    label: getChapterLabel(x),
-                    id: x
-                }))
-            }
-        ];
+
+        if (hideEmptyChapters) {
+            return [
+                {
+                    rows: hasIntroduction
+                        ? [{ label: $t['Chapter_Introduction_Title'], id: 'i' }]
+                        : null,
+                    cells: Object.keys(chapters)
+                        .filter(
+                            (y) =>
+                                typeof chapters[y] === 'object' &&
+                                Object.keys(chapters[y]).length > 1
+                        )
+                        .map((x) => ({
+                            label: getChapterLabel(x),
+                            id: x
+                        }))
+                }
+            ];
+        } else {
+            return [
+                {
+                    rows: hasIntroduction
+                        ? [{ label: $t['Chapter_Introduction_Title'], id: 'i' }]
+                        : null,
+                    cells: Object.keys(chapters).map((x) => ({
+                        label: getChapterLabel(x),
+                        id: x
+                    }))
+                }
+            ];
+        }
     };
     let verseGridGroup = (chapter: string) => {
         let value;

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -181,7 +181,7 @@ The navbar component.
                             ]
                           : undefined,
                       cells: Object.keys(chapters)
-                          .filter((y) => Object.keys(chapters[y]).length > 0 && hideEmptyChapters)
+                          .filter((y) => !hideEmptyChapters || Object.keys(chapters[y]).length > 0)
                           .map((x) => ({
                               label: getChapterLabel(x),
                               id: x

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -19,6 +19,7 @@ The navbar component.
     const book = $derived($nextRef.book === '' ? $refs.book : $nextRef.book);
     const chapter = $derived($nextRef.chapter === '' ? $refs.chapter : $nextRef.chapter);
     const showVerseSelector = $derived($userSettingsOrDefault['verse-selection']) as boolean;
+    const hideEmptyChapters = $derived(config.mainFeatures['hide-empty-chapters'] as boolean);
     const verseCount = $derived(getVerseCount(book, chapter));
     const numeralSystem = $derived(numerals.systemForBook(config, $refs.collection, book));
     const chaptersLabels = $derived(
@@ -179,10 +180,18 @@ The navbar component.
                                 }
                             ]
                           : undefined,
-                      cells: Object.keys(chapters).map((x) => ({
-                          label: getChapterLabel(x),
-                          id: x
-                      }))
+                      cells: hideEmptyChapters
+                          ? Object.keys(chapters)
+                                .filter(
+                                    (y) =>
+                                        typeof chapters[y] === 'object' &&
+                                        Object.keys(chapters[y]).length > 1
+                                )
+                                .map((x) => ({
+                                    label: getChapterLabel(x),
+                                    id: x
+                                }))
+                          : Object.keys(chapters).map((x) => ({ label: getChapterLabel(x), id: x }))
                   }
               ]
             : verseGridGroup(chapter)}

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -180,18 +180,12 @@ The navbar component.
                                 }
                             ]
                           : undefined,
-                      cells: hideEmptyChapters
-                          ? Object.keys(chapters)
-                                .filter(
-                                    (y) =>
-                                        typeof chapters[y] === 'object' &&
-                                        Object.keys(chapters[y]).length > 0
-                                )
-                                .map((x) => ({
-                                    label: getChapterLabel(x),
-                                    id: x
-                                }))
-                          : Object.keys(chapters).map((x) => ({ label: getChapterLabel(x), id: x }))
+                      cells: Object.keys(chapters)
+                          .filter((y) => Object.keys(chapters[y]).length > 0 && hideEmptyChapters)
+                          .map((x) => ({
+                              label: getChapterLabel(x),
+                              id: x
+                          }))
                   }
               ]
             : verseGridGroup(chapter)}

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -185,7 +185,7 @@ The navbar component.
                                 .filter(
                                     (y) =>
                                         typeof chapters[y] === 'object' &&
-                                        Object.keys(chapters[y]).length > 1
+                                        Object.keys(chapters[y]).length > 0
                                 )
                                 .map((x) => ({
                                     label: getChapterLabel(x),

--- a/src/lib/components/HistoryCard.svelte
+++ b/src/lib/components/HistoryCard.svelte
@@ -34,7 +34,7 @@ TODO:
     function onHistoryClick() {
         if (history.url) {
             // the url should have the full path??
-            // eslint-disable-next-line svelte/no-navigation-without-resolve
+             
             goto(history.url);
         } else if (docSet) {
             refs.set({

--- a/src/lib/components/HistoryCard.svelte
+++ b/src/lib/components/HistoryCard.svelte
@@ -34,7 +34,7 @@ TODO:
     function onHistoryClick() {
         if (history.url) {
             // the url should have the full path??
-             
+            // eslint-disable-next-line svelte/no-navigation-without-resolve
             goto(history.url);
         } else if (docSet) {
             refs.set({


### PR DESCRIPTION
Fix for users selecting "Hide empty chapters" in SAB, but the PWA still displays them. 

Also ensured that unchecking "Hide empty chapters" also shows those missing chapters in the navigation.

The initial issue is https://github.com/sillsdev/appbuilder-pwa/issues/489.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to hide empty chapters in book and chapter selection interfaces.

* **Bug Fixes**
  * Fixed an issue where disabling the hide-empty option could result in missing chapters; selection now shows chapters correctly when the option is off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->