### PR TITLE
#505 Finish implementing "repeat selection" audio mode

### DIFF
--- a/src/lib/components/AudioBar.svelte
+++ b/src/lib/components/AudioBar.svelte
@@ -100,7 +100,7 @@ TODO:
     const iconPlayColor = $derived($s?.['ui.bar.audio.play.icon']['color']);
     const backgroundColor = $derived($s?.['ui.bar.audio']['background-color']);
     const audioBarClass = $derived($refs.hasAudio?.timingFile ? 'audio-bar' : 'audio-bar-progress');
-    $effect(() => mayResetPlayMode($refs.hasAudio?.timingFile));
+    $effect(() => mayResetPlayMode(!!$refs.hasAudio?.timingFile));
     $effect(() => updatePlaybackSpeed($userSettings['audio-speed'] as string));
 </script>
 
@@ -116,8 +116,8 @@ TODO:
     {#if showRepeatMode}
         <div class="audio-control-buttons">
             <RepeatButton
-                color={iconColor}
-                onclick={() => playMode.next($refs.hasAudio?.timingFile)}
+                color="{iconColor},"
+                onclick={() => playMode.next(!!$refs.hasAudio?.timingFile)}
                 state={$playMode.mode}
             />
         </div>

--- a/src/lib/components/AudioBar.svelte
+++ b/src/lib/components/AudioBar.svelte
@@ -36,6 +36,7 @@ TODO:
         // If the current mode is repeatSelection and the reference is changed to something without timing
         // (even chapter without audio), then reset the playMode.  This matches how the Android app behaves.
         if (!hasTiming && $playMode.mode === 'repeatSelection') {
+            console.log(`mayResetPlayMode: calling reset()`);
             playMode.reset();
         }
     }
@@ -100,7 +101,11 @@ TODO:
     const iconPlayColor = $derived($s?.['ui.bar.audio.play.icon']['color']);
     const backgroundColor = $derived($s?.['ui.bar.audio']['background-color']);
     const audioBarClass = $derived($refs.hasAudio?.timingFile ? 'audio-bar' : 'audio-bar-progress');
-    $effect(() => mayResetPlayMode($refs.hasAudio?.timing));
+    $effect(() => mayResetPlayMode($refs.hasAudio?.timingFile));
+    // $effect(() => {
+    //     console.log(`effect: thinks that timing is ${$refs.hasAudio?.timing}`);
+    //     mayResetPlayMode($refs.hasAudio?.timing);
+    // });
     $effect(() => updatePlaybackSpeed($userSettings['audio-speed'] as string));
 </script>
 

--- a/src/lib/components/AudioBar.svelte
+++ b/src/lib/components/AudioBar.svelte
@@ -36,7 +36,6 @@ TODO:
         // If the current mode is repeatSelection and the reference is changed to something without timing
         // (even chapter without audio), then reset the playMode.  This matches how the Android app behaves.
         if (!hasTiming && $playMode.mode === 'repeatSelection') {
-            console.log(`mayResetPlayMode: calling reset()`);
             playMode.reset();
         }
     }
@@ -102,10 +101,6 @@ TODO:
     const backgroundColor = $derived($s?.['ui.bar.audio']['background-color']);
     const audioBarClass = $derived($refs.hasAudio?.timingFile ? 'audio-bar' : 'audio-bar-progress');
     $effect(() => mayResetPlayMode($refs.hasAudio?.timingFile));
-    // $effect(() => {
-    //     console.log(`effect: thinks that timing is ${$refs.hasAudio?.timing}`);
-    //     mayResetPlayMode($refs.hasAudio?.timing);
-    // });
     $effect(() => updatePlaybackSpeed($userSettings['audio-speed'] as string));
 </script>
 

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -176,16 +176,16 @@ TODO:
             {:else}
                 {#if $refs.hasAudio && $refs.hasAudio.timingFile}
                     {#if isAudioPlayable}
-                        <button 
-                            class="dy-btn-sm dy-btn-ghost" 
+                        <button
+                            class="dy-btn-sm dy-btn-ghost"
                             onclick={() => playSelectedVerseAudio({ repeat: false })}
                         >
                             <AudioIcon.Play color={iconColor} />
                         </button>
                     {/if}
                     {#if isRepeatableAudio}
-                        <button 
-                            class="dy-btn-sm dy-btn-ghost" 
+                        <button
+                            class="dy-btn-sm dy-btn-ghost"
                             onclick={() => playSelectedVerseAudio({ repeat: true })}
                         >
                             <AudioIcon.PlayRepeat color={iconColor} />
@@ -193,7 +193,7 @@ TODO:
                     {/if}
                 {/if}
                 {#if isTextOnImageEnabled}
-                    <button 
+                    <button
                         class="dy-btn-sm dy-btn-ghost"
                         onclick={() => {
                             voiCustomImage.update((v) => ({

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -14,17 +14,14 @@ TODO:
 <script lang="ts">
     import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';
-    import config, { scriptureConfig } from '$assets/config';
+    import { scriptureConfig } from '$assets/config';
     import { getBook, logShareContent } from '$lib/data/analytics';
-    import { play, playVerses, seekToVerse } from '$lib/data/audio';
+    import { playVerses } from '$lib/data/audio';
     import { addBookmark, findBookmark, removeBookmark } from '$lib/data/bookmarks';
     import { addHighlights, removeHighlights } from '$lib/data/highlights';
     import { shareText } from '$lib/data/share';
     import {
         audioActive,
-        defaultPlayModeRange,
-        PlayMode,
-        playMode,
         refs,
         s,
         selectedVerses,
@@ -113,16 +110,7 @@ TODO:
         selectedVerses.reset();
     }
 
-    // resets underlined verses and plays verse audio
-    function playVerseAudio() {
-        const element = $selectedVerses[0].verse;
-        const tagSelected = element + 'a';
-        seekToVerse(tagSelected);
-        play();
-        $audioActive = true;
-        selectedVerses.reset();
-    }
-
+    // Play from first selected verse, optionally repeating after the last verse
     function playSelectedVerseAudio(repeat: boolean) {
         const startVerse = $selectedVerses[0].verse;
 
@@ -135,19 +123,6 @@ TODO:
 
         $audioActive = true;
         selectedVerses.reset();
-    }
-
-    // Plays selected verses repeatedly, resets verse selection
-    function repeatVerseAudio() {
-        // Need to provide dummy range argument (see /lib/data/audio.ts:46).
-        // The button whose click handler calls this funcion is only present
-        // when there is audio and timing data. When playMode.set is called,
-        // the listener in /lib/data/audio.ts will replace the range with the
-        // correct values from the audio timing data.
-        console.log("Repeat verse audio");
-        // console.log(`timing: ${$refs.hasAudio.timingFile}`)
-        playMode.set({ range: defaultPlayModeRange, mode: PlayMode.RepeatSelection });
-        playVerseAudio();
     }
 
     async function copy() {
@@ -175,8 +150,8 @@ TODO:
         logShareContent('Text', bookCol, bookAbbrev ?? '', reference);
     }
 
-    const backgroundColor = $derived($s['ui.bar.text-select']['background-color']);
-    const iconColor = $derived($s['ui.bar.text-select.icon']['color']);
+    const backgroundColor = $derived($s!['ui.bar.text-select']['background-color']);
+    const iconColor = $derived($s!['ui.bar.text-select.icon']['color']);
 </script>
 
 <div
@@ -199,20 +174,27 @@ TODO:
                     {/each}
                 </div>
             {:else}
-                {#if isAudioPlayable && $refs.hasAudio && $refs.hasAudio.timingFile}
-                    <button 
-                        class="dy-btn-sm dy-btn-ghost" onclick={() => playSelectedVerseAudio(false)}
-                    >
-                        <AudioIcon.Play color={iconColor} />
-                    </button>
-                {/if}
-                {#if isRepeatableAudio && $refs.hasAudio && $refs.hasAudio.timingFile}
-                    <button class="dy-btn-sm dy-btn-ghost" onclick={() => playSelectedVerseAudio(true)}>
-                        <AudioIcon.PlayRepeat color={iconColor} />
-                    </button>
+                {#if $refs.hasAudio && $refs.hasAudio.timingFile}
+                    {#if isAudioPlayable}
+                        <button 
+                            class="dy-btn-sm dy-btn-ghost" 
+                            onclick={() => playSelectedVerseAudio(false)}
+                        >
+                            <AudioIcon.Play color={iconColor} />
+                        </button>
+                    {/if}
+                    {#if isRepeatableAudio}
+                        <button 
+                            class="dy-btn-sm dy-btn-ghost" 
+                            onclick={() => playSelectedVerseAudio(true)}
+                        >
+                            <AudioIcon.PlayRepeat color={iconColor} />
+                        </button>
+                    {/if}
                 {/if}
                 {#if isTextOnImageEnabled}
-                    <button
+                    <button 
+                        class="dy-btn-sm dy-btn-ghost"
                         onclick={() => {
                             voiCustomImage.update((v) => ({
                                 ...v,
@@ -221,7 +203,6 @@ TODO:
                             }));
                             goto(resolve(`/image`));
                         }}
-                        class="dy-btn-sm dy-btn-ghost"
                     >
                         <ImageIcon.Image color={iconColor} />
                     </button>

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -174,7 +174,7 @@ TODO:
                     {/each}
                 </div>
             {:else}
-                {#if isAudioPlayable && $refs.hasAudio && $refs.hasAudio.timingFile}
+                {#if isAudioPlayable && $refs.hasAudio?.timingFile}
                     <button
                         class="dy-btn-sm dy-btn-ghost"
                         onclick={() => playSelectedVerseAudio({ repeat: false })}
@@ -182,7 +182,7 @@ TODO:
                         <AudioIcon.Play color={iconColor} />
                     </button>
                 {/if}
-                {#if isRepeatableAudio && $refs.hasAudio && $refs.hasAudio.timingFile}
+                {#if isRepeatableAudio && $refs.hasAudio?.timingFile}
                     <button
                         class="dy-btn-sm dy-btn-ghost"
                         onclick={() => playSelectedVerseAudio({ repeat: true })}

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -16,7 +16,7 @@ TODO:
     import { resolve } from '$app/paths';
     import config, { scriptureConfig } from '$assets/config';
     import { getBook, logShareContent } from '$lib/data/analytics';
-    import { play, seekToVerse } from '$lib/data/audio';
+    import { play, playVerses, seekToVerse } from '$lib/data/audio';
     import { addBookmark, findBookmark, removeBookmark } from '$lib/data/bookmarks';
     import { addHighlights, removeHighlights } from '$lib/data/highlights';
     import { shareText } from '$lib/data/share';
@@ -123,6 +123,20 @@ TODO:
         selectedVerses.reset();
     }
 
+    function playSelectedVerseAudio(repeat: boolean) {
+        const startVerse = $selectedVerses[0].verse;
+
+        if (repeat) {
+            const endVerse = $selectedVerses[$selectedVerses.length - 1].verse;
+            playVerses(startVerse, endVerse);
+        } else {
+            playVerses(startVerse);
+        }
+
+        $audioActive = true;
+        selectedVerses.reset();
+    }
+
     // Plays selected verses repeatedly, resets verse selection
     function repeatVerseAudio() {
         // Need to provide dummy range argument (see /lib/data/audio.ts:46).
@@ -186,12 +200,14 @@ TODO:
                 </div>
             {:else}
                 {#if isAudioPlayable && $refs.hasAudio && $refs.hasAudio.timingFile}
-                    <button class="dy-btn-sm dy-btn-ghost" onclick={() => playVerseAudio()}>
+                    <button 
+                        class="dy-btn-sm dy-btn-ghost" onclick={() => playSelectedVerseAudio(false)}
+                    >
                         <AudioIcon.Play color={iconColor} />
                     </button>
                 {/if}
                 {#if isRepeatableAudio && $refs.hasAudio && $refs.hasAudio.timingFile}
-                    <button class="dy-btn-sm dy-btn-ghost" onclick={() => repeatVerseAudio()}>
+                    <button class="dy-btn-sm dy-btn-ghost" onclick={() => playSelectedVerseAudio(true)}>
                         <AudioIcon.PlayRepeat color={iconColor} />
                     </button>
                 {/if}

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -111,10 +111,10 @@ TODO:
     }
 
     // Play from first selected verse, optionally repeating after the last verse
-    function playSelectedVerseAudio(repeat: boolean) {
+    function playSelectedVerseAudio(options: { repeat: boolean }) {
         const startVerse = $selectedVerses[0].verse;
 
-        if (repeat) {
+        if (options.repeat) {
             const endVerse = $selectedVerses[$selectedVerses.length - 1].verse;
             playVerses(startVerse, endVerse);
         } else {
@@ -178,7 +178,7 @@ TODO:
                     {#if isAudioPlayable}
                         <button 
                             class="dy-btn-sm dy-btn-ghost" 
-                            onclick={() => playSelectedVerseAudio(false)}
+                            onclick={() => playSelectedVerseAudio({ repeat: false })}
                         >
                             <AudioIcon.Play color={iconColor} />
                         </button>
@@ -186,7 +186,7 @@ TODO:
                     {#if isRepeatableAudio}
                         <button 
                             class="dy-btn-sm dy-btn-ghost" 
-                            onclick={() => playSelectedVerseAudio(true)}
+                            onclick={() => playSelectedVerseAudio({ repeat: true })}
                         >
                             <AudioIcon.PlayRepeat color={iconColor} />
                         </button>

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -22,6 +22,7 @@ TODO:
     import { shareText } from '$lib/data/share';
     import {
         audioActive,
+        defaultPlayModeRange,
         PlayMode,
         playMode,
         refs,
@@ -131,7 +132,7 @@ TODO:
         // correct values from the audio timing data.
         console.log("Repeat verse audio");
         // console.log(`timing: ${$refs.hasAudio.timingFile}`)
-        playMode.set({ range: { start: 0, end: 1000 }, mode: PlayMode.RepeatSelection });
+        playMode.set({ range: defaultPlayModeRange, mode: PlayMode.RepeatSelection });
         playVerseAudio();
     }
 

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -150,8 +150,8 @@ TODO:
         logShareContent('Text', bookCol, bookAbbrev ?? '', reference);
     }
 
-    const backgroundColor = $derived($s!['ui.bar.text-select']['background-color']);
-    const iconColor = $derived($s!['ui.bar.text-select.icon']['color']);
+    const backgroundColor = $derived($s['ui.bar.text-select']['background-color']);
+    const iconColor = $derived($s['ui.bar.text-select.icon']['color']);
 </script>
 
 <div
@@ -174,27 +174,24 @@ TODO:
                     {/each}
                 </div>
             {:else}
-                {#if $refs.hasAudio && $refs.hasAudio.timingFile}
-                    {#if isAudioPlayable}
-                        <button
-                            class="dy-btn-sm dy-btn-ghost"
-                            onclick={() => playSelectedVerseAudio({ repeat: false })}
-                        >
-                            <AudioIcon.Play color={iconColor} />
-                        </button>
-                    {/if}
-                    {#if isRepeatableAudio}
-                        <button
-                            class="dy-btn-sm dy-btn-ghost"
-                            onclick={() => playSelectedVerseAudio({ repeat: true })}
-                        >
-                            <AudioIcon.PlayRepeat color={iconColor} />
-                        </button>
-                    {/if}
+                {#if isAudioPlayable && $refs.hasAudio && $refs.hasAudio.timingFile}
+                    <button
+                        class="dy-btn-sm dy-btn-ghost"
+                        onclick={() => playSelectedVerseAudio({ repeat: false })}
+                    >
+                        <AudioIcon.Play color={iconColor} />
+                    </button>
+                {/if}
+                {#if isRepeatableAudio && $refs.hasAudio && $refs.hasAudio.timingFile}
+                    <button
+                        class="dy-btn-sm dy-btn-ghost"
+                        onclick={() => playSelectedVerseAudio({ repeat: true })}
+                    >
+                        <AudioIcon.PlayRepeat color={iconColor} />
+                    </button>
                 {/if}
                 {#if isTextOnImageEnabled}
                     <button
-                        class="dy-btn-sm dy-btn-ghost"
                         onclick={() => {
                             voiCustomImage.update((v) => ({
                                 ...v,
@@ -203,6 +200,7 @@ TODO:
                             }));
                             goto(resolve(`/image`));
                         }}
+                        class="dy-btn-sm dy-btn-ghost"
                     >
                         <ImageIcon.Image color={iconColor} />
                     </button>

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -22,6 +22,8 @@ TODO:
     import { shareText } from '$lib/data/share';
     import {
         audioActive,
+        PlayMode,
+        playMode,
         refs,
         s,
         selectedVerses,
@@ -120,6 +122,19 @@ TODO:
         selectedVerses.reset();
     }
 
+    // Plays selected verses repeatedly, resets verse selection
+    function repeatVerseAudio() {
+        // Need to provide dummy range argument (see /lib/data/audio.ts:46).
+        // The button whose click handler calls this funcion is only present
+        // when there is audio and timing data. When playMode.set is called,
+        // the listener in /lib/data/audio.ts will replace the range with the
+        // correct values from the audio timing data.
+        console.log("Repeat verse audio");
+        // console.log(`timing: ${$refs.hasAudio.timingFile}`)
+        playMode.set({ range: { start: 0, end: 1000 }, mode: PlayMode.RepeatSelection });
+        playVerseAudio();
+    }
+
     async function copy() {
         var copyText =
             (await selectedVerses.getCompositeText()) +
@@ -175,7 +190,7 @@ TODO:
                     </button>
                 {/if}
                 {#if isRepeatableAudio && $refs.hasAudio && $refs.hasAudio.timingFile}
-                    <button class="dy-btn-sm dy-btn-ghost">
+                    <button class="dy-btn-sm dy-btn-ghost" onclick={() => repeatVerseAudio()}>
                         <AudioIcon.PlayRepeat color={iconColor} />
                     </button>
                 {/if}

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -36,20 +36,13 @@ audioPlayerStore.subscribe(async (value: AudioPlayer) => {
     currentAudioPlayer = value;
     await getAudio();
 });
+
 let currentPlayMode: PlayModeSettings | undefined = undefined;
 playMode.subscribe((value) => {
-    // if (
-    //     currentPlayMode &&
-    //     currentPlayMode.mode !== value.mode &&
-    //     value.mode === PlayMode.RepeatSelection
-    // ) {
-    //     const timing = getCurrentVerseTiming();
-    //     console.log(`playMode listener: resetting range to ${timing.start}-${timing.end}`);
-    //     value.range = timing || value.range;
-    // }
     currentPlayMode = value;
     console.log(`playMode listener: ${currentPlayMode.mode}`);
 });
+
 // produces the cache key for the mru audio cache
 function cacheKey(collection: string, book: string, chapter: string) {
     return `${collection}-${book}-${chapter}`;
@@ -129,18 +122,23 @@ async function getAudio() {
         updateTime();
     };
 }
+
 // plays or pauses the audio
 export function playPause() {
     if (currentAudioPlayer?.loaded) {
         currentAudioPlayer.playing? pause() : play();
+    } else {
+        console.log("Warning: tried to playPause() audio that wasn't loaded");
     }
 }
+
 // stops playing audio
 export function playStop() {
-    if (currentAudioPlayer?.loaded && currentAudioPlayer.playing) {
-        pause()
-    };
+    // The previous implementation of this function is now equivalent to pause()
+    // Keeping this alias for another PR to refactor to reduce scope
+    pause();
 }
+
 // changes chapter
 export async function skip(direction: number) {
     pause();
@@ -214,6 +212,8 @@ export async function seekOffset(offset: number) {
         play();
     }
 }
+
+// Move the audio player to the given number of seconds from the start
 export function seek(position: number) {
     if (!currentAudioPlayer) {
         console.error("Warning: missing audio player in seek()");
@@ -225,21 +225,20 @@ export function seek(position: number) {
 
     // If the audio is playing, we'll need to resume after the seek
     const wasPlaying = currentAudioPlayer.playing;
-    if (wasPlaying) pause();
-
-    // const timing = getCurrentVerseTiming();
-    // console.log(`seek: target position ${position}, verse ${timing?.start}-${timing?.end}`);
-    // if (timing) {
-    //     playMode.set({ ...(currentPlayMode ?? { mode: defaultPlayMode.mode }), range: timing });
-    // }
+    if (wasPlaying) { pause() };
 
     currentAudioPlayer.audio.currentTime = position;
     currentAudioPlayer.progress = position;
     audioPlayerStore.set(currentAudioPlayer);
 
-    if (wasPlaying) play();
+    if (wasPlaying) { play() };
 }
+
+// Countdown timer for slight delay before repeating the 
+// current section or continuing to next section
 let warmdown: number | undefined = undefined;
+
+// Interval callback for updating the audio state
 async function handlePlayMode() {
     if (warmdown) {
         console.log(`warmdown == ${warmdown}`);
@@ -262,7 +261,6 @@ async function handlePlayMode() {
     if (currentAudioPlayer?.audio?.ended) {
         if (currentPlayMode?.mode === PlayMode.Stop) {
             pause();
-            // audioPlayerStore.set(currentAudioPlayer);
         } else {
             warmdown = 5;
         }
@@ -292,47 +290,8 @@ async function handlePlayMode() {
         }
     }
 }
-// // gets the current verse start and end tag
-// function getCurrentVerseTiming() {
-//     let end: string = '';
-//     let start: string = '';
-//     if (currentAudioPlayer?.timing?.length) {
-//         for (let i = 0; i < currentAudioPlayer.timing.length; i++) {
-//             const timing = currentAudioPlayer.timing![i];
-//             if (
-//                 currentAudioPlayer.progress >= timing.starttime &&
-//                 currentAudioPlayer.progress < timing.endtime
-//             ) {
-//                 const verseNumber = parseInt(timing.tag, 10);
-//                 for (let k = i + 1; k >= 0; k--) {
-//                     const startVerseNumber = parseInt(currentAudioPlayer.timing[k].tag, 10);
-//                     if (startVerseNumber !== verseNumber) {
-//                         start = currentAudioPlayer.timing[k + 1].tag;
-//                         break;
-//                     }
-//                     if (k === 0) {
-//                         start = currentAudioPlayer.timing[0].tag;
-//                         break;
-//                     }
-//                 }
-//                 for (let j = i + 1; j < currentAudioPlayer.timing.length; j++) {
-//                     const endVerseNumber = parseInt(currentAudioPlayer.timing[j].tag, 10);
-//                     if (endVerseNumber !== verseNumber) {
-//                         end = currentAudioPlayer.timing[j - 1].tag;
-//                         break;
-//                     }
-//                     if (j === currentAudioPlayer.timing.length - 1) {
-//                         end = currentAudioPlayer.timing[j].tag;
-//                         break;
-//                     }
-//                 }
-//                 break;
-//             }
-//         }
-//     }
-//     return getVerseTimingRange(start, end);
-// }
 
+// Get the audio start and end timestamps for the current verse as a range
 function getCurrentVerseTiming() {
     if (!currentAudioPlayer?.timing) {
         console.error(`Warning in getCurrentVerseTiming(): ` + 
@@ -351,7 +310,7 @@ function getCurrentVerseTiming() {
             const verseNumber = parseInt(timing.tag, 10);
 
             // Step backwards until we reach the previous verse
-            for (let k = i; k >= 0; k--) {
+            for (let k = i - 1; k >= 0; k--) {
                 const startVerseNumber = parseInt(currentAudioPlayer.timing[k].tag, 10);
                 // The last tag of the previous verse is the closest
                 // to the current tag to have a different verse number
@@ -388,49 +347,6 @@ function getCurrentVerseTiming() {
     return { start, end } as PlayModeRange;
 }
 
-function getVerseEndTag(verse: string) {
-    if (!currentAudioPlayer?.timing) {
-        // No further detail, so return base tag
-        return verse;
-    }
-
-    let startTag = '', endTag = '', i: number;
-
-    // First find the beginning of the verse
-    for (i = 0; i < currentAudioPlayer.timing.length; i++) {
-        //adapted from seekToVerse() below
-        const tag = currentAudioPlayer.timing[i].tag;
-        const containsAlpha = /[a-z]/.test(tag);
-        const adjustedTag = containsAlpha ? tag : tag + 'a';
-
-        console.log(`Trying tag ${adjustedTag}`);
-
-        if (adjustedTag.slice(0, adjustedTag.length - 1) === verse) {
-            startTag = adjustedTag;
-            break;
-        }
-    }
-
-    // Then find the end of the verse
-    const baseTag = parseInt(startTag, 10);
-    console.log(`getVerseEndTag(${verse}): start tag is (${startTag}), base (${baseTag})`);
-    for (let j = i + 1; j < currentAudioPlayer.timing.length; j++) {
-        const endVerseNumber = parseInt(currentAudioPlayer.timing[j].tag, 10);
-        if (endVerseNumber !== baseTag) {
-            endTag = currentAudioPlayer.timing[j - 1].tag;
-            break;
-        }
-        if (j === currentAudioPlayer.timing.length - 1) {
-            endTag = currentAudioPlayer.timing[j].tag;
-            break;
-        }
-    }
-
-    console.log(`getVerseEndTag(${verse}): found end tag of ${endTag}`);
-
-    return endTag;
-}
-
 // function get range of current index all labels of the current verse playing
 // calls updatehighlights() to see if highlights need to be change
 async function updateTime() {
@@ -461,33 +377,42 @@ function toggleTimeRunning() {
 export function hasAudioPlayed() {
     return (currentAudioPlayer?.progress ?? 0) > 0;
 }
+
+// Pause audio if currently playing
 function pause() {
     if (!currentAudioPlayer?.loaded) {
+        console.error("Warning: tried to pause() audio before it was loaded");
         return;
     }
+
     if (currentAudioPlayer.playing) {
         currentAudioPlayer.audio?.pause();
         logAudioDuration(currentAudioPlayer);
         currentAudioPlayer.playing = false;
+        toggleTimeRunning();
+        audioPlayerStore.set(currentAudioPlayer);
     }
-    toggleTimeRunning();
-    audioPlayerStore.set(currentAudioPlayer);
 }
 
+// Play audio if currently paused
 export function play() {
     if (!currentAudioPlayer?.loaded) {
+        console.error("Warning: tried to play() audio before it was loaded");
         return;
     }
+
     if (!currentAudioPlayer.playing) {
         currentAudioPlayer.audio?.play();
         currentAudioPlayer.playStart = Date.now();
         logAudioPlay(currentAudioPlayer);
         currentAudioPlayer.playing = true;
+        toggleTimeRunning();
+        audioPlayerStore.set(currentAudioPlayer);
     }
-    toggleTimeRunning();
-    audioPlayerStore.set(currentAudioPlayer);
 }
 
+// Start audio at beginning of startVerse, repeating after
+// endVerse if endVerse is provided
 export function playVerses(startVerse: string, endVerse?: string) {
     let mode: PlayMode, range: PlayModeRange;
 
@@ -504,8 +429,60 @@ export function playVerses(startVerse: string, endVerse?: string) {
     console.log(`playVerses: setting range ${range.start} - ${range.end}`);
 
     playMode.set({ mode, range });
-    seekToVerse(startVerse + 'a');
+    seekToVerse(startVerse);
     play();
+}
+
+// Seek to the start of the first audio tag for the specified verse
+export function seekToVerse(verse: string) {
+    if (!currentAudioPlayer?.timing) {
+        console.error(`Warning in seekToVerse(${verse}): ` + 
+                      "missing audio timing data");
+        return; 
+    }
+
+    for (let i = 0; i < currentAudioPlayer.timing.length; i++) {
+        const timing = currentAudioPlayer.timing[i];
+        // Handle case where tag has form '9a' for first tag in verse 9
+        if (timing.tag === verse || timing.tag === (verse + 'a')) {
+            seek(timing.starttime);
+            // Force text highlighting update
+            updateTime();
+            return;
+        }
+    }
+
+}
+
+// Get an audio timing range bounded by the first tag 
+// of startVerse and the last tag of endVerse
+function getVerseTimingRange(startVerse: string, endVerse: string) {
+    if (!currentAudioPlayer?.timing) {
+        console.error(`Warning in getVerseTimingRange(${startVerse}-${endVerse}): ` + 
+                      "missing audio timing data");
+        return defaultPlayMode.range;
+    }
+
+    let start = 0, end = 0;
+    for (let i = 0; i < currentAudioPlayer.timing.length; i++) {
+        const timing = currentAudioPlayer.timing[i];
+
+        // Handle case where tag has form '9a' for first tag in verse 9
+        if (timing.tag === startVerse || timing.tag === (startVerse + 'a')) {
+            start = timing.starttime;
+        }
+        if (timing.tag === endVerse) {
+            end = timing.endtime;
+            break;
+        } else if (parseInt(timing.tag) === (parseInt(endVerse) + 1)) {
+            // This is the first timing tag in the next verse, so 
+            // the previous tag (at i - 1) is the last tag in the current verse
+            end = currentAudioPlayer.timing[i - 1].endtime;
+            break;
+        }
+    }
+
+    return { start, end } as PlayModeRange;
 }
 
 // selects the tag to highlight
@@ -627,73 +604,4 @@ export async function getAudioSourceInfo(
         source: audioPath,
         timing: timing.length > 0 ? timing : null
     };
-}
-// This function can be called when the text selection toolbar play button is clicked on and it changes the audio to the start of the verse clicked on
-export function seekToVerse(verseClicked: string) {
-    if (!currentAudioPlayer?.timing) {
-        return;
-    }
-    const elements = currentAudioPlayer.timing;
-    for (let i = 0; i < elements.length; i++) {
-        const tag = currentAudioPlayer.timing[i].tag;
-        // Handle timing tags that are just the verse number
-        const containsAlpha = /[a-z]/.test(tag);
-        const adjustedTag = containsAlpha ? tag : tag + 'a';
-        if (verseClicked === adjustedTag) {
-            const newtime = currentAudioPlayer.timing[i].starttime;
-            seek(newtime);
-            break;
-        }
-    }
-    //forces highlighting change
-    updateTime();
-}
-// takes a start and end tag and returns the range of times
-// function getVerseTimingRange(startTag: string, endTag: string) {
-//     const elements = currentAudioPlayer?.timing ?? [];
-//     let start: number = 0;
-//     for (let i = 0; i < elements.length; i++) {
-//         const tag = currentAudioPlayer!.timing![i].tag;
-//         if (startTag === tag) {
-//             const newstarttime = currentAudioPlayer!.timing![i].starttime;
-//             start = newstarttime;
-//         }
-//         if (endTag === tag) {
-//             const newendtime = currentAudioPlayer!.timing![i].endtime;
-//             const end = newendtime;
-//             const range = { start, end };
-//             return range;
-//         }
-//     }
-// }
-
-// Get an audio timing range bounded by the first tag 
-// of startVerse and the last tag of endVerse
-function getVerseTimingRange(startVerse: string, endVerse: string) {
-    if (!currentAudioPlayer?.timing) {
-        console.error(`Warning in getVerseTimingRange(${startVerse}-${endVerse}): ` + 
-                      "missing audio timing data");
-        return defaultPlayMode.range;
-    }
-
-    let start = 0, end = 0;
-    for (let i = 0; i < currentAudioPlayer.timing.length; i++) {
-        const timing = currentAudioPlayer.timing[i];
-
-        // Handle case where tag has form '9a' for first phrase in verse 9
-        if (timing.tag === startVerse || timing.tag === (startVerse + 'a')) {
-            start = timing.starttime;
-        }
-        if (timing.tag === endVerse) {
-            end = timing.endtime;
-            break;
-        } else if (parseInt(timing.tag) === (parseInt(endVerse) + 1)) {
-            // This is the first timing tag in the next verse, so 
-            // the previous tag (at i - 1) is the last tag in the current verse
-            end = currentAudioPlayer.timing[i - 1].endtime;
-            break;
-        }
-    }
-
-    return { start, end } as PlayModeRange;
 }

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -38,14 +38,15 @@ audioPlayerStore.subscribe(async (value: AudioPlayer) => {
 });
 let currentPlayMode: PlayModeSettings | undefined = undefined;
 playMode.subscribe((value) => {
-    if (
-        currentPlayMode &&
-        currentPlayMode.mode !== value.mode &&
-        value.mode === PlayMode.RepeatSelection
-    ) {
-        const timing = getCurrentVerseTiming();
-        value.range = timing || value.range;
-    }
+    // if (
+    //     currentPlayMode &&
+    //     currentPlayMode.mode !== value.mode &&
+    //     value.mode === PlayMode.RepeatSelection
+    // ) {
+    //     const timing = getCurrentVerseTiming();
+    //     console.log(`playMode listener: resetting range to ${timing.start}-${timing.end}`);
+    //     value.range = timing || value.range;
+    // }
     currentPlayMode = value;
     console.log(`playMode listener: ${currentPlayMode.mode}`);
 });
@@ -291,45 +292,100 @@ async function handlePlayMode() {
         }
     }
 }
-// gets the current verse start and end tag
+// // gets the current verse start and end tag
+// function getCurrentVerseTiming() {
+//     let end: string = '';
+//     let start: string = '';
+//     if (currentAudioPlayer?.timing?.length) {
+//         for (let i = 0; i < currentAudioPlayer.timing.length; i++) {
+//             const timing = currentAudioPlayer.timing![i];
+//             if (
+//                 currentAudioPlayer.progress >= timing.starttime &&
+//                 currentAudioPlayer.progress < timing.endtime
+//             ) {
+//                 const verseNumber = parseInt(timing.tag, 10);
+//                 for (let k = i + 1; k >= 0; k--) {
+//                     const startVerseNumber = parseInt(currentAudioPlayer.timing[k].tag, 10);
+//                     if (startVerseNumber !== verseNumber) {
+//                         start = currentAudioPlayer.timing[k + 1].tag;
+//                         break;
+//                     }
+//                     if (k === 0) {
+//                         start = currentAudioPlayer.timing[0].tag;
+//                         break;
+//                     }
+//                 }
+//                 for (let j = i + 1; j < currentAudioPlayer.timing.length; j++) {
+//                     const endVerseNumber = parseInt(currentAudioPlayer.timing[j].tag, 10);
+//                     if (endVerseNumber !== verseNumber) {
+//                         end = currentAudioPlayer.timing[j - 1].tag;
+//                         break;
+//                     }
+//                     if (j === currentAudioPlayer.timing.length - 1) {
+//                         end = currentAudioPlayer.timing[j].tag;
+//                         break;
+//                     }
+//                 }
+//                 break;
+//             }
+//         }
+//     }
+//     return getVerseTimingRange(start, end);
+// }
+
 function getCurrentVerseTiming() {
-    let end: string = '';
-    let start: string = '';
-    if (currentAudioPlayer?.timing?.length) {
-        for (let i = 0; i < currentAudioPlayer.timing.length; i++) {
-            const timing = currentAudioPlayer.timing![i];
-            if (
-                currentAudioPlayer.progress >= timing.starttime &&
-                currentAudioPlayer.progress < timing.endtime
-            ) {
-                const verseNumber = parseInt(timing.tag, 10);
-                for (let k = i + 1; k >= 0; k--) {
-                    const startVerseNumber = parseInt(currentAudioPlayer.timing[k].tag, 10);
-                    if (startVerseNumber !== verseNumber) {
-                        start = currentAudioPlayer.timing[k + 1].tag;
-                        break;
-                    }
-                    if (k === 0) {
-                        start = currentAudioPlayer.timing[0].tag;
-                        break;
-                    }
+    if (!currentAudioPlayer?.timing) {
+        console.error(`Warning in getCurrentVerseTiming(): ` + 
+                      "missing audio timing data");
+        return defaultPlayMode.range;
+    }
+    
+    let start = 0, end = 0;
+    for (let i = 0; i < currentAudioPlayer.timing.length; i++) {
+        const timing = currentAudioPlayer.timing[i];
+        if (
+            currentAudioPlayer.progress >= timing.starttime &&
+            currentAudioPlayer.progress < timing.endtime
+        ) {
+            // The verse number of tag '9a' is 9
+            const verseNumber = parseInt(timing.tag, 10);
+
+            // Step backwards until we reach the previous verse
+            for (let k = i; k >= 0; k--) {
+                const startVerseNumber = parseInt(currentAudioPlayer.timing[k].tag, 10);
+                // The last tag of the previous verse is the closest
+                // to the current tag to have a different verse number
+                if (startVerseNumber !== verseNumber) {
+                    start = currentAudioPlayer.timing[k + 1].starttime;
+                    break;
                 }
-                for (let j = i + 1; j < currentAudioPlayer.timing.length; j++) {
-                    const endVerseNumber = parseInt(currentAudioPlayer.timing[j].tag, 10);
-                    if (endVerseNumber !== verseNumber) {
-                        end = currentAudioPlayer.timing[j - 1].tag;
-                        break;
-                    }
-                    if (j === currentAudioPlayer.timing.length - 1) {
-                        end = currentAudioPlayer.timing[j].tag;
-                        break;
-                    }
+                // If we've gone to the beginning of the section, 
+                // assume we're in the first, "title" tag (or similar)
+                if (k === 0) {
+                    start = currentAudioPlayer.timing[0].starttime;
+                    break;
                 }
-                break;
             }
+
+            // Step forwards until we reach the next verse
+            for (let j = i + 1; j < currentAudioPlayer.timing.length; j++) {
+                const endVerseNumber = parseInt(currentAudioPlayer.timing[j].tag, 10);
+                if (endVerseNumber !== verseNumber) {
+                    end = currentAudioPlayer.timing[j - 1].endtime;
+                    break;
+                }
+                // If we've gone to the end of the section without
+                // progressing to the next verse, assume we're at the last tag
+                if (j === currentAudioPlayer.timing.length - 1) {
+                    end = currentAudioPlayer.timing[j].endtime;
+                    break;
+                }
+            }
+            break;
         }
     }
-    return getVerseTimingRange(start, end);
+
+    return { start, end } as PlayModeRange;
 }
 
 function getVerseEndTag(verse: string) {
@@ -437,11 +493,11 @@ export function playVerses(startVerse: string, endVerse?: string) {
 
     if (endVerse) {
         mode = PlayMode.RepeatSelection;
-        range = getVerseTimingRange(startVerse + 'a', getVerseEndTag(endVerse))
+        range = getVerseTimingRange(startVerse, endVerse) //
             || defaultPlayMode.range;
     } else {
         mode = currentPlayMode?.mode || defaultPlayMode.mode;
-        range = getVerseTimingRange(startVerse + 'a', getVerseEndTag(startVerse))
+        range = getVerseTimingRange(startVerse, startVerse) //
             || defaultPlayMode.range;
     }
 
@@ -593,20 +649,51 @@ export function seekToVerse(verseClicked: string) {
     updateTime();
 }
 // takes a start and end tag and returns the range of times
-function getVerseTimingRange(startTag: string, endTag: string) {
-    const elements = currentAudioPlayer?.timing ?? [];
-    let start: number = 0;
-    for (let i = 0; i < elements.length; i++) {
-        const tag = currentAudioPlayer!.timing![i].tag;
-        if (startTag === tag) {
-            const newstarttime = currentAudioPlayer!.timing![i].starttime;
-            start = newstarttime;
+// function getVerseTimingRange(startTag: string, endTag: string) {
+//     const elements = currentAudioPlayer?.timing ?? [];
+//     let start: number = 0;
+//     for (let i = 0; i < elements.length; i++) {
+//         const tag = currentAudioPlayer!.timing![i].tag;
+//         if (startTag === tag) {
+//             const newstarttime = currentAudioPlayer!.timing![i].starttime;
+//             start = newstarttime;
+//         }
+//         if (endTag === tag) {
+//             const newendtime = currentAudioPlayer!.timing![i].endtime;
+//             const end = newendtime;
+//             const range = { start, end };
+//             return range;
+//         }
+//     }
+// }
+
+// Get an audio timing range bounded by the first tag 
+// of startVerse and the last tag of endVerse
+function getVerseTimingRange(startVerse: string, endVerse: string) {
+    if (!currentAudioPlayer?.timing) {
+        console.error(`Warning in getVerseTimingRange(${startVerse}-${endVerse}): ` + 
+                      "missing audio timing data");
+        return defaultPlayMode.range;
+    }
+
+    let start = 0, end = 0;
+    for (let i = 0; i < currentAudioPlayer.timing.length; i++) {
+        const timing = currentAudioPlayer.timing[i];
+
+        // Handle case where tag has form '9a' for first phrase in verse 9
+        if (timing.tag === startVerse || timing.tag === (startVerse + 'a')) {
+            start = timing.starttime;
         }
-        if (endTag === tag) {
-            const newendtime = currentAudioPlayer!.timing![i].endtime;
-            const end = newendtime;
-            const range = { start, end };
-            return range;
+        if (timing.tag === endVerse) {
+            end = timing.endtime;
+            break;
+        } else if (parseInt(timing.tag) === (parseInt(endVerse) + 1)) {
+            // This is the first timing tag in the next verse, so 
+            // the previous tag (at i - 1) is the last tag in the current verse
+            end = currentAudioPlayer.timing[i - 1].endtime;
+            break;
         }
     }
+
+    return { start, end } as PlayModeRange;
 }

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -10,9 +10,9 @@ import {
     refs,
     type AudioPlayer,
     type PlayModeSettings,
+    type PlayModeRange,
     type Timing
 } from '$lib/data/stores';
-import type { PlayModeRange } from '$lib/data/stores';
 import { pathJoin } from '$lib/scripts/stringUtils';
 import { logAudioDuration, logAudioPlay } from './analytics';
 
@@ -36,13 +36,10 @@ audioPlayerStore.subscribe(async (value: AudioPlayer) => {
     currentAudioPlayer = value;
     await getAudio();
 });
-
 let currentPlayMode: PlayModeSettings | undefined = undefined;
 playMode.subscribe((value) => {
     currentPlayMode = value;
-    console.log(`playMode listener: ${currentPlayMode.mode}`);
 });
-
 // produces the cache key for the mru audio cache
 function cacheKey(collection: string, book: string, chapter: string) {
     return `${collection}-${book}-${chapter}`;
@@ -122,11 +119,10 @@ async function getAudio() {
         updateTime();
     };
 }
-
 // plays or pauses the audio
 export function playPause() {
     if (!currentAudioPlayer?.loaded) {
-        console.log("Warning: tried to playPause() audio that wasn't loaded");
+        console.error("Warning: tried to playPause() audio that wasn't loaded");
         return;
     }
 
@@ -134,9 +130,8 @@ export function playPause() {
         pause();
     } else {
         if (
-            currentPlayMode &&
-            currentPlayMode.range !== defaultPlayMode.range &&
-            currentAudioPlayer.progress > currentPlayMode.range.end
+            currentPlayMode && (currentPlayMode.range !== defaultPlayMode.range) &&
+            (currentAudioPlayer.progress > currentPlayMode.range.end)
         ) {
             resetVersePlaybackRange();
         }
@@ -145,16 +140,14 @@ export function playPause() {
     }
 }
 
-// stops playing audio
 export function playStop() {
     if (!currentAudioPlayer?.loaded) {
-        console.log("Warning: tried to playStop() audio that wasn't loaded");
+        console.error("Warning: tried to playStop() audio that wasn't loaded");
         return;
     }
 
     if (currentAudioPlayer.playing) {
         pause();
-        resetVersePlaybackRange();
     }
 }
 
@@ -264,7 +257,6 @@ let warmdown: number | undefined = undefined;
 // Interval callback for updating the audio state
 async function handlePlayMode() {
     if (warmdown) {
-        console.log(`warmdown == ${warmdown}`);
         warmdown--;
         if (warmdown === 0) {
             if (currentPlayMode?.mode === PlayMode.Continue) {
@@ -273,9 +265,6 @@ async function handlePlayMode() {
             } else if (currentPlayMode?.mode === PlayMode.RepeatPage) {
                 seek(0);
             } else if (currentPlayMode?.mode === PlayMode.RepeatSelection) {
-                console.log(
-                    `handlePlayMode: seeking to start of range ${currentPlayMode.range.start}-${currentPlayMode.range.end}`
-                );
                 seek(currentPlayMode.range.start);
                 play();
             }
@@ -296,13 +285,11 @@ async function handlePlayMode() {
         play();
     }
     if (currentPlayMode?.mode === PlayMode.RepeatSelection) {
-        console.log(`warmdown == ${warmdown}`);
         if (currentPlayMode.range === defaultPlayMode.range) {
             const resultArray = getCurrentVerseTiming();
             if (resultArray?.start === undefined || resultArray.end === undefined) {
                 return;
             }
-            console.log(`handlePlayMode: setting range to ${resultArray.start}-${resultArray.end}`);
             playMode.set({
                 ...currentPlayMode,
                 range: { start: resultArray.start, end: resultArray.end }
@@ -312,9 +299,6 @@ async function handlePlayMode() {
             currentAudioPlayer?.playing &&
             (currentAudioPlayer?.progress ?? 0) + 0.05 > currentPlayMode.range.end
         ) {
-            console.log(
-                `handlePlayMode: pausing since after end (${currentAudioPlayer?.progress ?? 0 + 0.05} > ${currentPlayMode.range.end})`
-            );
             pause({ keepListening: true });
             warmdown = 5;
         }
@@ -387,6 +371,11 @@ function getCurrentVerseTiming() {
     }
 
     return { start, end } as PlayModeRange;
+}
+
+// Sets the playback range to the start and end of the current verse
+function resetVersePlaybackRange() {
+    playMode.set({ ...(currentPlayMode || defaultPlayMode), range: getCurrentVerseTiming() });
 }
 
 // function get range of current index all labels of the current verse playing
@@ -487,80 +476,6 @@ export function playVerses(startVerse: string, endVerse?: string) {
     playMode.set({ mode, range });
     seekToVerse(startVerse);
     play();
-}
-
-// Seek to the start of the first audio tag for the specified verse
-export function seekToVerse(verse: string) {
-    if (!currentAudioPlayer?.timing) {
-        console.error(`Warning in seekToVerse(${verse}): ` + 'missing audio timing data');
-        return;
-    }
-
-    for (let i = 0; i < currentAudioPlayer.timing.length; i++) {
-        const timing = currentAudioPlayer.timing[i];
-        // Handle case where tag has form '9a' for first tag in verse 9
-        if (timing.tag === verse || timing.tag === verse + 'a') {
-            seek(timing.starttime);
-            // Force text highlighting update
-            updateTime();
-            return;
-        }
-    }
-}
-
-// Get an audio timing range bounded by the first tag
-// of startVerse and the last tag of endVerse
-function getVerseTimingRange(startVerse: string, endVerse: string) {
-    if (!currentAudioPlayer?.timing) {
-        console.error(
-            `Warning in getVerseTimingRange(${startVerse}-${endVerse}): ` +
-                'missing audio timing data'
-        );
-        return defaultPlayMode.range;
-    }
-
-    let start = 0,
-        end = 0;
-    const finalTiming = currentAudioPlayer.timing.at(-1)!;
-    const finalVerseNumber = parseInt(finalTiming.tag);
-
-    for (let i = 0; i < currentAudioPlayer.timing.length; i++) {
-        const timing = currentAudioPlayer.timing[i];
-
-        // Handle case where tag has form '9a' for first tag in verse 9
-        if (timing.tag === startVerse || timing.tag === startVerse + 'a') {
-            start = timing.starttime;
-        }
-
-        // If end verse has a single numeric tag, that is the last tag
-        if (timing.tag === endVerse) {
-            end = timing.endtime;
-            break;
-        }
-
-        // Otherwise, we need to find the last tag of the end verse
-        const verseNumber = parseInt(timing.tag);
-        if (verseNumber === parseInt(endVerse) + 1) {
-            // This is the first timing tag in the next verse, so
-            // the previous tag (at i - 1) is the last tag in the current verse
-            end = currentAudioPlayer.timing[i - 1].endtime;
-            break;
-        } else if (verseNumber === finalVerseNumber) {
-            // There is no "next verse" for the final verse of the chapter,
-            // but we already know the final tag of the final verse
-            end = finalTiming.endtime;
-            break;
-        }
-    }
-
-    return { start, end } as PlayModeRange;
-}
-
-// Sets the playback range to the start and end of the current verse
-function resetVersePlaybackRange() {
-    const range = getCurrentVerseTiming();
-    console.log(`resetVersePlaybackRange: ${range.start}-${range.end}`);
-    playMode.set({ ...(currentPlayMode || defaultPlayMode), range: getCurrentVerseTiming() });
 }
 
 // selects the tag to highlight
@@ -682,4 +597,71 @@ export async function getAudioSourceInfo(
         source: audioPath,
         timing: timing.length > 0 ? timing : null
     };
+}
+
+// Seek to the start of the first audio tag for the specified verse
+export function seekToVerse(verse: string) {
+    if (!currentAudioPlayer?.timing) {
+        console.error(`Warning in seekToVerse(${verse}): ` + 'missing audio timing data');
+        return;
+    }
+
+    for (let i = 0; i < currentAudioPlayer.timing.length; i++) {
+        const timing = currentAudioPlayer.timing[i];
+        // Handle case where tag has form '9a' for first tag in verse 9
+        if (timing.tag === verse || timing.tag === verse + 'a') {
+            seek(timing.starttime);
+            // Force text highlighting update
+            updateTime();
+            return;
+        }
+    }
+}
+
+// Get an audio timing range bounded by the first tag
+// of startVerse and the last tag of endVerse
+function getVerseTimingRange(startVerse: string, endVerse: string) {
+    if (!currentAudioPlayer?.timing) {
+        console.error(
+            `Warning in getVerseTimingRange(${startVerse}-${endVerse}): ` +
+                'missing audio timing data'
+        );
+        return defaultPlayMode.range;
+    }
+
+    let start = 0,
+        end = 0;
+    const finalTiming = currentAudioPlayer.timing.at(-1)!;
+    const finalVerseNumber = parseInt(finalTiming.tag);
+
+    for (let i = 0; i < currentAudioPlayer.timing.length; i++) {
+        const timing = currentAudioPlayer.timing[i];
+
+        // Handle case where tag has form '9a' for first tag in verse 9
+        if (timing.tag === startVerse || timing.tag === startVerse + 'a') {
+            start = timing.starttime;
+        }
+
+        // If end verse has a single numeric tag, that is the last tag
+        if (timing.tag === endVerse) {
+            end = timing.endtime;
+            break;
+        }
+
+        // Otherwise, we need to find the last tag of the end verse
+        const verseNumber = parseInt(timing.tag);
+        if (verseNumber === parseInt(endVerse) + 1) {
+            // This is the first timing tag in the next verse, so
+            // the previous tag (at i - 1) is the last tag in the current verse
+            end = currentAudioPlayer.timing[i - 1].endtime;
+            break;
+        } else if (verseNumber === finalVerseNumber) {
+            // There is no "next verse" for the final verse of the chapter,
+            // but we already know the final tag of the final verse
+            end = finalTiming.endtime;
+            break;
+        }
+    }
+
+    return { start, end } as PlayModeRange;
 }

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -46,6 +46,7 @@ playMode.subscribe((value) => {
         value.range = timing || value.range;
     }
     currentPlayMode = value;
+    console.log(`playMode listener: ${currentPlayMode.mode}`);
 });
 // produces the cache key for the mru audio cache
 function cacheKey(collection: string, book: string, chapter: string) {
@@ -230,6 +231,7 @@ export function seek(position: number) {
     const timing = getCurrentVerseTiming();
     if (currentAudioPlayer && timing) {
         currentAudioPlayer.progress = position;
+        console.log(`seek: ${currentPlayMode?.mode}`);
         playMode.set({ ...(currentPlayMode ?? { mode: defaultPlayMode.mode }), range: timing });
         audioPlayerStore.set(currentAudioPlayer);
     }

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -133,8 +133,10 @@ export function playPause() {
     if (currentAudioPlayer.playing) {
         pause();
     } else {
-        if (currentPlayMode && (currentPlayMode.range !== defaultPlayMode.range) &&
-           (currentAudioPlayer.progress > currentPlayMode.range.end)
+        if (
+            currentPlayMode &&
+            currentPlayMode.range !== defaultPlayMode.range &&
+            currentAudioPlayer.progress > currentPlayMode.range.end
         ) {
             resetVersePlaybackRange();
         }
@@ -153,7 +155,7 @@ export function playStop() {
     if (currentAudioPlayer.playing) {
         pause();
         resetVersePlaybackRange();
-    } 
+    }
 }
 
 // changes chapter
@@ -233,25 +235,29 @@ export async function seekOffset(offset: number) {
 // Move the audio player to the given number of seconds from the start
 export function seek(position: number) {
     if (!currentAudioPlayer) {
-        console.error("Warning: missing audio player in seek()");
+        console.error('Warning: missing audio player in seek()');
         return;
     } else if (!currentAudioPlayer.audio) {
-        console.error("Warning: null audio element in seek()");
+        console.error('Warning: null audio element in seek()');
         return;
     }
 
     // If the audio is playing, we'll need to resume after the seek
     const wasPlaying = currentAudioPlayer.playing;
-    if (wasPlaying) { pause() };
+    if (wasPlaying) {
+        pause();
+    }
 
     currentAudioPlayer.audio.currentTime = position;
     currentAudioPlayer.progress = position;
     audioPlayerStore.set(currentAudioPlayer);
 
-    if (wasPlaying) { play() };
+    if (wasPlaying) {
+        play();
+    }
 }
 
-// Countdown timer for slight delay before repeating the 
+// Countdown timer for slight delay before repeating the
 // current section or continuing to next section
 let warmdown: number | undefined = undefined;
 
@@ -267,7 +273,9 @@ async function handlePlayMode() {
             } else if (currentPlayMode?.mode === PlayMode.RepeatPage) {
                 seek(0);
             } else if (currentPlayMode?.mode === PlayMode.RepeatSelection) {
-                console.log(`handlePlayMode: seeking to start of range ${currentPlayMode.range.start}-${currentPlayMode.range.end}`);
+                console.log(
+                    `handlePlayMode: seeking to start of range ${currentPlayMode.range.start}-${currentPlayMode.range.end}`
+                );
                 seek(currentPlayMode.range.start);
                 play();
             }
@@ -300,9 +308,13 @@ async function handlePlayMode() {
                 range: { start: resultArray.start, end: resultArray.end }
             });
         }
-        if (currentAudioPlayer?.playing && ((currentAudioPlayer?.progress ?? 0) + 0.05 >
-             currentPlayMode.range.end)) {
-            console.log(`handlePlayMode: pausing since after end (${currentAudioPlayer?.progress ?? 0 + 0.05} > ${currentPlayMode.range.end})`);
+        if (
+            currentAudioPlayer?.playing &&
+            (currentAudioPlayer?.progress ?? 0) + 0.05 > currentPlayMode.range.end
+        ) {
+            console.log(
+                `handlePlayMode: pausing since after end (${currentAudioPlayer?.progress ?? 0 + 0.05} > ${currentPlayMode.range.end})`
+            );
             pause({ keepListening: true });
             warmdown = 5;
         }
@@ -312,15 +324,15 @@ async function handlePlayMode() {
 // Get the audio start and end timestamps for the current verse as a range
 function getCurrentVerseTiming() {
     if (!currentAudioPlayer?.timing) {
-        console.error(`Warning in getCurrentVerseTiming(): ` + 
-                      "missing audio timing data");
+        console.error(`Warning in getCurrentVerseTiming(): ` + 'missing audio timing data');
         return defaultPlayMode.range;
     }
 
-    let start = 0, end = 0;
+    let start = 0,
+        end = 0;
 
     // Handle the title segment as a special case.
-    // The loading function for timings always adds a 
+    // The loading function for timings always adds a
     // 'title' tag as the first timing, so the first verse
     // is actually at the second position in the timing array
     const firstVerseTiming = currentAudioPlayer.timing[1];
@@ -348,7 +360,7 @@ function getCurrentVerseTiming() {
                     start = currentAudioPlayer.timing[k + 1].starttime;
                     break;
                 }
-                // If we've gone to the beginning of the section, 
+                // If we've gone to the beginning of the section,
                 // assume we're in the first, "title" tag (or similar)
                 if (k === 0) {
                     start = currentAudioPlayer.timing[0].starttime;
@@ -396,12 +408,12 @@ async function updateTime() {
 // calls updateTime() every 100ms
 function updateAudioHandler() {
     if (!currentAudioPlayer?.audio) {
-        console.error("Warning: tried to update listener for missing audio");
+        console.error('Warning: tried to update listener for missing audio');
         return;
     }
 
     if (currentAudioPlayer.audio.ended || !currentAudioPlayer.playing) {
-        // Separate this condition check since we don't want to call 
+        // Separate this condition check since we don't want to call
         // setInterval (the else case) unless the audio is actually playing
         if (currentAudioPlayer.timer) {
             clearInterval(currentAudioPlayer.timer);
@@ -421,7 +433,7 @@ export function hasAudioPlayed() {
 // Pause audio if currently playing
 function pause(options?: { keepListening: boolean }) {
     if (!currentAudioPlayer?.loaded) {
-        console.error("Warning: tried to pause() audio before it was loaded");
+        console.error('Warning: tried to pause() audio before it was loaded');
         return;
     }
 
@@ -439,7 +451,7 @@ function pause(options?: { keepListening: boolean }) {
 // Play audio if currently paused
 export function play() {
     if (!currentAudioPlayer?.loaded) {
-        console.error("Warning: tried to play() audio before it was loaded");
+        console.error('Warning: tried to play() audio before it was loaded');
         return;
     }
 
@@ -460,12 +472,14 @@ export function playVerses(startVerse: string, endVerse?: string) {
 
     if (endVerse) {
         mode = PlayMode.RepeatSelection;
-        range = getVerseTimingRange(startVerse, endVerse) //
-            || defaultPlayMode.range;
+        range =
+            getVerseTimingRange(startVerse, endVerse) || //
+            defaultPlayMode.range;
     } else {
         mode = currentPlayMode?.mode || defaultPlayMode.mode;
-        range = getVerseTimingRange(startVerse, startVerse) //
-            || defaultPlayMode.range;
+        range =
+            getVerseTimingRange(startVerse, startVerse) || //
+            defaultPlayMode.range;
     }
 
     console.log(`playVerses: setting range ${range.start} - ${range.end}`);
@@ -478,34 +492,35 @@ export function playVerses(startVerse: string, endVerse?: string) {
 // Seek to the start of the first audio tag for the specified verse
 export function seekToVerse(verse: string) {
     if (!currentAudioPlayer?.timing) {
-        console.error(`Warning in seekToVerse(${verse}): ` + 
-                      "missing audio timing data");
-        return; 
+        console.error(`Warning in seekToVerse(${verse}): ` + 'missing audio timing data');
+        return;
     }
 
     for (let i = 0; i < currentAudioPlayer.timing.length; i++) {
         const timing = currentAudioPlayer.timing[i];
         // Handle case where tag has form '9a' for first tag in verse 9
-        if (timing.tag === verse || timing.tag === (verse + 'a')) {
+        if (timing.tag === verse || timing.tag === verse + 'a') {
             seek(timing.starttime);
             // Force text highlighting update
             updateTime();
             return;
         }
     }
-
 }
 
-// Get an audio timing range bounded by the first tag 
+// Get an audio timing range bounded by the first tag
 // of startVerse and the last tag of endVerse
 function getVerseTimingRange(startVerse: string, endVerse: string) {
     if (!currentAudioPlayer?.timing) {
-        console.error(`Warning in getVerseTimingRange(${startVerse}-${endVerse}): ` + 
-                      "missing audio timing data");
+        console.error(
+            `Warning in getVerseTimingRange(${startVerse}-${endVerse}): ` +
+                'missing audio timing data'
+        );
         return defaultPlayMode.range;
     }
 
-    let start = 0, end = 0;
+    let start = 0,
+        end = 0;
     const finalTiming = currentAudioPlayer.timing.at(-1)!;
     const finalVerseNumber = parseInt(finalTiming.tag);
 
@@ -513,7 +528,7 @@ function getVerseTimingRange(startVerse: string, endVerse: string) {
         const timing = currentAudioPlayer.timing[i];
 
         // Handle case where tag has form '9a' for first tag in verse 9
-        if (timing.tag === startVerse || timing.tag === (startVerse + 'a')) {
+        if (timing.tag === startVerse || timing.tag === startVerse + 'a') {
             start = timing.starttime;
         }
 
@@ -525,8 +540,8 @@ function getVerseTimingRange(startVerse: string, endVerse: string) {
 
         // Otherwise, we need to find the last tag of the end verse
         const verseNumber = parseInt(timing.tag);
-        if (verseNumber === (parseInt(endVerse) + 1)) {
-            // This is the first timing tag in the next verse, so 
+        if (verseNumber === parseInt(endVerse) + 1) {
+            // This is the first timing tag in the next verse, so
             // the previous tag (at i - 1) is the last tag in the current verse
             end = currentAudioPlayer.timing[i - 1].endtime;
             break;
@@ -545,7 +560,7 @@ function getVerseTimingRange(startVerse: string, endVerse: string) {
 function resetVersePlaybackRange() {
     const range = getCurrentVerseTiming();
     console.log(`resetVersePlaybackRange: ${range.start}-${range.end}`);
-    playMode.set({...(currentPlayMode || defaultPlayMode), range: getCurrentVerseTiming()}); 
+    playMode.set({ ...(currentPlayMode || defaultPlayMode), range: getCurrentVerseTiming() });
 }
 
 // selects the tag to highlight

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -129,23 +129,15 @@ async function getAudio() {
 }
 // plays or pauses the audio
 export function playPause() {
-    if (!currentAudioPlayer?.loaded) {
-        return;
+    if (currentAudioPlayer?.loaded) {
+        currentAudioPlayer.playing? pause() : play();
     }
-    if (currentAudioPlayer.playing === true) {
-        pause();
-    } else {
-        play();
-    }
-    audioPlayerStore.set(currentAudioPlayer);
 }
+// stops playing audio
 export function playStop() {
-    if (!currentAudioPlayer?.loaded) {
-        return;
-    }
-    if (currentAudioPlayer.playing === true) {
-        pause();
-    }
+    if (currentAudioPlayer?.loaded && currentAudioPlayer.playing) {
+        pause()
+    };
 }
 // changes chapter
 export async function skip(direction: number) {
@@ -221,23 +213,49 @@ export async function seekOffset(offset: number) {
     }
 }
 export function seek(position: number) {
-    const playing = currentAudioPlayer?.playing;
-    pause();
-    if (currentAudioPlayer?.audio) {
-        currentAudioPlayer.audio.currentTime = position;
-    } else {
-        console.log('audio seek: current audio player audio missing ');
+    // const playing = currentAudioPlayer?.playing;
+    // pause();
+    // if (currentAudioPlayer?.audio) {
+    //     currentAudioPlayer.audio.currentTime = position;
+    // } else {
+    //     console.log('audio seek: current audio player audio missing ');
+    // }
+    // const timing = getCurrentVerseTiming();
+    // console.log(`seek: position ${position} with timing ${timing?.start}-${timing?.end}`);
+    // if (currentAudioPlayer && timing) {
+    //     currentAudioPlayer.progress = position;
+    //     console.log(`seek: ${currentPlayMode?.mode}`);
+    //     playMode.set({ ...(currentPlayMode ?? { mode: defaultPlayMode.mode }), range: timing });
+    //     audioPlayerStore.set(currentAudioPlayer);
+    // }
+    // if (playing === true) {
+    //     play();
+    // }
+
+
+    if (!currentAudioPlayer) {
+        console.error("Warning: missing audio player in seek()");
+        return;
+    } else if (!currentAudioPlayer.audio) {
+        console.error("Warning: null audio element in seek()");
+        return;
     }
+
+    const wasPlaying = currentAudioPlayer.playing;
+    if (wasPlaying) pause();
+
+    currentAudioPlayer.audio.currentTime = position;
+    currentAudioPlayer.progress = position;
+
     const timing = getCurrentVerseTiming();
-    if (currentAudioPlayer && timing) {
-        currentAudioPlayer.progress = position;
-        console.log(`seek: ${currentPlayMode?.mode}`);
+    console.log(`seek: target position ${position}, verse ${timing?.start}-${timing?.end}`);
+
+    if (timing) {
         playMode.set({ ...(currentPlayMode ?? { mode: defaultPlayMode.mode }), range: timing });
-        audioPlayerStore.set(currentAudioPlayer);
     }
-    if (playing === true) {
-        play();
-    }
+    audioPlayerStore.set(currentAudioPlayer);
+
+    if (wasPlaying) play();
 }
 let warmdown: number | undefined = undefined;
 async function handlePlayMode() {
@@ -250,6 +268,7 @@ async function handlePlayMode() {
             } else if (currentPlayMode?.mode === PlayMode.RepeatPage) {
                 seek(0);
             } else if (currentPlayMode?.mode === PlayMode.RepeatSelection) {
+                console.log(`handlePlayMode: seeking to start of range ${currentPlayMode.range.start}-${currentPlayMode.range.end}`);
                 seek(currentPlayMode.range.start);
                 play();
             }
@@ -260,7 +279,7 @@ async function handlePlayMode() {
     if (currentAudioPlayer?.audio?.ended) {
         if (currentPlayMode?.mode === PlayMode.Stop) {
             pause();
-            audioPlayerStore.set(currentAudioPlayer);
+            // audioPlayerStore.set(currentAudioPlayer);
         } else {
             warmdown = 5;
         }
@@ -271,11 +290,13 @@ async function handlePlayMode() {
         play();
     }
     if (currentPlayMode?.mode === PlayMode.RepeatSelection) {
+        // console.log(`warmdown == ${warmdown}`);
         if (currentPlayMode.range === defaultPlayMode.range) {
             const resultArray = getCurrentVerseTiming();
             if (resultArray?.start === undefined || resultArray.end === undefined) {
                 return;
             }
+            console.log(`handlePlayMode: setting range to ${resultArray.start}-${resultArray.end}`);
             playMode.set({
                 ...currentPlayMode,
                 range: { start: resultArray.start, end: resultArray.end }
@@ -366,6 +387,7 @@ function pause() {
         currentAudioPlayer.playing = false;
     }
     toggleTimeRunning();
+    audioPlayerStore.set(currentAudioPlayer);
 }
 
 export function play() {
@@ -379,6 +401,7 @@ export function play() {
         currentAudioPlayer.playing = true;
     }
     toggleTimeRunning();
+    audioPlayerStore.set(currentAudioPlayer);
 }
 // selects the tag to highlight
 function updateHighlights() {

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -12,6 +12,7 @@ import {
     type PlayModeSettings,
     type Timing
 } from '$lib/data/stores';
+import type { PlayModeRange } from '$lib/data/stores';
 import { pathJoin } from '$lib/scripts/stringUtils';
 import { logAudioDuration, logAudioPlay } from './analytics';
 
@@ -213,26 +214,6 @@ export async function seekOffset(offset: number) {
     }
 }
 export function seek(position: number) {
-    // const playing = currentAudioPlayer?.playing;
-    // pause();
-    // if (currentAudioPlayer?.audio) {
-    //     currentAudioPlayer.audio.currentTime = position;
-    // } else {
-    //     console.log('audio seek: current audio player audio missing ');
-    // }
-    // const timing = getCurrentVerseTiming();
-    // console.log(`seek: position ${position} with timing ${timing?.start}-${timing?.end}`);
-    // if (currentAudioPlayer && timing) {
-    //     currentAudioPlayer.progress = position;
-    //     console.log(`seek: ${currentPlayMode?.mode}`);
-    //     playMode.set({ ...(currentPlayMode ?? { mode: defaultPlayMode.mode }), range: timing });
-    //     audioPlayerStore.set(currentAudioPlayer);
-    // }
-    // if (playing === true) {
-    //     play();
-    // }
-
-
     if (!currentAudioPlayer) {
         console.error("Warning: missing audio player in seek()");
         return;
@@ -241,18 +222,18 @@ export function seek(position: number) {
         return;
     }
 
+    // If the audio is playing, we'll need to resume after the seek
     const wasPlaying = currentAudioPlayer.playing;
     if (wasPlaying) pause();
 
+    // const timing = getCurrentVerseTiming();
+    // console.log(`seek: target position ${position}, verse ${timing?.start}-${timing?.end}`);
+    // if (timing) {
+    //     playMode.set({ ...(currentPlayMode ?? { mode: defaultPlayMode.mode }), range: timing });
+    // }
+
     currentAudioPlayer.audio.currentTime = position;
     currentAudioPlayer.progress = position;
-
-    const timing = getCurrentVerseTiming();
-    console.log(`seek: target position ${position}, verse ${timing?.start}-${timing?.end}`);
-
-    if (timing) {
-        playMode.set({ ...(currentPlayMode ?? { mode: defaultPlayMode.mode }), range: timing });
-    }
     audioPlayerStore.set(currentAudioPlayer);
 
     if (wasPlaying) play();
@@ -348,6 +329,50 @@ function getCurrentVerseTiming() {
     }
     return getVerseTimingRange(start, end);
 }
+
+function getVerseEndTag(verse: string) {
+    if (!currentAudioPlayer?.timing) {
+        // No further detail, so return base tag
+        return verse;
+    }
+
+    let startTag = '', endTag = '', i: number;
+
+    // First find the beginning of the verse
+    for (i = 0; i < currentAudioPlayer.timing.length; i++) {
+        //adapted from seekToVerse() below
+        const tag = currentAudioPlayer.timing[i].tag;
+        const containsAlpha = /[a-z]/.test(tag);
+        const adjustedTag = containsAlpha ? tag : tag + 'a';
+
+        console.log(`Trying tag ${adjustedTag}`);
+
+        if (adjustedTag.slice(0, adjustedTag.length - 1) === verse) {
+            startTag = adjustedTag;
+            break;
+        }
+    }
+
+    // Then find the end of the verse
+    const baseTag = parseInt(startTag, 10);
+    console.log(`getVerseEndTag(${verse}): start tag is (${startTag}), base (${baseTag})`);
+    for (let j = i + 1; j < currentAudioPlayer.timing.length; j++) {
+        const endVerseNumber = parseInt(currentAudioPlayer.timing[j].tag, 10);
+        if (endVerseNumber !== baseTag) {
+            endTag = currentAudioPlayer.timing[j - 1].tag;
+            break;
+        }
+        if (j === currentAudioPlayer.timing.length - 1) {
+            endTag = currentAudioPlayer.timing[j].tag;
+            break;
+        }
+    }
+
+    console.log(`getVerseEndTag(${verse}): found end tag of ${endTag}`);
+
+    return endTag;
+}
+
 // function get range of current index all labels of the current verse playing
 // calls updatehighlights() to see if highlights need to be change
 async function updateTime() {
@@ -403,6 +428,27 @@ export function play() {
     toggleTimeRunning();
     audioPlayerStore.set(currentAudioPlayer);
 }
+
+export function playVerses(startVerse: string, endVerse?: string) {
+    let mode: PlayMode, range: PlayModeRange;
+
+    if (endVerse) {
+        mode = PlayMode.RepeatSelection;
+        range = getVerseTimingRange(startVerse + 'a', getVerseEndTag(endVerse))
+            || defaultPlayMode.range;
+    } else {
+        mode = currentPlayMode?.mode || defaultPlayMode.mode;
+        range = getVerseTimingRange(startVerse + 'a', getVerseEndTag(startVerse))
+            || defaultPlayMode.range;
+    }
+
+    console.log(`playVerses: setting range ${range.start} - ${range.end}`);
+
+    playMode.set({ mode, range });
+    seekToVerse(startVerse + 'a');
+    play();
+}
+
 // selects the tag to highlight
 function updateHighlights() {
     const highlights = [];
@@ -544,16 +590,16 @@ export function seekToVerse(verseClicked: string) {
     updateTime();
 }
 // takes a start and end tag and returns the range of times
-function getVerseTimingRange(startverse: string, endverse: string) {
+function getVerseTimingRange(startTag: string, endTag: string) {
     const elements = currentAudioPlayer?.timing ?? [];
     let start: number = 0;
     for (let i = 0; i < elements.length; i++) {
         const tag = currentAudioPlayer!.timing![i].tag;
-        if (startverse === tag) {
+        if (startTag === tag) {
             const newstarttime = currentAudioPlayer!.timing![i].starttime;
             start = newstarttime;
         }
-        if (endverse === tag) {
+        if (endTag === tag) {
             const newendtime = currentAudioPlayer!.timing![i].endtime;
             const end = newendtime;
             const range = { start, end };

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -285,7 +285,7 @@ async function handlePlayMode() {
         }
         if ((currentAudioPlayer?.progress ?? 0) + 0.05 > currentPlayMode.range.end) {
             console.log(`handlePlayMode: pausing since after end (${currentAudioPlayer?.progress ?? 0 + 0.05} > ${currentPlayMode.range.end})`);
-            pause();
+            pause({ keepListening: true });
             warmdown = 5;
         }
     }
@@ -362,24 +362,34 @@ async function updateTime() {
     }
     await handlePlayMode();
 }
+
 // calls updateTime() every 100ms
-function toggleTimeRunning() {
-    if (currentPlayMode?.mode !== PlayMode.RepeatSelection && 
-        (currentAudioPlayer?.audio?.ended || currentAudioPlayer?.playing === false)) {
-        clearInterval(currentAudioPlayer?.timer ?? undefined);
-        currentAudioPlayer.timer = null;
-    } else if (currentAudioPlayer) {
+function updateAudioListener() {
+    if (!currentAudioPlayer?.audio) {
+        console.error("Warning: tried to update listener for missing audio");
+        return;
+    }
+
+    if (currentAudioPlayer.audio.ended || !currentAudioPlayer.playing) {
+        // Separate this condition check since we don't want to call 
+        // setInterval (the else case) unless the audio is actually playing
+        if (currentAudioPlayer.timer) {
+            clearInterval(currentAudioPlayer.timer);
+            currentAudioPlayer.timer = null;
+        }
+    } else if (!currentAudioPlayer.timer) {
         currentAudioPlayer.timer = setInterval(() => updateTime(), 100);
     }
     return;
 }
+
 // checks if audio has played
 export function hasAudioPlayed() {
     return (currentAudioPlayer?.progress ?? 0) > 0;
 }
 
 // Pause audio if currently playing
-function pause() {
+function pause(options?: { keepListening: boolean }) {
     if (!currentAudioPlayer?.loaded) {
         console.error("Warning: tried to pause() audio before it was loaded");
         return;
@@ -389,7 +399,9 @@ function pause() {
         currentAudioPlayer.audio?.pause();
         logAudioDuration(currentAudioPlayer);
         currentAudioPlayer.playing = false;
-        toggleTimeRunning();
+        if (!options?.keepListening) {
+            updateAudioListener();
+        }
         audioPlayerStore.set(currentAudioPlayer);
     }
 }
@@ -406,7 +418,7 @@ export function play() {
         currentAudioPlayer.playStart = Date.now();
         logAudioPlay(currentAudioPlayer);
         currentAudioPlayer.playing = true;
-        toggleTimeRunning();
+        updateAudioListener();
         audioPlayerStore.set(currentAudioPlayer);
     }
 }

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -125,18 +125,35 @@ async function getAudio() {
 
 // plays or pauses the audio
 export function playPause() {
-    if (currentAudioPlayer?.loaded) {
-        currentAudioPlayer.playing? pause() : play();
-    } else {
+    if (!currentAudioPlayer?.loaded) {
         console.log("Warning: tried to playPause() audio that wasn't loaded");
+        return;
+    }
+
+    if (currentAudioPlayer.playing) {
+        pause();
+    } else {
+        if (currentPlayMode && (currentPlayMode.range !== defaultPlayMode.range) &&
+           (currentAudioPlayer.progress > currentPlayMode.range.end)
+        ) {
+            resetVersePlaybackRange();
+        }
+
+        play();
     }
 }
 
 // stops playing audio
 export function playStop() {
-    // The previous implementation of this function is now equivalent to pause()
-    // Keeping this alias for another PR to refactor to reduce scope
-    pause();
+    if (!currentAudioPlayer?.loaded) {
+        console.log("Warning: tried to playStop() audio that wasn't loaded");
+        return;
+    }
+
+    if (currentAudioPlayer.playing) {
+        pause();
+        resetVersePlaybackRange();
+    } 
 }
 
 // changes chapter
@@ -283,7 +300,8 @@ async function handlePlayMode() {
                 range: { start: resultArray.start, end: resultArray.end }
             });
         }
-        if ((currentAudioPlayer?.progress ?? 0) + 0.05 > currentPlayMode.range.end) {
+        if (currentAudioPlayer?.playing && ((currentAudioPlayer?.progress ?? 0) + 0.05 >
+             currentPlayMode.range.end)) {
             console.log(`handlePlayMode: pausing since after end (${currentAudioPlayer?.progress ?? 0 + 0.05} > ${currentPlayMode.range.end})`);
             pause({ keepListening: true });
             warmdown = 5;
@@ -298,8 +316,20 @@ function getCurrentVerseTiming() {
                       "missing audio timing data");
         return defaultPlayMode.range;
     }
-    
+
     let start = 0, end = 0;
+
+    // Handle the title segment as a special case.
+    // The loading function for timings always adds a 
+    // 'title' tag as the first timing, so the first verse
+    // is actually at the second position in the timing array
+    const firstVerseTiming = currentAudioPlayer.timing[1];
+    if (currentAudioPlayer.progress < firstVerseTiming.starttime) {
+        // We're in the title segment; return timings for the first verse
+        return getVerseTimingRange('1', '1');
+    }
+
+    // Otherwise, find timings for the current verse
     for (let i = 0; i < currentAudioPlayer.timing.length; i++) {
         const timing = currentAudioPlayer.timing[i];
         if (
@@ -364,7 +394,7 @@ async function updateTime() {
 }
 
 // calls updateTime() every 100ms
-function updateAudioListener() {
+function updateAudioHandler() {
     if (!currentAudioPlayer?.audio) {
         console.error("Warning: tried to update listener for missing audio");
         return;
@@ -400,7 +430,7 @@ function pause(options?: { keepListening: boolean }) {
         logAudioDuration(currentAudioPlayer);
         currentAudioPlayer.playing = false;
         if (!options?.keepListening) {
-            updateAudioListener();
+            updateAudioHandler();
         }
         audioPlayerStore.set(currentAudioPlayer);
     }
@@ -418,7 +448,7 @@ export function play() {
         currentAudioPlayer.playStart = Date.now();
         logAudioPlay(currentAudioPlayer);
         currentAudioPlayer.playing = true;
-        updateAudioListener();
+        updateAudioHandler();
         audioPlayerStore.set(currentAudioPlayer);
     }
 }
@@ -476,6 +506,9 @@ function getVerseTimingRange(startVerse: string, endVerse: string) {
     }
 
     let start = 0, end = 0;
+    const finalTiming = currentAudioPlayer.timing.at(-1)!;
+    const finalVerseNumber = parseInt(finalTiming.tag);
+
     for (let i = 0; i < currentAudioPlayer.timing.length; i++) {
         const timing = currentAudioPlayer.timing[i];
 
@@ -483,18 +516,36 @@ function getVerseTimingRange(startVerse: string, endVerse: string) {
         if (timing.tag === startVerse || timing.tag === (startVerse + 'a')) {
             start = timing.starttime;
         }
+
+        // If end verse has a single numeric tag, that is the last tag
         if (timing.tag === endVerse) {
             end = timing.endtime;
             break;
-        } else if (parseInt(timing.tag) === (parseInt(endVerse) + 1)) {
+        }
+
+        // Otherwise, we need to find the last tag of the end verse
+        const verseNumber = parseInt(timing.tag);
+        if (verseNumber === (parseInt(endVerse) + 1)) {
             // This is the first timing tag in the next verse, so 
             // the previous tag (at i - 1) is the last tag in the current verse
             end = currentAudioPlayer.timing[i - 1].endtime;
+            break;
+        } else if (verseNumber === finalVerseNumber) {
+            // There is no "next verse" for the final verse of the chapter,
+            // but we already know the final tag of the final verse
+            end = finalTiming.endtime;
             break;
         }
     }
 
     return { start, end } as PlayModeRange;
+}
+
+// Sets the playback range to the start and end of the current verse
+function resetVersePlaybackRange() {
+    const range = getCurrentVerseTiming();
+    console.log(`resetVersePlaybackRange: ${range.start}-${range.end}`);
+    playMode.set({...(currentPlayMode || defaultPlayMode), range: getCurrentVerseTiming()}); 
 }
 
 // selects the tag to highlight

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -9,8 +9,8 @@ import {
     PlayMode,
     refs,
     type AudioPlayer,
-    type PlayModeSettings,
     type PlayModeRange,
+    type PlayModeSettings,
     type Timing
 } from '$lib/data/stores';
 import { pathJoin } from '$lib/scripts/stringUtils';
@@ -130,8 +130,9 @@ export function playPause() {
         pause();
     } else {
         if (
-            currentPlayMode && (currentPlayMode.range !== defaultPlayMode.range) &&
-            (currentAudioPlayer.progress > currentPlayMode.range.end)
+            currentPlayMode &&
+            currentPlayMode.range !== defaultPlayMode.range &&
+            currentAudioPlayer.progress > currentPlayMode.range.end
         ) {
             resetVersePlaybackRange();
         }
@@ -155,6 +156,8 @@ export function playStop() {
 export async function skip(direction: number) {
     pause();
     await refs.skip(direction);
+    playMode.reset();
+    // resetVersePlaybackRange();
 }
 // formats timing information
 export function format(seconds: number) {
@@ -167,24 +170,23 @@ export function format(seconds: number) {
     const sPrefix = seconds < 10 ? '0' : '';
     return `${minutes}:${sPrefix}${seconds}`;
 }
+
 // changes the phrase of the audio
 export async function changeVerse(direction: number) {
     if (!currentAudioPlayer?.loaded) {
+        console.error('Warning: tried to change audio verse before audio was loaded');
         return;
     }
-    const playing = currentAudioPlayer.playing;
+
+    const wasPlaying = currentAudioPlayer.playing;
     pause();
+
     if (direction >= 0) {
         if (
             currentAudioPlayer.timing?.[currentAudioPlayer.timeIndex] !=
             currentAudioPlayer.timing?.at(-1)
         ) {
             currentAudioPlayer.timeIndex++;
-            const newtime = currentAudioPlayer.timing?.[currentAudioPlayer.timeIndex].starttime;
-            if (newtime && currentAudioPlayer.audio) {
-                currentAudioPlayer.audio.currentTime = newtime;
-                updateTime();
-            }
         } else {
             await skip(1);
         }
@@ -192,16 +194,17 @@ export async function changeVerse(direction: number) {
         if (currentAudioPlayer.timeIndex > 0) {
             currentAudioPlayer.timeIndex--;
         }
-        if (currentAudioPlayer.audio && currentAudioPlayer.timing) {
-            currentAudioPlayer.audio.currentTime =
-                currentAudioPlayer.timing?.[currentAudioPlayer.timeIndex].starttime;
-        }
-        updateTime();
     }
-    if (playing) {
+
+    const newtime = currentAudioPlayer.timing?.[currentAudioPlayer.timeIndex].starttime;
+    if (newtime && currentAudioPlayer.audio) {
+        seek(newtime);
+    }
+    if (wasPlaying) {
         play();
     }
 }
+
 export async function seekOffset(offset: number) {
     const playing = currentAudioPlayer?.playing;
     pause();
@@ -244,6 +247,7 @@ export function seek(position: number) {
     currentAudioPlayer.audio.currentTime = position;
     currentAudioPlayer.progress = position;
     audioPlayerStore.set(currentAudioPlayer);
+    updateHighlights();
 
     if (wasPlaying) {
         play();
@@ -382,6 +386,7 @@ function resetVersePlaybackRange() {
 // calls updatehighlights() to see if highlights need to be change
 async function updateTime() {
     if (!currentAudioPlayer?.loaded) {
+        console.error('Warning: tried to updateTime() for audio before it was loaded');
         return;
     }
     currentAudioPlayer.progress = currentAudioPlayer.audio?.currentTime ?? 0;
@@ -470,8 +475,6 @@ export function playVerses(startVerse: string, endVerse?: string) {
             getVerseTimingRange(startVerse, startVerse) || //
             defaultPlayMode.range;
     }
-
-    console.log(`playVerses: setting range ${range.start} - ${range.end}`);
 
     playMode.set({ mode, range });
     seekToVerse(startVerse);
@@ -611,8 +614,6 @@ export function seekToVerse(verse: string) {
         // Handle case where tag has form '9a' for first tag in verse 9
         if (timing.tag === verse || timing.tag === verse + 'a') {
             seek(timing.starttime);
-            // Force text highlighting update
-            updateTime();
             return;
         }
     }

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -241,6 +241,7 @@ export function seek(position: number) {
 let warmdown: number | undefined = undefined;
 async function handlePlayMode() {
     if (warmdown) {
+        console.log(`warmdown == ${warmdown}`);
         warmdown--;
         if (warmdown === 0) {
             if (currentPlayMode?.mode === PlayMode.Continue) {
@@ -271,7 +272,7 @@ async function handlePlayMode() {
         play();
     }
     if (currentPlayMode?.mode === PlayMode.RepeatSelection) {
-        // console.log(`warmdown == ${warmdown}`);
+        console.log(`warmdown == ${warmdown}`);
         if (currentPlayMode.range === defaultPlayMode.range) {
             const resultArray = getCurrentVerseTiming();
             if (resultArray?.start === undefined || resultArray.end === undefined) {
@@ -284,6 +285,7 @@ async function handlePlayMode() {
             });
         }
         if ((currentAudioPlayer?.progress ?? 0) + 0.05 > currentPlayMode.range.end) {
+            console.log(`handlePlayMode: pausing since after end (${currentAudioPlayer?.progress ?? 0 + 0.05} > ${currentPlayMode.range.end})`);
             pause();
             warmdown = 5;
         }
@@ -390,7 +392,8 @@ async function updateTime() {
 }
 // calls updateTime() every 100ms
 function toggleTimeRunning() {
-    if (currentAudioPlayer?.audio?.ended || currentAudioPlayer?.playing === false) {
+    if (currentPlayMode?.mode !== PlayMode.RepeatSelection && 
+        (currentAudioPlayer?.audio?.ended || currentAudioPlayer?.playing === false)) {
         clearInterval(currentAudioPlayer?.timer ?? undefined);
         currentAudioPlayer.timer = null;
     } else if (currentAudioPlayer) {

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -119,7 +119,10 @@ async function getAudio() {
         updateTime();
     };
 }
-// plays or pauses the audio
+
+/**
+ * If the current audio is loaded, toggles its playing state.
+ */
 export function playPause() {
     if (!currentAudioPlayer?.loaded) {
         console.error("Warning: tried to playPause() audio that wasn't loaded");
@@ -141,6 +144,9 @@ export function playPause() {
     }
 }
 
+/**
+ * If the current audio is loaded and playing, pauses it.
+ */
 export function playStop() {
     if (!currentAudioPlayer?.loaded) {
         console.error("Warning: tried to playStop() audio that wasn't loaded");
@@ -157,7 +163,6 @@ export async function skip(direction: number) {
     pause();
     await refs.skip(direction);
     playMode.reset();
-    // resetVersePlaybackRange();
 }
 // formats timing information
 export function format(seconds: number) {
@@ -171,7 +176,10 @@ export function format(seconds: number) {
     return `${minutes}:${sPrefix}${seconds}`;
 }
 
-// changes the phrase of the audio
+/**
+ * Seeks to the next audio phrase in the given direction.
+ * @param direction the direction to seek (backwards if negative, forwards otherwise)
+ */
 export async function changeVerse(direction: number) {
     if (!currentAudioPlayer?.loaded) {
         console.error('Warning: tried to change audio verse before audio was loaded');
@@ -228,7 +236,10 @@ export async function seekOffset(offset: number) {
     }
 }
 
-// Move the audio player to the given number of seconds from the start
+/**
+ * Moves the audio player to the given number of seconds from the start.
+ * @param position the target location in seconds from the beginning of the track
+ */
 export function seek(position: number) {
     if (!currentAudioPlayer) {
         console.error('Warning: missing audio player in seek()');
@@ -254,11 +265,12 @@ export function seek(position: number) {
     }
 }
 
-// Countdown timer for slight delay before repeating the
-// current section or continuing to next section
+// Tracks delay before repeating audio section or continuing to next
 let warmdown: number | undefined = undefined;
 
-// Interval callback for updating the audio state
+/**
+ * Updates the audio playback according to the current playback mode.
+ */
 async function handlePlayMode() {
     if (warmdown) {
         warmdown--;
@@ -309,34 +321,29 @@ async function handlePlayMode() {
     }
 }
 
-// Get the audio start and end timestamps for the current verse as a range
+/**
+ * Returns the audio timestamp range for the current verse.
+ */
 function getCurrentVerseTiming() {
     if (!currentAudioPlayer?.timing) {
         console.error(`Warning in getCurrentVerseTiming(): ` + 'missing audio timing data');
         return defaultPlayMode.range;
     }
 
-    let start = 0,
-        end = 0;
-
-    // Handle the title segment as a special case.
-    // The loading function for timings always adds a
-    // 'title' tag as the first timing, so the first verse
-    // is actually at the second position in the timing array
-    const firstVerseTiming = currentAudioPlayer.timing[1];
-    if (currentAudioPlayer.progress < firstVerseTiming.starttime) {
-        // We're in the title segment; return timings for the first verse
+    // If in the first or title segment, treat the first verse as current
+    if (currentAudioPlayer.progress < currentAudioPlayer.timing[1].starttime) {
         return getVerseTimingRange('1', '1');
     }
 
-    // Otherwise, find timings for the current verse
-    for (let i = 0; i < currentAudioPlayer.timing.length; i++) {
+    let start = 0,
+        end = 0;
+
+    for (let i = 1; i < currentAudioPlayer.timing.length; i++) {
         const timing = currentAudioPlayer.timing[i];
         if (
             currentAudioPlayer.progress >= timing.starttime &&
             currentAudioPlayer.progress < timing.endtime
         ) {
-            // The verse number of tag '9a' is 9
             const verseNumber = parseInt(timing.tag, 10);
 
             // Step backwards until we reach the previous verse
@@ -348,12 +355,6 @@ function getCurrentVerseTiming() {
                     start = currentAudioPlayer.timing[k + 1].starttime;
                     break;
                 }
-                // If we've gone to the beginning of the section,
-                // assume we're in the first, "title" tag (or similar)
-                if (k === 0) {
-                    start = currentAudioPlayer.timing[0].starttime;
-                    break;
-                }
             }
 
             // Step forwards until we reach the next verse
@@ -363,8 +364,8 @@ function getCurrentVerseTiming() {
                     end = currentAudioPlayer.timing[j - 1].endtime;
                     break;
                 }
-                // If we've gone to the end of the section without
-                // progressing to the next verse, assume we're at the last tag
+                // If we've gone to the end of the section without progressing
+                // to the next verse, assume we're at the last tag
                 if (j === currentAudioPlayer.timing.length - 1) {
                     end = currentAudioPlayer.timing[j].endtime;
                     break;
@@ -374,16 +375,25 @@ function getCurrentVerseTiming() {
         }
     }
 
+    if (end === 0) {
+        console.error('Warning: failed to get current verse timing range, falling back to default');
+        return defaultPlayMode.range;
+    }
+
     return { start, end } as PlayModeRange;
 }
 
-// Sets the playback range to the start and end of the current verse
+/**
+ * Sets the playback range to the start and end of the current verse
+ */
 function resetVersePlaybackRange() {
     playMode.set({ ...(currentPlayMode || defaultPlayMode), range: getCurrentVerseTiming() });
 }
 
-// function get range of current index all labels of the current verse playing
-// calls updatehighlights() to see if highlights need to be change
+/**
+ * Updates the audio player store, playback mode, and text highlights.
+ * This method is designed to be called via `setInterval()`.
+ */
 async function updateTime() {
     if (!currentAudioPlayer?.loaded) {
         console.error('Warning: tried to updateTime() for audio before it was loaded');
@@ -399,10 +409,13 @@ async function updateTime() {
     await handlePlayMode();
 }
 
-// calls updateTime() every 100ms
+/**
+ * If audio is playing, starts the audio update interval callback;
+ * otherwise if playback has stopped, clears the interval callback.
+ */
 function updateAudioHandler() {
     if (!currentAudioPlayer?.audio) {
-        console.error('Warning: tried to update listener for missing audio');
+        console.error('Warning: tried to update handler for missing audio');
         return;
     }
 
@@ -424,7 +437,9 @@ export function hasAudioPlayed() {
     return (currentAudioPlayer?.progress ?? 0) > 0;
 }
 
-// Pause audio if currently playing
+/**
+ * Pauses audio if currently playing. Optionally keeps the audio update interval active.
+ */
 function pause(options?: { keepListening: boolean }) {
     if (!currentAudioPlayer?.loaded) {
         console.error('Warning: tried to pause() audio before it was loaded');
@@ -442,7 +457,9 @@ function pause(options?: { keepListening: boolean }) {
     }
 }
 
-// Play audio if currently paused
+/**
+ * Plays audio if currently paused.
+ */
 export function play() {
     if (!currentAudioPlayer?.loaded) {
         console.error('Warning: tried to play() audio before it was loaded');
@@ -459,8 +476,12 @@ export function play() {
     }
 }
 
-// Start audio at beginning of startVerse, repeating after
-// endVerse if endVerse is provided
+/**
+ * Begins audio playback at beginning of startVerse, repeating after endverse
+ * if endVerse is provided.
+ * @param startVerse the verse at which to start playback
+ * @param endVerse   the verse after which to loop playback
+ */
 export function playVerses(startVerse: string, endVerse?: string) {
     let mode: PlayMode, range: PlayModeRange;
 
@@ -602,7 +623,10 @@ export async function getAudioSourceInfo(
     };
 }
 
-// Seek to the start of the first audio tag for the specified verse
+/**
+ * Seeks to the start of the first audio tag for the specified verse
+ * @param verse the verse to seek
+ */
 export function seekToVerse(verse: string) {
     if (!currentAudioPlayer?.timing) {
         console.error(`Warning in seekToVerse(${verse}): ` + 'missing audio timing data');
@@ -619,8 +643,12 @@ export function seekToVerse(verse: string) {
     }
 }
 
-// Get an audio timing range bounded by the first tag
-// of startVerse and the last tag of endVerse
+/**
+ * Returns an audio timing range bounded by the first tag of startVerse
+ * and the last tag of endVerse
+ * @param startVerse the first verse of the range
+ * @param endVerse   the last verse of the range
+ */
 function getVerseTimingRange(startVerse: string, endVerse: string) {
     if (!currentAudioPlayer?.timing) {
         console.error(
@@ -638,7 +666,7 @@ function getVerseTimingRange(startVerse: string, endVerse: string) {
     for (let i = 0; i < currentAudioPlayer.timing.length; i++) {
         const timing = currentAudioPlayer.timing[i];
 
-        // Handle case where tag has form '9a' for first tag in verse 9
+        // Tags like '9' or '9a' would both represent the first tag in verse 9
         if (timing.tag === startVerse || timing.tag === startVerse + 'a') {
             start = timing.starttime;
         }
@@ -649,16 +677,13 @@ function getVerseTimingRange(startVerse: string, endVerse: string) {
             break;
         }
 
-        // Otherwise, we need to find the last tag of the end verse
         const verseNumber = parseInt(timing.tag);
         if (verseNumber === parseInt(endVerse) + 1) {
-            // This is the first timing tag in the next verse, so
-            // the previous tag (at i - 1) is the last tag in the current verse
+            // The current timing tag is the first in the next verse after endVerse,
+            // so the previous timing tag is the last tag in endVerse
             end = currentAudioPlayer.timing[i - 1].endtime;
             break;
         } else if (verseNumber === finalVerseNumber) {
-            // There is no "next verse" for the final verse of the chapter,
-            // but we already know the final tag of the final verse
             end = finalTiming.endtime;
             break;
         }

--- a/src/lib/data/navigation.ts
+++ b/src/lib/data/navigation.ts
@@ -1,4 +1,5 @@
 import { scriptureConfig } from '$assets/config';
+import type { BookCollectionAudioConfig } from '$config';
 import { isBlank } from '$lib/scripts/stringUtils';
 import { loadCatalog, type CatalogData } from './catalogData';
 
@@ -14,7 +15,7 @@ export class NavigationContext {
     chapterLength: number;
     chapterVerses: string;
     verse: string;
-    audio: any;
+    audio: BookCollectionAudioConfig | undefined;
     title: string;
     bookTab: number;
     name: string;
@@ -138,12 +139,12 @@ export class NavigationContext {
     }
 
     private updateAudio() {
-        this.audio =
-            this.config.traits['has-audio'] &&
-            this.config.bookCollections
-                ?.find((x) => x.id === this.collection)
-                ?.books.find((x) => x.id === this.book)
-                ?.audio.find((x) => String(x.num) === this.chapter);
+        this.audio = this.config?.traits?.['has-audio']
+            ? (this.config.bookCollections
+                  ?.find((x) => x.id === this.collection)
+                  ?.books.find((x) => x.id === this.book)
+                  ?.audio.find((x) => String(x.num) === this.chapter) as BookCollectionAudioConfig)
+            : undefined;
     }
 
     private updateHeadings() {

--- a/src/lib/data/stores/audio.ts
+++ b/src/lib/data/stores/audio.ts
@@ -105,11 +105,9 @@ function createPlayMode() {
                     nextMode = PlayMode.Continue;
                     break;
             }
-            console.log(`playMode.next(): changing mode to ${nextMode}`);
             external.set({ mode: nextMode, range: nextRange });
         },
         reset: () => {
-            console.log(`playMode.reset(): changing mode to ${defaultPlayMode.mode}`);
             external.set(defaultPlayMode);
         }
     };

--- a/src/lib/data/stores/audio.ts
+++ b/src/lib/data/stores/audio.ts
@@ -105,9 +105,11 @@ function createPlayMode() {
                     nextMode = PlayMode.Continue;
                     break;
             }
+            console.log(`playMode.next(): changing mode to ${nextMode}`);
             external.set({ mode: nextMode, range: nextRange });
         },
         reset: () => {
+            console.log(`playMode.reset(): changing mode to ${defaultPlayMode.mode}`);
             external.set(defaultPlayMode);
         }
     };

--- a/src/lib/data/stores/reference.ts
+++ b/src/lib/data/stores/reference.ts
@@ -1,4 +1,5 @@
 import config from '$assets/config';
+import type { BookCollectionAudioConfig } from '$config';
 import { NavigationContext } from '$lib/data/navigation';
 import { derived, writable } from 'svelte/store';
 import type { CatalogData } from '../catalogData';
@@ -14,7 +15,7 @@ interface ReferenceStore extends Reference {
     collection: string;
     chapterVerses: string;
     numVerses: number;
-    hasAudio: any;
+    hasAudio: BookCollectionAudioConfig | undefined;
     title: string;
     bookTab: number;
     name: string;


### PR DESCRIPTION
Fixes #505.

Upon investigating #505 I found that the functionality for playing an audio selection on repeat was incomplete. The audio state machine has already been written, but it didn't support configuring a playback range based on the first and last selected verses (like the Android app does).

- Fixed an existing typo that prevented "repeat selection" mode from activating
- Added an onclick handler for "repeat selected audio" button in `TextSelectionToolbar`
- Wrote logic in `data/audio.ts` for determining the correct playback range from the first and last selected verses.
- Debugged and improved code quality in `data/audio.ts`

I tried to match the native Android behavior closely. The only significant difference that I am aware of is that the native version waits until the end of the current phrase to jump back to the beginning of the selection if the user attempts to seek beyond the end of the selection, while in this PR the jump-back is immediate.

Simple testing on an installed PWA on Android 16 looks good so far. The following are desktop screenshots. (Note: the "repeat selection" hint only shows when changing modes using the mode buttton, not the repeat selection button. If this is not intended behavior I can look at addressing that.)

<img width="321" height="712" alt="image" src="https://github.com/user-attachments/assets/39f27759-1757-4a20-9454-cbc63dd6d5be" />

<img width="321" height="712" alt="image" src="https://github.com/user-attachments/assets/57832f58-5c3a-4833-ab86-e3f8afca0745" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted audio play-mode reset to trigger only when timing data is truly available.

* **Improvements**
  * Updated text selection playback so Play starts from the first selected verse, and Repeat plays the full selected verse range.
  * Improved play/pause, stop, and seek behavior—better handling when audio isn’t loaded and more consistent pause/resume.
  * Refined verse timing calculations and playback range fallbacks for smoother listening updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->