### PR TITLE
Implement Video Download Button for Verse On Image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "13.3.2",
             "dependencies": {
                 "html-to-image": "^1.11.11",
+                "mediabunny": "^1.45.4",
                 "sql.js": "^1.13.0"
             },
             "devDependencies": {
@@ -4567,6 +4568,21 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/dom-mediacapture-transform": {
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.11.tgz",
+            "integrity": "sha512-Y2p+nGf1bF2XMttBnsVPHUWzRRZzqUoJAKmiP10b5umnO6DDrWI0BrGDJy1pOHoOULVmGSfFNkQrAlC5dcj6nQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/dom-webcodecs": "*"
+            }
+        },
+        "node_modules/@types/dom-webcodecs": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz",
+            "integrity": "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==",
+            "license": "MIT"
+        },
         "node_modules/@types/emscripten": {
             "version": "1.41.5",
             "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
@@ -8298,6 +8314,24 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/mediabunny": {
+            "version": "1.45.4",
+            "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.45.4.tgz",
+            "integrity": "sha512-NtJl4va2wUhkNDAsS9ZVkK8cP54DK3jvqgQOf4h3DV5j8GS0rOXHCQTbjZehOkhrfUPLA5qls/zEtMAuGiVCyw==",
+            "license": "MPL-2.0",
+            "workspaces": [
+                ".",
+                "packages/*"
+            ],
+            "dependencies": {
+                "@types/dom-mediacapture-transform": "^0.1.11",
+                "@types/dom-webcodecs": "0.1.13"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://github.com/sponsors/Vanilagy"
             }
         },
         "node_modules/merge2": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     },
     "dependencies": {
         "html-to-image": "^1.11.11",
+        "mediabunny": "^1.45.4",
         "sql.js": "^1.13.0"
     }
 }

--- a/src/lib/components/DownloadSelector.svelte
+++ b/src/lib/components/DownloadSelector.svelte
@@ -32,12 +32,12 @@ A component for verse-on-image providing a dropdown where you can choose to down
             <ImageIcon.Image />
             {$t['Text_On_Image_Save_Image']}
         </button>
-        <!--<button
+        <button
             class="dy-btn dy-btn-sm flex items-center justify-center gap-2"
             onclick={() => downloadVideo()}
         >
             <VideoIcon />
             {$t['Text_On_Image_Save_Video']}
-        </button>-->
+        </button>
     </div>
 </Modal>

--- a/src/lib/components/VerseOnImage.svelte
+++ b/src/lib/components/VerseOnImage.svelte
@@ -16,6 +16,7 @@ The verse on image component.
         refs,
         s,
         selectedVerses,
+        t,
         themeColors,
         voiCustomImage,
         windowSize
@@ -1242,8 +1243,8 @@ The verse on image component.
               flex flex-col justify-between h-64"
         >
             <div class="flex flex-col gap-1 text-left">
-                <p class="text-lg font-bold">Save Video</p>
-                <p class="text-sm">Creating video...</p>
+                <p class="text-lg font-bold">{$t['Text_On_Image_Save_Video']}</p>
+                <p class="text-sm">{$t['Video_Creating_Video']}</p>
             </div>
 
             <div class="w-full">
@@ -1255,7 +1256,7 @@ The verse on image component.
                     class="dy-btn dy-btn-sm dy-btn-ghost"
                     onclick={() => {
                         cancelDownload = true;
-                    }}>Cancel</button
+                    }}>{$t['Button_Cancel']}</button
                 >
             </div>
         </div>

--- a/src/lib/components/VerseOnImage.svelte
+++ b/src/lib/components/VerseOnImage.svelte
@@ -1,17 +1,22 @@
 <!--
 @component
 The verse on image component.
+TODO: 
+Make the video download button not show up if there isn't audio or a timing file for that chapter
+Make some sort of popup indicating that the video is downloading
 -->
 <script lang="ts">
     import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';
     import { scriptureConfig } from '$assets/config';
     import FontList from '$lib/components/FontList.svelte';
+    import { getAudioSourceInfo } from '$lib/data/audio';
     import { shareImage } from '$lib/data/share';
     import {
         currentFont,
         direction,
         monoIconColor,
+        refs,
         s,
         selectedVerses,
         themeColors,
@@ -22,6 +27,22 @@ The verse on image component.
     import { ImageIcon } from '$lib/icons/image';
     import ImagesIcon from '$lib/icons/image/ImagesIcon.svelte';
     import { toPng } from 'html-to-image';
+    import {
+        AudioBufferSource,
+        BufferTarget,
+        canEncodeAudio,
+        Mp4OutputFormat,
+        Output,
+        QUALITY_HIGH,
+        VideoSample,
+        VideoSampleSource,
+        WebMOutputFormat
+    } from 'mediabunny';
+    import type {
+        AudioCodec,
+        AudioEncodingAdditionalOptions,
+        AudioEncodingConfig
+    } from 'mediabunny';
     import { onDestroy, onMount } from 'svelte';
     import ColorPicker from 'svelte-awesome-color-picker';
     import Slider from './Slider.svelte';
@@ -427,6 +448,159 @@ The verse on image component.
                 }
             });
     }
+    async function pickSupportedAudioConfig() {
+        const candidates: AudioEncodingConfig[] = [
+            { codec: 'aac', bitrate: 128000 },
+            { codec: 'aac', bitrate: 96000 },
+            { codec: 'aac', bitrate: 64000 },
+            {
+                codec: 'opus',
+                bitrate: 96000
+            }
+        ];
+
+        for (const cfg of candidates) {
+            if (await canEncodeAudio(cfg.codec, cfg)) {
+                return cfg;
+            }
+        }
+
+        throw new Error('No supported AAC configuration found.');
+    } //This is used to determine a supported audio configuration. It first tries AAC (Which can be used for mp4 files), but then falls back to opus (And thus a webm file) if AAC isn't supported
+
+    export async function downloadVideo() {
+        console.log('Video download started');
+        const original = document.getElementById('verseOnImgPreview');
+        if (!original) {
+            console.error('Error getting preview to export');
+            return;
+        }
+
+        const clone = original.cloneNode(true) as HTMLElement; //Clone the verse on image so we can make adjustments to it for the export without affecting the preview.
+
+        const origCanvas = original.querySelector('canvas');
+        const cloneCanvas = clone.querySelector('canvas');
+        if (!cloneCanvas || !origCanvas) {
+            console.error('Error getting canvas to export');
+            return;
+        }
+        cloneCanvas.width = origCanvas.width & -1;
+        cloneCanvas.height = origCanvas.height & -1;
+        const ctx = cloneCanvas.getContext('2d');
+        if (ctx) {
+            ctx.drawImage(origCanvas, 0, 0); //Copy the canvas bitmap.
+        }
+
+        clone.style.position = 'absolute';
+        clone.style.left = '0px';
+        clone.style.top = '0px';
+        clone.style.zIndex = '-9999'; //Make sure the clone isn't visible
+
+        var cloneParagraph = clone.querySelector('p');
+        const parentRect = parentDiv.getBoundingClientRect();
+        if (cloneParagraph) {
+            cloneParagraph.style.left = textX - parentRect.left + 'px';
+            cloneParagraph.style.top = textY - parentRect.top + 'px'; //Adjust the textbox so it shows up in the correct place
+        }
+
+        document.body.appendChild(clone);
+        const pngUrl = await toPng(clone);
+        const img = new Image();
+        img.src = pngUrl;
+        await img.decode();
+        const bitmap = await createImageBitmap(img, {
+            resizeWidth: img.width & ~1, // force even
+            resizeHeight: img.height & ~1, // force even
+            resizeQuality: 'high'
+        });
+
+        const frame = new VideoFrame(bitmap, {
+            timestamp: 0,
+            duration: 1_000_000
+        });
+        const sample = new VideoSample(frame);
+
+        const audioConfig: AudioEncodingConfig = await pickSupportedAudioConfig();
+
+        const output = new Output({
+            format: audioConfig.codec === 'opus' ? new WebMOutputFormat() : new Mp4OutputFormat(),
+            target: new BufferTarget()
+        });
+        const videoSource = new VideoSampleSource({
+            codec: audioConfig.codec === 'opus' ? 'vp9' : 'avc',
+            bitrate: QUALITY_HIGH
+        });
+
+        output.addVideoTrack(videoSource);
+
+        const audioSourceInfo = await getAudioSourceInfo({
+            collection: $refs.collection,
+            book: $refs.book,
+            chapter: $refs.chapter
+        });
+
+        const audioSource = new AudioBufferSource(audioConfig);
+        output.addAudioTrack(audioSource);
+        await output.start();
+        await videoSource.add(sample);
+
+        const audioBlob = await fetch(audioSourceInfo?.source).then((r) => r.blob());
+        const audioCtx = new AudioContext();
+        const audioBuffer = await audioCtx.decodeAudioData(await audioBlob.arrayBuffer());
+
+        const sampleRate = audioBuffer.sampleRate;
+
+        for (let i = 0; i < $selectedVerses.length; i++) {
+            let startFrame = 0;
+            let endFrame = 0;
+            for (var j = 0; j < (audioSourceInfo?.timing?.length || 0); j++) {
+                const timing = audioSourceInfo?.timing?.[j];
+                const verse = timing?.tag?.replace(/\D/g, '');
+                if (verse === $selectedVerses[i].verse) {
+                    if (!startFrame) {
+                        startFrame = Math.floor((timing?.starttime || 0) * sampleRate);
+                        endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
+                    } else {
+                        endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
+                    }
+                }
+            }
+            const trimmedBuffer = audioCtx.createBuffer(
+                audioBuffer.numberOfChannels,
+                endFrame - startFrame,
+                sampleRate
+            );
+
+            for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
+                const src = audioBuffer.getChannelData(ch);
+                const dst = trimmedBuffer.getChannelData(ch);
+                dst.set(src.slice(startFrame, endFrame));
+            }
+
+            await audioSource.add(trimmedBuffer);
+        }
+        await output.finalize();
+
+        const buffer = output.target.buffer as BlobPart;
+        const blob = new Blob([buffer], {
+            type: audioConfig.codec === 'opus' ? 'video/webm' : 'video/mp4'
+        });
+        const filename = reference + (audioConfig.codec === 'opus' ? '.webm' : '.mp4');
+        const file = new File([blob], filename, {
+            type: audioConfig.codec === 'opus' ? 'video/webm' : 'video/mp4'
+        });
+        document.body.removeChild(clone);
+        sample.close();
+        const url = URL.createObjectURL(file);
+
+        const anchor = document.createElement('a');
+        anchor.href = url;
+        anchor.download = filename;
+        anchor.click();
+
+        URL.revokeObjectURL(url);
+        console.log('Video download done');
+    } //Most of this is AI-generated, so serious testing is needed. I've done a lot of testing, but it would be good to make sure there aren't subtle problems with this code.
 
     // EditorTabs centering feature:
 

--- a/src/lib/components/VerseOnImage.svelte
+++ b/src/lib/components/VerseOnImage.svelte
@@ -524,14 +524,14 @@ The verse on image component.
             sample = new VideoSample(frame);
 
             const audioConfig: AudioEncodingConfig = await pickSupportedAudioConfig();
+            const useWebm = audioConfig.codec === 'opus';
 
             const output = new Output({
-                format:
-                    audioConfig.codec === 'opus' ? new WebMOutputFormat() : new Mp4OutputFormat(),
+                format: useWebm ? new WebMOutputFormat() : new Mp4OutputFormat(),
                 target: new BufferTarget()
             });
             const videoSource = new VideoSampleSource({
-                codec: audioConfig.codec === 'opus' ? 'vp9' : 'avc',
+                codec: useWebm ? 'vp9' : 'avc',
                 bitrate: QUALITY_HIGH
             });
 
@@ -621,11 +621,11 @@ The verse on image component.
 
             const buffer = output.target.buffer as BlobPart;
             const blob = new Blob([buffer], {
-                type: audioConfig.codec === 'opus' ? 'video/webm' : 'video/mp4'
+                type: useWebm ? 'video/webm' : 'video/mp4'
             });
-            const filename = reference + (audioConfig.codec === 'opus' ? '.webm' : '.mp4');
+            const filename = reference + (useWebm ? '.webm' : '.mp4');
             const file = new File([blob], filename, {
-                type: audioConfig.codec === 'opus' ? 'video/webm' : 'video/mp4'
+                type: useWebm ? 'video/webm' : 'video/mp4'
             });
             downloadProgress = 90;
             const url = URL.createObjectURL(file);

--- a/src/lib/components/VerseOnImage.svelte
+++ b/src/lib/components/VerseOnImage.svelte
@@ -482,8 +482,8 @@ The verse on image component.
                 console.error('Error getting canvas to export');
                 return;
             }
-            cloneCanvas.width = origCanvas.width & -1;
-            cloneCanvas.height = origCanvas.height & -1;
+            cloneCanvas.width = origCanvas.width & ~1;
+            cloneCanvas.height = origCanvas.height & ~1;
             const ctx = cloneCanvas.getContext('2d');
             if (ctx) {
                 ctx.drawImage(origCanvas, 0, 0); //Copy the canvas bitmap.
@@ -545,6 +545,9 @@ The verse on image component.
                 book: $refs.book,
                 chapter: $refs.chapter
             });
+            if (!audioSourceInfo?.source) {
+                throw new Error('No audio source available for this chapter');
+            }
             downloadProgress = 30;
             if (cancelDownload) {
                 return;
@@ -595,6 +598,10 @@ The verse on image component.
                             endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
                         }
                     }
+                }
+                if (endFrame <= startFrame) {
+                    console.warn(`No timing found for verse ${$selectedVerses[i].verse}, skipping`);
+                    continue;
                 }
                 const trimmedBuffer = audioCtx.createBuffer(
                     audioBuffer.numberOfChannels,

--- a/src/lib/components/VerseOnImage.svelte
+++ b/src/lib/components/VerseOnImage.svelte
@@ -462,201 +462,189 @@ The verse on image component.
     } //This is used to determine a supported audio configuration. It first tries AAC (Which can be used for mp4 files), but then falls back to opus (And thus a webm file) if AAC isn't supported
     let cancelDownload = false;
     export async function downloadVideo() {
+        cancelDownload = false;
+        let clone: HTMLElement | undefined;
+        let sample: VideoSample | undefined;
         downloadProgress = 1;
-        const original = document.getElementById('verseOnImgPreview');
-        if (!original) {
-            console.error('Error getting preview to export');
-            return;
-        }
+        try {
+            const original = document.getElementById('verseOnImgPreview');
+            if (!original) {
+                console.error('Error getting preview to export');
+                return;
+            }
 
-        const clone = original.cloneNode(true) as HTMLElement; //Clone the verse on image so we can make adjustments to it for the export without affecting the preview.
+            clone = original.cloneNode(true) as HTMLElement; //Clone the verse on image so we can make adjustments to it for the export without affecting the preview.
 
-        const origCanvas = original.querySelector('canvas');
-        const cloneCanvas = clone.querySelector('canvas');
-        if (!cloneCanvas || !origCanvas) {
-            console.error('Error getting canvas to export');
-            return;
-        }
-        cloneCanvas.width = origCanvas.width & -1;
-        cloneCanvas.height = origCanvas.height & -1;
-        const ctx = cloneCanvas.getContext('2d');
-        if (ctx) {
-            ctx.drawImage(origCanvas, 0, 0); //Copy the canvas bitmap.
-        }
+            const origCanvas = original.querySelector('canvas');
+            const cloneCanvas = clone.querySelector('canvas');
+            if (!cloneCanvas || !origCanvas) {
+                console.error('Error getting canvas to export');
+                return;
+            }
+            cloneCanvas.width = origCanvas.width & -1;
+            cloneCanvas.height = origCanvas.height & -1;
+            const ctx = cloneCanvas.getContext('2d');
+            if (ctx) {
+                ctx.drawImage(origCanvas, 0, 0); //Copy the canvas bitmap.
+            }
 
-        clone.style.position = 'absolute';
-        clone.style.left = '0px';
-        clone.style.top = '0px';
-        clone.style.zIndex = '-9999'; //Make sure the clone isn't visible
+            clone.style.position = 'absolute';
+            clone.style.left = '0px';
+            clone.style.top = '0px';
+            clone.style.zIndex = '-9999'; //Make sure the clone isn't visible
 
-        var cloneParagraph = clone.querySelector('p');
-        const parentRect = parentDiv.getBoundingClientRect();
-        if (cloneParagraph) {
-            cloneParagraph.style.left = textX - parentRect.left + 'px';
-            cloneParagraph.style.top = textY - parentRect.top + 'px'; //Adjust the textbox so it shows up in the correct place
-        }
+            var cloneParagraph = clone.querySelector('p');
+            const parentRect = parentDiv.getBoundingClientRect();
+            if (cloneParagraph) {
+                cloneParagraph.style.left = textX - parentRect.left + 'px';
+                cloneParagraph.style.top = textY - parentRect.top + 'px'; //Adjust the textbox so it shows up in the correct place
+            }
 
-        document.body.appendChild(clone);
-        const pngUrl = await toPng(clone);
-        const img = new Image();
-        img.src = pngUrl;
-        await img.decode();
-        const bitmap = await createImageBitmap(img, {
-            resizeWidth: img.width & ~1, // force even
-            resizeHeight: img.height & ~1, // force even
-            resizeQuality: 'high'
-        });
-        downloadProgress = 10;
-        if (cancelDownload) {
-            document.body.removeChild(clone);
-            cancelDownload = false;
-            downloadProgress = 0;
-            return;
-        }
+            document.body.appendChild(clone);
+            const pngUrl = await toPng(clone);
+            const img = new Image();
+            img.src = pngUrl;
+            await img.decode();
+            const bitmap = await createImageBitmap(img, {
+                resizeWidth: img.width & ~1, // force even
+                resizeHeight: img.height & ~1, // force even
+                resizeQuality: 'high'
+            });
+            downloadProgress = 10;
+            if (cancelDownload) {
+                return;
+            }
 
-        const frame = new VideoFrame(bitmap, {
-            timestamp: 0,
-            duration: 1_000_000
-        });
-        const sample = new VideoSample(frame);
+            const frame = new VideoFrame(bitmap, {
+                timestamp: 0,
+                duration: 1_000_000
+            });
+            sample = new VideoSample(frame);
 
-        const audioConfig: AudioEncodingConfig = await pickSupportedAudioConfig();
+            const audioConfig: AudioEncodingConfig = await pickSupportedAudioConfig();
 
-        const output = new Output({
-            format: audioConfig.codec === 'opus' ? new WebMOutputFormat() : new Mp4OutputFormat(),
-            target: new BufferTarget()
-        });
-        const videoSource = new VideoSampleSource({
-            codec: audioConfig.codec === 'opus' ? 'vp9' : 'avc',
-            bitrate: QUALITY_HIGH
-        });
+            const output = new Output({
+                format:
+                    audioConfig.codec === 'opus' ? new WebMOutputFormat() : new Mp4OutputFormat(),
+                target: new BufferTarget()
+            });
+            const videoSource = new VideoSampleSource({
+                codec: audioConfig.codec === 'opus' ? 'vp9' : 'avc',
+                bitrate: QUALITY_HIGH
+            });
 
-        output.addVideoTrack(videoSource);
-        downloadProgress = 20;
-        if (cancelDownload) {
-            document.body.removeChild(clone);
-            sample.close();
-            cancelDownload = false;
-            downloadProgress = 0;
-            return;
-        }
+            output.addVideoTrack(videoSource);
+            downloadProgress = 20;
+            if (cancelDownload) {
+                return;
+            }
 
-        const audioSourceInfo = await getAudioSourceInfo({
-            collection: $refs.collection,
-            book: $refs.book,
-            chapter: $refs.chapter
-        });
-        downloadProgress = 30;
-        if (cancelDownload) {
-            document.body.removeChild(clone);
-            sample.close();
-            cancelDownload = false;
-            downloadProgress = 0;
-            return;
-        }
+            const audioSourceInfo = await getAudioSourceInfo({
+                collection: $refs.collection,
+                book: $refs.book,
+                chapter: $refs.chapter
+            });
+            downloadProgress = 30;
+            if (cancelDownload) {
+                return;
+            }
 
-        const audioSource = new AudioBufferSource(audioConfig);
-        output.addAudioTrack(audioSource);
-        await output.start();
-        downloadProgress = 40;
-        if (cancelDownload) {
-            document.body.removeChild(clone);
-            sample.close();
-            cancelDownload = false;
-            downloadProgress = 0;
-            return;
-        }
-        await videoSource.add(sample);
-        downloadProgress = 50;
-        if (cancelDownload) {
-            document.body.removeChild(clone);
-            sample.close();
-            cancelDownload = false;
-            downloadProgress = 0;
-            return;
-        }
+            const audioSource = new AudioBufferSource(audioConfig);
+            output.addAudioTrack(audioSource);
+            await output.start();
+            downloadProgress = 40;
+            if (cancelDownload) {
+                return;
+            }
+            await videoSource.add(sample);
+            downloadProgress = 50;
+            if (cancelDownload) {
+                return;
+            }
 
-        const audioBlob = await fetch(audioSourceInfo?.source).then((r) => r.blob());
-        downloadProgress = 60;
-        if (cancelDownload) {
-            document.body.removeChild(clone);
-            sample.close();
-            cancelDownload = false;
-            downloadProgress = 0;
-            return;
-        }
-        const audioCtx = new AudioContext();
-        const audioBuffer = await audioCtx.decodeAudioData(await audioBlob.arrayBuffer());
-        downloadProgress = 70;
-        if (cancelDownload) {
-            document.body.removeChild(clone);
-            sample.close();
-            cancelDownload = false;
-            downloadProgress = 0;
-            return;
-        }
+            const audioBlob = await fetch(audioSourceInfo?.source).then((r) => r.blob());
+            downloadProgress = 60;
+            if (cancelDownload) {
+                document.body.removeChild(clone);
+                sample.close();
+                cancelDownload = false;
+                downloadProgress = 0;
+                return;
+            }
+            const audioCtx = new AudioContext();
+            const audioBuffer = await audioCtx.decodeAudioData(await audioBlob.arrayBuffer());
+            downloadProgress = 70;
+            if (cancelDownload) {
+                return;
+            }
 
-        const sampleRate = audioBuffer.sampleRate;
+            const sampleRate = audioBuffer.sampleRate;
 
-        for (let i = 0; i < $selectedVerses.length; i++) {
-            let startFrame = 0;
-            let endFrame = 0;
-            for (var j = 0; j < (audioSourceInfo?.timing?.length || 0); j++) {
-                const timing = audioSourceInfo?.timing?.[j];
-                const verse = timing?.tag?.replace(/\D/g, '');
-                if (verse === $selectedVerses[i].verse) {
-                    if (!startFrame) {
-                        startFrame = Math.floor((timing?.starttime || 0) * sampleRate);
-                        endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
-                    } else {
-                        endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
+            for (let i = 0; i < $selectedVerses.length; i++) {
+                let startFrame = 0;
+                let endFrame = 0;
+                for (var j = 0; j < (audioSourceInfo?.timing?.length || 0); j++) {
+                    const timing = audioSourceInfo?.timing?.[j];
+                    const verse = timing?.tag?.replace(/\D/g, '');
+                    if (verse === $selectedVerses[i].verse) {
+                        if (!startFrame) {
+                            startFrame = Math.floor((timing?.starttime || 0) * sampleRate);
+                            endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
+                        } else {
+                            endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
+                        }
                     }
                 }
-            }
-            const trimmedBuffer = audioCtx.createBuffer(
-                audioBuffer.numberOfChannels,
-                endFrame - startFrame,
-                sampleRate
-            );
+                const trimmedBuffer = audioCtx.createBuffer(
+                    audioBuffer.numberOfChannels,
+                    endFrame - startFrame,
+                    sampleRate
+                );
 
-            for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
-                const src = audioBuffer.getChannelData(ch);
-                const dst = trimmedBuffer.getChannelData(ch);
-                dst.set(src.slice(startFrame, endFrame));
+                for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
+                    const src = audioBuffer.getChannelData(ch);
+                    const dst = trimmedBuffer.getChannelData(ch);
+                    dst.set(src.slice(startFrame, endFrame));
+                }
+
+                await audioSource.add(trimmedBuffer);
+            }
+            await output.finalize();
+            downloadProgress = 80;
+            if (cancelDownload) {
+                return;
             }
 
-            await audioSource.add(trimmedBuffer);
-        }
-        await output.finalize();
-        downloadProgress = 80;
-        if (cancelDownload) {
+            const buffer = output.target.buffer as BlobPart;
+            const blob = new Blob([buffer], {
+                type: audioConfig.codec === 'opus' ? 'video/webm' : 'video/mp4'
+            });
+            const filename = reference + (audioConfig.codec === 'opus' ? '.webm' : '.mp4');
+            const file = new File([blob], filename, {
+                type: audioConfig.codec === 'opus' ? 'video/webm' : 'video/mp4'
+            });
+            downloadProgress = 90;
             document.body.removeChild(clone);
             sample.close();
+            downloadProgress = 0;
+            const url = URL.createObjectURL(file);
+
+            const anchor = document.createElement('a');
+            anchor.href = url;
+            anchor.download = filename;
+            anchor.click();
+
+            URL.revokeObjectURL(url);
+        } catch (error) {
+            console.error('Error generating video export:', error);
+        } finally {
+            if (clone?.isConnected) {
+                document.body.removeChild(clone);
+            }
+            sample?.close();
             cancelDownload = false;
             downloadProgress = 0;
-            return;
         }
-
-        const buffer = output.target.buffer as BlobPart;
-        const blob = new Blob([buffer], {
-            type: audioConfig.codec === 'opus' ? 'video/webm' : 'video/mp4'
-        });
-        const filename = reference + (audioConfig.codec === 'opus' ? '.webm' : '.mp4');
-        const file = new File([blob], filename, {
-            type: audioConfig.codec === 'opus' ? 'video/webm' : 'video/mp4'
-        });
-        downloadProgress = 90;
-        document.body.removeChild(clone);
-        sample.close();
-        downloadProgress = 0;
-        const url = URL.createObjectURL(file);
-
-        const anchor = document.createElement('a');
-        anchor.href = url;
-        anchor.download = filename;
-        anchor.click();
-
-        URL.revokeObjectURL(url);
     } //Most of this is AI-generated, so serious testing is needed. I've done a lot of testing, but it would be good to make sure there aren't subtle problems with this code.
 
     // EditorTabs centering feature:

--- a/src/lib/components/VerseOnImage.svelte
+++ b/src/lib/components/VerseOnImage.svelte
@@ -38,11 +38,7 @@ Make some sort of popup indicating that the video is downloading
         VideoSampleSource,
         WebMOutputFormat
     } from 'mediabunny';
-    import type {
-        AudioCodec,
-        AudioEncodingAdditionalOptions,
-        AudioEncodingConfig
-    } from 'mediabunny';
+    import type { AudioEncodingConfig } from 'mediabunny';
     import { onDestroy, onMount } from 'svelte';
     import ColorPicker from 'svelte-awesome-color-picker';
     import Slider from './Slider.svelte';

--- a/src/lib/components/VerseOnImage.svelte
+++ b/src/lib/components/VerseOnImage.svelte
@@ -1247,12 +1247,12 @@ The verse on image component.
             </div>
 
             <div class="w-full">
-                <progress class="progress w-full" value={downloadProgress} max="100"></progress>
+                <progress class="dy-progress w-full" value={downloadProgress} max="100"></progress>
             </div>
 
             <div class="flex justify-end">
                 <button
-                    class="btn btn-sm btn-ghost"
+                    class="dy-btn dy-btn-sm dy-btn-ghost"
                     onclick={() => {
                         cancelDownload = true;
                     }}>Cancel</button

--- a/src/lib/components/VerseOnImage.svelte
+++ b/src/lib/components/VerseOnImage.svelte
@@ -1255,6 +1255,7 @@ The verse on image component.
                 <button
                     class="dy-btn dy-btn-sm dy-btn-ghost"
                     onclick={() => {
+                        downloadProgress = 0;
                         cancelDownload = true;
                     }}>{$t['Button_Cancel']}</button
                 >

--- a/src/lib/components/VerseOnImage.svelte
+++ b/src/lib/components/VerseOnImage.svelte
@@ -1,9 +1,6 @@
 <!--
 @component
 The verse on image component.
-TODO: 
-Make the video download button not show up if there isn't audio or a timing file for that chapter
-Make some sort of popup indicating that the video is downloading
 -->
 <script lang="ts">
     import { goto } from '$app/navigation';
@@ -59,7 +56,7 @@ Make some sort of popup indicating that the video is downloading
     const viewportHeight_in_px = $derived(
         Math.max(document.documentElement.clientHeight || 0, window.innerHeight || 0)
     );
-
+    let downloadProgress = $state(0);
     const reference = $derived(selectedVerses.getCompositeReference());
     let verses: string = $state('');
     let imgSrc: string = $state('');
@@ -463,9 +460,9 @@ Make some sort of popup indicating that the video is downloading
 
         throw new Error('No supported AAC configuration found.');
     } //This is used to determine a supported audio configuration. It first tries AAC (Which can be used for mp4 files), but then falls back to opus (And thus a webm file) if AAC isn't supported
-
+    let cancelDownload = false;
     export async function downloadVideo() {
-        console.log('Video download started');
+        downloadProgress = 1;
         const original = document.getElementById('verseOnImgPreview');
         if (!original) {
             console.error('Error getting preview to export');
@@ -509,6 +506,13 @@ Make some sort of popup indicating that the video is downloading
             resizeHeight: img.height & ~1, // force even
             resizeQuality: 'high'
         });
+        downloadProgress = 10;
+        if (cancelDownload) {
+            document.body.removeChild(clone);
+            cancelDownload = false;
+            downloadProgress = 0;
+            return;
+        }
 
         const frame = new VideoFrame(bitmap, {
             timestamp: 0,
@@ -528,21 +532,69 @@ Make some sort of popup indicating that the video is downloading
         });
 
         output.addVideoTrack(videoSource);
+        downloadProgress = 20;
+        if (cancelDownload) {
+            document.body.removeChild(clone);
+            sample.close();
+            cancelDownload = false;
+            downloadProgress = 0;
+            return;
+        }
 
         const audioSourceInfo = await getAudioSourceInfo({
             collection: $refs.collection,
             book: $refs.book,
             chapter: $refs.chapter
         });
+        downloadProgress = 30;
+        if (cancelDownload) {
+            document.body.removeChild(clone);
+            sample.close();
+            cancelDownload = false;
+            downloadProgress = 0;
+            return;
+        }
 
         const audioSource = new AudioBufferSource(audioConfig);
         output.addAudioTrack(audioSource);
         await output.start();
+        downloadProgress = 40;
+        if (cancelDownload) {
+            document.body.removeChild(clone);
+            sample.close();
+            cancelDownload = false;
+            downloadProgress = 0;
+            return;
+        }
         await videoSource.add(sample);
+        downloadProgress = 50;
+        if (cancelDownload) {
+            document.body.removeChild(clone);
+            sample.close();
+            cancelDownload = false;
+            downloadProgress = 0;
+            return;
+        }
 
         const audioBlob = await fetch(audioSourceInfo?.source).then((r) => r.blob());
+        downloadProgress = 60;
+        if (cancelDownload) {
+            document.body.removeChild(clone);
+            sample.close();
+            cancelDownload = false;
+            downloadProgress = 0;
+            return;
+        }
         const audioCtx = new AudioContext();
         const audioBuffer = await audioCtx.decodeAudioData(await audioBlob.arrayBuffer());
+        downloadProgress = 70;
+        if (cancelDownload) {
+            document.body.removeChild(clone);
+            sample.close();
+            cancelDownload = false;
+            downloadProgress = 0;
+            return;
+        }
 
         const sampleRate = audioBuffer.sampleRate;
 
@@ -576,6 +628,14 @@ Make some sort of popup indicating that the video is downloading
             await audioSource.add(trimmedBuffer);
         }
         await output.finalize();
+        downloadProgress = 80;
+        if (cancelDownload) {
+            document.body.removeChild(clone);
+            sample.close();
+            cancelDownload = false;
+            downloadProgress = 0;
+            return;
+        }
 
         const buffer = output.target.buffer as BlobPart;
         const blob = new Blob([buffer], {
@@ -585,8 +645,10 @@ Make some sort of popup indicating that the video is downloading
         const file = new File([blob], filename, {
             type: audioConfig.codec === 'opus' ? 'video/webm' : 'video/mp4'
         });
+        downloadProgress = 90;
         document.body.removeChild(clone);
         sample.close();
+        downloadProgress = 0;
         const url = URL.createObjectURL(file);
 
         const anchor = document.createElement('a');
@@ -595,7 +657,6 @@ Make some sort of popup indicating that the video is downloading
         anchor.click();
 
         URL.revokeObjectURL(url);
-        console.log('Video download done');
     } //Most of this is AI-generated, so serious testing is needed. I've done a lot of testing, but it would be good to make sure there aren't subtle problems with this code.
 
     // EditorTabs centering feature:
@@ -1186,6 +1247,32 @@ Make some sort of popup indicating that the video is downloading
         ]}; flex: 1 1 auto; z-index: 3;"
     ></div>
 </div>
+{#if downloadProgress > 0}
+    <div class="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50">
+        <div
+            class="bg-base-100 p-6 shadow-xl w-80
+              flex flex-col justify-between h-64"
+        >
+            <div class="flex flex-col gap-1 text-left">
+                <p class="text-lg font-bold">Save Video</p>
+                <p class="text-sm">Creating video...</p>
+            </div>
+
+            <div class="w-full">
+                <progress class="progress w-full" value={downloadProgress} max="100"></progress>
+            </div>
+
+            <div class="flex justify-end">
+                <button
+                    class="btn btn-sm btn-ghost"
+                    onclick={() => {
+                        cancelDownload = true;
+                    }}>Cancel</button
+                >
+            </div>
+        </div>
+    </div>
+{/if}
 
 <style>
     #editorTabs::-webkit-scrollbar {

--- a/src/lib/components/VerseOnImage.svelte
+++ b/src/lib/components/VerseOnImage.svelte
@@ -466,6 +466,7 @@ The verse on image component.
         cancelDownload = false;
         let clone: HTMLElement | undefined;
         let sample: VideoSample | undefined;
+        const audioCtx = new AudioContext();
         downloadProgress = 1;
         try {
             const original = document.getElementById('verseOnImgPreview');
@@ -569,13 +570,8 @@ The verse on image component.
             const audioBlob = await fetch(audioSourceInfo?.source).then((r) => r.blob());
             downloadProgress = 60;
             if (cancelDownload) {
-                document.body.removeChild(clone);
-                sample.close();
-                cancelDownload = false;
-                downloadProgress = 0;
                 return;
             }
-            const audioCtx = new AudioContext();
             const audioBuffer = await audioCtx.decodeAudioData(await audioBlob.arrayBuffer());
             downloadProgress = 70;
             if (cancelDownload) {
@@ -632,9 +628,6 @@ The verse on image component.
                 type: audioConfig.codec === 'opus' ? 'video/webm' : 'video/mp4'
             });
             downloadProgress = 90;
-            document.body.removeChild(clone);
-            sample.close();
-            downloadProgress = 0;
             const url = URL.createObjectURL(file);
 
             const anchor = document.createElement('a');
@@ -652,6 +645,7 @@ The verse on image component.
             sample?.close();
             cancelDownload = false;
             downloadProgress = 0;
+            await audioCtx?.close();
         }
     } //Most of this is AI-generated, so serious testing is needed. I've done a lot of testing, but it would be good to make sure there aren't subtle problems with this code.
 

--- a/src/routes/image/+page.svelte
+++ b/src/routes/image/+page.svelte
@@ -2,7 +2,7 @@
     import DownloadSelector from '$lib/components/DownloadSelector.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
     import VerseOnImage from '$lib/components/VerseOnImage.svelte';
-    import { modal, ModalType, NAVBAR_HEIGHT, t } from '$lib/data/stores';
+    import { modal, ModalType, NAVBAR_HEIGHT, refs, t } from '$lib/data/stores';
     import { DownloadIcon, ShareIcon } from '$lib/icons';
     import { fromStore } from 'svelte/store';
 
@@ -41,6 +41,13 @@
             modal.clear();
         }
     }
+    function downloadClicked() {
+        if ($refs.hasAudio?.timingFile) {
+            modal.open(ModalType.Download);
+        } else {
+            downloadImage();
+        }
+    }
     let downloadSelector: DownloadSelector;
 </script>
 
@@ -59,10 +66,7 @@
                         <ShareIcon color="white" />
                     </button>
                 </div>
-                <button
-                    class="dy-btn-sm dy-btn-ghost"
-                    onclick={() => modal.open(ModalType.Download)}
-                >
+                <button class="dy-btn-sm dy-btn-ghost" onclick={downloadClicked}>
                     <DownloadIcon color="white" />
                 </button>
             {/snippet}

--- a/src/routes/image/+page.svelte
+++ b/src/routes/image/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-    //TODO: Implement video download
     import DownloadSelector from '$lib/components/DownloadSelector.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
     import VerseOnImage from '$lib/components/VerseOnImage.svelte';
@@ -19,7 +18,9 @@
         }
     }
     function downloadVideo() {
-        console.log('Download video (Not yet implemented)');
+        if (verseOnImage_Component) {
+            verseOnImage_Component.downloadVideo(); // Call the exported function from the VerseOnImage component
+        }
     }
     const stateModal = fromStore<any[]>(modal);
     $effect(() => {


### PR DESCRIPTION
Implementing #300 and continuing my work from #963. This implements the video download feature for verse on image. When audio files are available for the chapter, clicking the download button causes a small menu to pop up with "Save Image" and "Save Video" options. When "Save Video" is clicked, it creates and downloads a video consisting of a still frame of the image and text, with the audio playing the audio associated with the selected verse(s). If the browser can support it, it creates the video as an mp4 file. Firefox (At least on my machine) does not support the audio encoding needed for mp4, so for any browsers that do not support it, it downloads it as a webm file instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export and download verses as single-frame video files with integrated audio when available.
  * Active “Save video” option in the download modal; page button now triggers video export or immediate image download based on audio presence.
  * Video export displays a progress overlay with cancel support; outputs saved as WebM or MP4 depending on codec support.

* **Chores**
  * Added a media runtime dependency to support the new export workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->