### PR TITLE
#955 Fix for Contents Menu Carousel being parsed incorrectly

### DIFF
--- a/convert/convertContents.ts
+++ b/convert/convertContents.ts
@@ -134,7 +134,11 @@ export function parseItemTitle(
     return title;
 }
 
-export function parseItemSubtitle(tag: Element | HTMLElement | undefined): LangContainer {
+export function parseItemSubtitle(
+    tag: Element | HTMLElement | undefined,
+    upperLayer: boolean,
+    verbose: number
+): LangContainer {
     const subtitle: LangContainer = {};
     if (tag === undefined) {
         return subtitle;
@@ -143,8 +147,15 @@ export function parseItemSubtitle(tag: Element | HTMLElement | undefined): LangC
     const subtitleTags = tag.getElementsByTagName('subtitle');
     if (subtitleTags?.length > 0) {
         for (const subtitleTag of subtitleTags) {
-            const lang = parseLangAttribute(subtitleTag);
-            subtitle[lang] = decodeFromXml(subtitleTag.innerHTML);
+            if (verbose >= 3) {
+                console.log(
+                    `subtitle is nested: ${isTagInnerNestedItem(subtitleTag)} ${subtitleTag.innerHTML} ${subtitleTag.parentElement?.parentElement?.tagName}`
+                );
+            }
+            if ((!isTagInnerNestedItem(subtitleTag) && upperLayer) || !upperLayer) {
+                const lang = parseLangAttribute(subtitleTag);
+                subtitle[lang] = decodeFromXml(subtitleTag.innerHTML);
+            }
         }
     }
     return subtitle;
@@ -395,7 +406,7 @@ export function convertContents(
                 console.warn(`item type is undefined for ${title}`);
             }
 
-            const subtitle = parseItemSubtitle(itemTag);
+            const subtitle = parseItemSubtitle(itemTag, true, verbose);
 
             let audioFilename: { [lang: string]: string } = {};
             let imageFilename: string | undefined = undefined;
@@ -430,7 +441,7 @@ export function convertContents(
                         const cTitle = parseItemTitle(itemChild, false, verbose);
                         const childContentItemContainer = false; // by virtue of being a child item it is not a contentItemContainer
                         const cItemType = itemType; // Technically this is a child of the item
-                        const cSubtitle = parseItemSubtitle(itemChild);
+                        const cSubtitle = parseItemSubtitle(itemChild, false, verbose);
                         if (verbose >= 3) {
                             console.log(`Child Tag: ${itemChild.tagName}`);
                         }

--- a/src/lib/components/ContentCarousel.svelte
+++ b/src/lib/components/ContentCarousel.svelte
@@ -20,7 +20,11 @@
         features
     }: Props = $props();
 
+    // NOTE: Item.features is per specific toward this instance
+    // while features will be different in the overall layout
+
     const carouselId = $derived(`contents-carousel-${item.id}`);
+    let carouselInnerWidthCSS = 'n2';
 
     function onClickFallback(target: HTMLElement, item: ContentItem) {
         console.warn('USING THE onClickFallback');
@@ -113,6 +117,10 @@
             carouselScroll.scrollLeft = scrollLeft - walk;
         });
     });
+
+    if (item.features?.['visible-items']) {
+        carouselInnerWidthCSS = 'n' + item.features['visible-items'];
+    }
 </script>
 
 <div id={carouselId} class="contents-carousel no-select">
@@ -133,7 +141,7 @@
         class="contents-carousel-row"
         style="overscroll-behavior: auto contain; overflow-y: hidden; scrollbar-width:none; -ms-overflow-style:none; -webkit-scrollbar: none;"
     >
-        <div class="contents-carousel-inner n2">
+        <div class="contents-carousel-inner {carouselInnerWidthCSS}">
             {#each item.children as child}
                 <!-- svelte-ignore a11y_click_events_have_key_events -->
                 <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/src/lib/components/ContentCarousel.svelte
+++ b/src/lib/components/ContentCarousel.svelte
@@ -24,7 +24,7 @@
     // while features will be different in the overall layout
 
     const carouselId = $derived(`contents-carousel-${item.id}`);
-    let carouselInnerWidthCSS = 'n2';
+    const carouselInnerWidthCSS = $derived(`n${item.features?.['visible-items'] || 2}`);
 
     function onClickFallback(target: HTMLElement, item: ContentItem) {
         console.warn('USING THE onClickFallback');
@@ -117,10 +117,6 @@
             carouselScroll.scrollLeft = scrollLeft - walk;
         });
     });
-
-    if (item.features?.['visible-items']) {
-        carouselInnerWidthCSS = 'n' + item.features['visible-items'];
-    }
 </script>
 
 <div id={carouselId} class="contents-carousel no-select">


### PR DESCRIPTION
1. Was because of how the features are divided in the xml. One set of features is in data.features and another is in item.features. So 'visible-items' was simply missed.
2. Part of the logic that was used missed for parsing subtitles which check for the upper layer and nested items. Thus it was duplicating id  4.  This had to be fixed in convertContents.

Original Issue: https://github.com/sillsdev/appbuilder-pwa/issues/955

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content carousels now support variable, configurable visible item counts on a per-carousel basis, enabling different carousel instances to display customized numbers of items.

* **Improvements**
  * Subtitle extraction for nested content items has been improved with enhanced detection and comprehensive verbose logging for better debugging capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->