### PR TITLE
Use style color instead of hardcoding white

### DIFF
--- a/src/lib/components/AudioBar.svelte
+++ b/src/lib/components/AudioBar.svelte
@@ -116,7 +116,7 @@ TODO:
     {#if showRepeatMode}
         <div class="audio-control-buttons">
             <RepeatButton
-                color="{iconColor},"
+                color={iconColor}
                 onclick={() => playMode.next($refs.hasAudio?.timingFile)}
                 state={$playMode.mode}
             />

--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -343,6 +343,7 @@ The navbar component.
         {#snippet label()}
             <div
                 class="normal-case whitespace-nowrap"
+                style:color={$actionBarColor}
                 style={convertStyle($s?.['ui.selector.book'])}
             >
                 {labelDisplayed}
@@ -357,7 +358,11 @@ The navbar component.
     </Dropdown>
 {:else}
     <!-- Book Label -->
-    <div class="normal-case whitespace-nowrap" style={convertStyle($s?.['ui.selector.book'])}>
+    <div
+        class="normal-case whitespace-nowrap"
+        style:color={$actionBarColor}
+        style={convertStyle($s?.['ui.selector.book'])}
+    >
         {labelDisplayed}
     </div>
 {/if}

--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -311,6 +311,7 @@ The navbar component.
             visible: showChapterSelector && showVerseSelector
         }
     } satisfies App.TabMenuOptions);
+    let tabColor = $derived($s?.['ui.selector.tabs']['color']);
 </script>
 
 {#snippet selectList(bcv: string, menuaction: App.MenuActionHandler)}
@@ -352,7 +353,12 @@ The navbar component.
         {/snippet}
         {#snippet content()}
             <div>
-                <TabsMenu bind:this={bookSelector} {options} menuaction={navigateReference} />
+                <TabsMenu
+                    bind:this={bookSelector}
+                    {options}
+                    menuaction={navigateReference}
+                    color={tabColor}
+                />
             </div>
         {/snippet}
     </Dropdown>

--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -6,7 +6,15 @@ The navbar component.
     import { resolve } from '$app/paths';
     import config, { scriptureConfig } from '$assets/config';
     import type { BookConfig } from '$config';
-    import { convertStyle, nextRef, refs, s, t, userSettingsOrDefault } from '$lib/data/stores';
+    import {
+        actionBarColor,
+        convertStyle,
+        nextRef,
+        refs,
+        s,
+        t,
+        userSettingsOrDefault
+    } from '$lib/data/stores';
     import { DropdownIcon } from '$lib/icons';
     import { navigateToText, navigateToUrl } from '$lib/navigate';
     import * as numerals from '$lib/scripts/numeralSystem';
@@ -339,7 +347,7 @@ The navbar component.
             >
                 {labelDisplayed}
             </div>
-            <DropdownIcon color="white" />
+            <DropdownIcon color={actionBarColor} />
         {/snippet}
         {#snippet content()}
             <div>

--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -347,7 +347,7 @@ The navbar component.
             >
                 {labelDisplayed}
             </div>
-            <DropdownIcon color={actionBarColor} />
+            <DropdownIcon color={$actionBarColor} />
         {/snippet}
         {#snippet content()}
             <div>

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -206,7 +206,7 @@ The navbar component.
                 {chapterIndicator(book, chapter)}
             </div>
             {#if canSelect}
-                <DropdownIcon color={actionBarColor} />
+                <DropdownIcon color={$actionBarColor} />
             {/if}
         {/snippet}
         {#snippet content()}

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -4,7 +4,15 @@ The navbar component.
 -->
 <script lang="ts">
     import config, { scriptureConfig } from '$assets/config';
-    import { convertStyle, nextRef, refs, s, t, userSettingsOrDefault } from '$lib/data/stores';
+    import {
+        actionBarColor,
+        convertStyle,
+        nextRef,
+        refs,
+        s,
+        t,
+        userSettingsOrDefault
+    } from '$lib/data/stores';
     import { DropdownIcon } from '$lib/icons';
     import { navigateToText } from '$lib/navigate';
     import * as numerals from '$lib/scripts/numeralSystem';
@@ -198,7 +206,7 @@ The navbar component.
                 {chapterIndicator(book, chapter)}
             </div>
             {#if canSelect}
-                <DropdownIcon color="white" />
+                <DropdownIcon color={actionBarColor} />
             {/if}
         {/snippet}
         {#snippet content()}

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -171,6 +171,7 @@ The navbar component.
         config.mainFeatures['show-chapter-number-on-app-bar'] && getChapterCount($refs.book) > 0
     );
     const canSelect = config.mainFeatures['show-chapter-selector'];
+    let tabColor = $derived($s?.['ui.selector.tabs']['color']);
 </script>
 
 {#snippet selectGrid(cv: string, menuaction: App.MenuActionHandler)}
@@ -229,6 +230,7 @@ The navbar component.
                             }
                         }}
                         menuaction={navigateReference}
+                        color={tabColor}
                     />
                 </div>
             {/if}

--- a/src/lib/components/ChapterSelector.svelte
+++ b/src/lib/components/ChapterSelector.svelte
@@ -202,7 +202,11 @@ The navbar component.
 {#if showSelector && ($nextRef.book === '' || $nextRef.chapter !== '')}
     <Dropdown bind:this={dropdown} navEnd={resetNavigation} cols={5}>
         {#snippet label()}
-            <div class="normal-case" style={convertStyle($s?.['ui.selector.chapter'])}>
+            <div
+                class="normal-case"
+                style:color={$actionBarColor}
+                style={convertStyle($s?.['ui.selector.chapter'])}
+            >
                 {chapterIndicator(book, chapter)}
             </div>
             {#if canSelect}

--- a/src/lib/components/CollectionSelector.svelte
+++ b/src/lib/components/CollectionSelector.svelte
@@ -4,7 +4,16 @@ Book Collection Selector component.
 -->
 <script lang="ts">
     import { scriptureConfig } from '$assets/config';
-    import { convertStyle, layout, Layout, refs, s, selectedLayouts, t } from '$lib/data/stores';
+    import {
+        actionBarColor,
+        convertStyle,
+        layout,
+        Layout,
+        refs,
+        s,
+        selectedLayouts,
+        t
+    } from '$lib/data/stores';
     import { SideBySideIcon, SinglePaneIcon, VerseByVerseIcon } from '$lib/icons';
     import LayoutOptions from './LayoutOptions.svelte';
     import Modal from './Modal.svelte';
@@ -57,6 +66,8 @@ Book Collection Selector component.
     function handleCancel() {
         $selectedLayouts = JSON.parse(restoreDocSets);
     }
+
+    let tabColor = $derived($s?.['ui.layouts.tabs']['color']);
 </script>
 
 {#snippet layoutOptions(layoutOption: Layout, menuaction: App.MenuActionHandler)}
@@ -65,11 +76,11 @@ Book Collection Selector component.
 
 {#snippet icon(mode: Layout)}
     {#if mode === Layout.Single}
-        <SinglePaneIcon />
+        <SinglePaneIcon color={$actionBarColor} />
     {:else if mode === Layout.Two}
-        <SideBySideIcon />
+        <SideBySideIcon color={$actionBarColor} />
     {:else}
-        <VerseByVerseIcon />
+        <VerseByVerseIcon color={$actionBarColor} />
     {/if}
 {/snippet}
 
@@ -94,6 +105,7 @@ Book Collection Selector component.
             }
         }}
         scroll={true}
+        color={tabColor}
     />
     <div class="flex w-full justify-between dy-modal-action">
         <!-- svelte-ignore a11y_click_events_have_key_events -->

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -36,13 +36,18 @@ The navbar component.
         }
     }
 
-    let actionBarColor = $derived($s?.['ui.bar.action']['background-color']);
+    let actionBarBackgroundColor = $derived($s?.['ui.bar.action']['background-color']);
+    let actionBarColor = $derived($s?.['ui.bar.action']['color']);
 </script>
 
 <!--
   see Dynamic values in https://v2.tailwindcss.com/docs/just-in-time-mode#arbitrary-value-support
 -->
-<div class="dy-navbar" style:height={NAVBAR_HEIGHT} style:background-color={actionBarColor}>
+<div
+    class="dy-navbar"
+    style:height={NAVBAR_HEIGHT}
+    style:background-color={actionBarBackgroundColor}
+>
     <div class="justify-start grow">
         {#if !showBackButton}
             <label
@@ -50,15 +55,15 @@ The navbar component.
                 class="dy-btn dy-btn-ghost dy-btn-circle p-1 dy-drawer-button"
                 class:lg:hidden={$showDesktopSidebar && $layout.mode !== Layout.Two}
             >
-                <HamburgerIcon color="white" />
+                <HamburgerIcon color={actionBarColor} />
             </label>
         {:else}
             <!-- svelte-ignore a11y_click_events_have_key_events -->
             <button onclick={handleBackNavigation} class="dy-btn dy-btn-ghost dy-btn-circle">
                 {#if $direction === 'ltr'}
-                    <ArrowBackIcon color="white" />
+                    <ArrowBackIcon color={actionBarColor} />
                 {:else}
-                    <ArrowForwardIcon color="white" />
+                    <ArrowForwardIcon color={actionBarColor} />
                 {/if}
             </button>
         {/if}

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -7,6 +7,7 @@ The navbar component.
     import { resolve } from '$app/paths';
     import { page } from '$app/state';
     import {
+        actionBarColor,
         convertStyle,
         direction,
         layout,
@@ -37,7 +38,6 @@ The navbar component.
     }
 
     let actionBarBackgroundColor = $derived($s?.['ui.bar.action']['background-color']);
-    let actionBarColor = $derived($s?.['ui.bar.action']['color']);
 </script>
 
 <!--
@@ -55,15 +55,15 @@ The navbar component.
                 class="dy-btn dy-btn-ghost dy-btn-circle p-1 dy-drawer-button"
                 class:lg:hidden={$showDesktopSidebar && $layout.mode !== Layout.Two}
             >
-                <HamburgerIcon color={actionBarColor} />
+                <HamburgerIcon color={$actionBarColor} />
             </label>
         {:else}
             <!-- svelte-ignore a11y_click_events_have_key_events -->
             <button onclick={handleBackNavigation} class="dy-btn dy-btn-ghost dy-btn-circle">
                 {#if $direction === 'ltr'}
-                    <ArrowBackIcon color={actionBarColor} />
+                    <ArrowBackIcon color={$actionBarColor} />
                 {:else}
-                    <ArrowForwardIcon color={actionBarColor} />
+                    <ArrowForwardIcon color={$actionBarColor} />
                 {/if}
             </button>
         {/if}

--- a/src/lib/components/SortMenu.svelte
+++ b/src/lib/components/SortMenu.svelte
@@ -4,6 +4,7 @@ A drop-down menu for use in ColorCard, HistoryCard, and IconCard.
 Dispatches a menuaction event when an option is selected from the menu.
 -->
 <script lang="ts">
+    import { actionBarColor } from '$lib/data/stores';
     import { SortIcon } from '$lib/icons';
 
     let { menuaction, actions = [''] } = $props();
@@ -20,7 +21,7 @@ Dispatches a menuaction event when an option is selected from the menu.
 <div class="dy-dropdown dy-dropdown-bottom dy-dropdown-end">
     <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
     <div tabindex="0" class="dy-btn dy-btn-ghost p-1">
-        <SortIcon color="white" />
+        <SortIcon color={$actionBarColor} />
     </div>
     <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
     <ul tabindex="0" class="dy-dropdown-content dy-menu shadow bg-base-100 z-10">

--- a/src/lib/components/TabsMenu.svelte
+++ b/src/lib/components/TabsMenu.svelte
@@ -12,13 +12,15 @@ A component to display tabbed menus.
         active = $bindable(Object.keys(options).filter((x) => options[x].visible)[0]),
         scroll = true,
         height = '50vh',
-        menuaction
+        menuaction,
+        color
     }: {
         options: App.TabMenuOptions;
         active?: string;
         scroll?: boolean;
         height?: string;
         menuaction?: App.TabMenuActionHandler;
+        color?: string;
     } = $props();
 
     const hasTabs = $derived(Object.keys(options).filter((x) => options[x].visible).length > 1);
@@ -38,7 +40,6 @@ A component to display tabbed menus.
         active = tab;
     };
     const ActiveComponent = $derived(options[active]?.snippet);
-    let borderColor = $derived($s?.['ui.selector.tabs']['border-color']);
 </script>
 
 {#if hasTabs}
@@ -50,7 +51,7 @@ A component to display tabbed menus.
                 <!-- svelte-ignore a11y_interactive_supports_focus -->
                 <a
                     onclick={preventDefault(() => setActive(opt))}
-                    style:border-color={active === opt ? borderColor : ''}
+                    style:border-color={active === opt ? color : ''}
                     class="dy-tab normal-case {active === opt ? 'dy-tab-active font-bold' : ''}"
                     style:background="none"
                     style:color={$actionBarColor}

--- a/src/lib/components/TabsMenu.svelte
+++ b/src/lib/components/TabsMenu.svelte
@@ -53,7 +53,7 @@ A component to display tabbed menus.
                     style:border-color={active === opt ? borderColor : ''}
                     class="dy-tab normal-case {active === opt ? 'dy-tab-active font-bold' : ''}"
                     style:background="none"
-                    style:color={actionBarColor}
+                    style:color={$actionBarColor}
                     role="button"
                 >
                     {#if options[opt].tab?.icon}

--- a/src/lib/components/TabsMenu.svelte
+++ b/src/lib/components/TabsMenu.svelte
@@ -4,7 +4,7 @@ A component to display tabbed menus.
 -->
 
 <script lang="ts">
-    import { convertStyle, s } from '$lib/data/stores';
+    import { actionBarColor, convertStyle, s } from '$lib/data/stores';
     import { preventDefault } from '$lib/scripts/event-wrappers';
 
     let {
@@ -38,6 +38,7 @@ A component to display tabbed menus.
         active = tab;
     };
     const ActiveComponent = $derived(options[active]?.snippet);
+    let borderColor = $derived($s?.['ui.selector.tabs']['border-color']);
 </script>
 
 {#if hasTabs}
@@ -49,11 +50,10 @@ A component to display tabbed menus.
                 <!-- svelte-ignore a11y_interactive_supports_focus -->
                 <a
                     onclick={preventDefault(() => setActive(opt))}
-                    style:border-color={active === opt ? '#FFFFFF' : ''}
-                    class="dy-tab text-white normal-case {active === opt
-                        ? 'dy-tab-active font-bold'
-                        : ''}"
+                    style:border-color={active === opt ? borderColor : ''}
+                    class="dy-tab normal-case {active === opt ? 'dy-tab-active font-bold' : ''}"
                     style:background="none"
+                    style:color={actionBarColor}
                     role="button"
                 >
                     {#if options[opt].tab?.icon}

--- a/src/lib/data/stores/theme.ts
+++ b/src/lib/data/stores/theme.ts
@@ -67,3 +67,5 @@ export const s = derived(themeColors, ($themeColors) => {
         {} as Record<string, Record<string, string>>
     );
 });
+
+export const actionBarColor = derived(s, ($s) => $s?.['ui.bar.action']['color'] ?? 'inherit');

--- a/src/lib/data/stores/theme.ts
+++ b/src/lib/data/stores/theme.ts
@@ -68,4 +68,4 @@ export const s = derived(themeColors, ($themeColors) => {
     );
 });
 
-export const actionBarColor = derived(s, ($s) => $s?.['ui.bar.action']['color'] ?? 'inherit');
+export let actionBarColor = derived(s, ($s) => $s?.['ui.bar.action']?.['color'] ?? 'inherit');

--- a/src/lib/data/stores/theme.ts
+++ b/src/lib/data/stores/theme.ts
@@ -68,4 +68,4 @@ export const s = derived(themeColors, ($themeColors) => {
     );
 });
 
-export let actionBarColor = derived(s, ($s) => $s?.['ui.bar.action']?.['color'] ?? 'inherit');
+export const actionBarColor = derived(s, ($s) => $s?.['ui.bar.action']?.['color'] ?? 'inherit');

--- a/src/lib/icons/SideBySideIcon.svelte
+++ b/src/lib/icons/SideBySideIcon.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    let { color = 'white' } = $props();
+    let { color = 'currentColor' } = $props();
 </script>
 
 <svg fill={color} xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px"

--- a/src/lib/icons/SinglePaneIcon.svelte
+++ b/src/lib/icons/SinglePaneIcon.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    let { color = 'white' } = $props();
+    let { color = 'currentColor' } = $props();
 </script>
 
 <svg fill={color} xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px"

--- a/src/lib/icons/VerseByVerseIcon.svelte
+++ b/src/lib/icons/VerseByVerseIcon.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    let { color = 'white' } = $props();
+    let { color = 'currentColor' } = $props();
 </script>
 
 <svg fill={color} xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px"

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -2,7 +2,7 @@
     import config from '$assets/config';
     import BottomNavigationBar from '$lib/components/BottomNavigationBar.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
-    import { t } from '$lib/data/stores';
+    import { actionBarColor, t } from '$lib/data/stores';
 
     let { data } = $props();
 
@@ -15,7 +15,10 @@
         <Navbar>
             {#snippet start()}
                 <label for="sidebar">
-                    <div class="btn btn-ghost normal-case text-xl text-white font-bold pl-1">
+                    <div
+                        class="btn btn-ghost normal-case text-xl font-bold pl-1"
+                        style:color={$actionBarColor}
+                    >
                         {$t['Menu_About']}
                     </div>
                 </label>

--- a/src/routes/bookmarks/+page.svelte
+++ b/src/routes/bookmarks/+page.svelte
@@ -7,7 +7,7 @@
     import { shareAnnotation, shareAnnotations } from '$lib/data/annotation-share';
     import { SORT_DATE, SORT_REFERENCE, toSorted } from '$lib/data/annotation-sort';
     import { removeBookmark, type BookmarkItem } from '$lib/data/bookmarks';
-    import { bodyFontSize, refs, t } from '$lib/data/stores';
+    import { actionBarColor, bodyFontSize, refs, t } from '$lib/data/stores';
     import { BookmarkIcon } from '$lib/icons';
     import ShareIcon from '$lib/icons/ShareIcon.svelte';
     import { formatDate } from '$lib/scripts/dateUtils';
@@ -70,7 +70,7 @@
                     onclick={async () =>
                         await shareAnnotations(toSorted(data.bookmarks, sortOrder))}
                 >
-                    <ShareIcon color="white" />
+                    <ShareIcon color={$actionBarColor} />
                 </button>
                 <SortMenu menuaction={(e) => handleSortAction(e)} {...sortMenu} />
             {/snippet}

--- a/src/routes/contents/[id]/+page.svelte
+++ b/src/routes/contents/[id]/+page.svelte
@@ -11,6 +11,7 @@
     import Navbar from '$lib/components/Navbar.svelte';
     import { loadCatalog } from '$lib/data/catalogData';
     import {
+        actionBarColor,
         contentsFontSize,
         contentsStack,
         convertStyle,
@@ -269,7 +270,7 @@
                                 onclick={() =>
                                     modal.open(ModalType.TextAppearance, { contentsMode: true })}
                             >
-                                <TextAppearanceIcon color="white" />
+                                <TextAppearanceIcon color={$actionBarColor} />
                             </label>
                         {/if}
                     </div>

--- a/src/routes/highlights/+page.svelte
+++ b/src/routes/highlights/+page.svelte
@@ -7,7 +7,7 @@
     import { shareAnnotation, shareAnnotations } from '$lib/data/annotation-share';
     import { SORT_COLOR, SORT_DATE, SORT_REFERENCE, toSorted } from '$lib/data/annotation-sort';
     import { removeHighlight, type HighlightItem } from '$lib/data/highlights';
-    import { bodyFontSize, refs, t } from '$lib/data/stores';
+    import { actionBarColor, bodyFontSize, refs, t } from '$lib/data/stores';
     import ShareIcon from '$lib/icons/ShareIcon.svelte';
     import { formatDate } from '$lib/scripts/dateUtils';
     import type { MenuActionEvent } from '$lib/types';
@@ -77,7 +77,7 @@
                     onclick={async () =>
                         await shareAnnotations(toSorted(data.highlights, sortOrder))}
                 >
-                    <ShareIcon color="white" />
+                    <ShareIcon color={$actionBarColor} />
                 </button>
                 <SortMenu menuaction={(e) => handleSortAction(e)} {...sortMenu} />
             {/snippet}

--- a/src/routes/history/+page.svelte
+++ b/src/routes/history/+page.svelte
@@ -2,7 +2,7 @@
     import HistoryCard from '$lib/components/HistoryCard.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
     import { clearHistory } from '$lib/data/history';
-    import { bodyFontSize, t } from '$lib/data/stores';
+    import { actionBarColor, bodyFontSize, t } from '$lib/data/stores';
     import DeleteSweepIcon from '$lib/icons/DeleteSweepIcon.svelte';
 
     let { data } = $props();
@@ -25,7 +25,7 @@
 
             {#snippet end()}
                 <button class="dy-btn dy-btn-ghost dy-btn-circle" onclick={onClearHistory}>
-                    <DeleteSweepIcon color="white" />
+                    <DeleteSweepIcon color={$actionBarColor} />
                 </button>
             {/snippet}
         </Navbar>

--- a/src/routes/image/+page.svelte
+++ b/src/routes/image/+page.svelte
@@ -2,7 +2,7 @@
     import DownloadSelector from '$lib/components/DownloadSelector.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
     import VerseOnImage from '$lib/components/VerseOnImage.svelte';
-    import { modal, ModalType, NAVBAR_HEIGHT, refs, t } from '$lib/data/stores';
+    import { actionBarColor, modal, ModalType, NAVBAR_HEIGHT, refs, t } from '$lib/data/stores';
     import { DownloadIcon, ShareIcon } from '$lib/icons';
     import { fromStore } from 'svelte/store';
 
@@ -63,11 +63,11 @@
             {#snippet end()}
                 <div>
                     <button class="dy-btn-sm dy-btn-ghost" onclick={share}>
-                        <ShareIcon color="white" />
+                        <ShareIcon color={$actionBarColor} />
                     </button>
                 </div>
                 <button class="dy-btn-sm dy-btn-ghost" onclick={downloadClicked}>
-                    <DownloadIcon color="white" />
+                    <DownloadIcon color={$actionBarColor} />
                 </button>
             {/snippet}
         </Navbar>

--- a/src/routes/image/upload/+page.svelte
+++ b/src/routes/image/upload/+page.svelte
@@ -2,7 +2,7 @@
     import { goto } from '$app/navigation';
     import { resolve } from '$app/paths';
     import Navbar from '$lib/components/Navbar.svelte';
-    import { t, voiCustomImage } from '$lib/data/stores';
+    import { actionBarColor, t, voiCustomImage } from '$lib/data/stores';
     import { CheckIcon } from '$lib/icons';
     import { onDestroy, onMount } from 'svelte';
 
@@ -242,7 +242,7 @@
             {#snippet end()}
                 <div>
                     <button class="dy-btn-sm dy-btn-ghost" onclick={cropImage}>
-                        <CheckIcon color="white" />
+                        <CheckIcon color={$actionBarColor} />
                     </button>
                 </div>
             {/snippet}

--- a/src/routes/lexicon/+layout.svelte
+++ b/src/routes/lexicon/+layout.svelte
@@ -5,7 +5,7 @@
     import config from '$assets/config';
     import Navbar from '$lib/components/Navbar.svelte';
     import { showTextAppearance } from '$lib/components/TextAppearanceSelector.svelte';
-    import { fontChoices, modal, ModalType, t } from '$lib/data/stores';
+    import { actionBarColor, fontChoices, modal, ModalType, t } from '$lib/data/stores';
     import { selectedWord, selectWord } from '$lib/data/stores/lexicon.svelte';
     import SearchIcon from '$lib/icons/SearchIcon.svelte';
     import TextAppearanceIcon from '$lib/icons/TextAppearanceIcon.svelte';
@@ -52,14 +52,14 @@
                             goto(resolve(`/lexicon/search`)).then(() => selectWord(null));
                         }}
                     >
-                        <SearchIcon color="white" />
+                        <SearchIcon color={$actionBarColor} />
                     </button>
                     {#if showTextAppearance($fontChoices)}
                         <button
                             class="dy-btn dy-btn-ghost dy-btn-circle"
                             onclick={() => modal.open(ModalType.TextAppearance)}
                         >
-                            <TextAppearanceIcon color="white" />
+                            <TextAppearanceIcon color={$actionBarColor} />
                         </button>
                     {/if}
                 </div>

--- a/src/routes/lexicon/+layout.svelte
+++ b/src/routes/lexicon/+layout.svelte
@@ -38,7 +38,10 @@
     >
         {#snippet start()}
             <label for="sidebar">
-                <div class="dy-btn dy-btn-ghost normal-case text-xl text-white font-bold pl-1">
+                <div
+                    class="dy-btn dy-btn-ghost normal-case text-xl font-bold pl-1"
+                    style:color={$actionBarColor}
+                >
                     {inSearchRoute ? $t['Menu_Search'] : config.name}
                 </div>
             </label>

--- a/src/routes/notes/+page.svelte
+++ b/src/routes/notes/+page.svelte
@@ -7,7 +7,7 @@
     import { shareAnnotation, shareAnnotations } from '$lib/data/annotation-share';
     import { SORT_DATE, SORT_REFERENCE, toSorted } from '$lib/data/annotation-sort';
     import { removeNote, type NoteItem } from '$lib/data/notes';
-    import { bodyFontSize, monoIconColor, refs, t } from '$lib/data/stores';
+    import { actionBarColor, bodyFontSize, monoIconColor, refs, t } from '$lib/data/stores';
     import { NoteIcon } from '$lib/icons';
     import ShareIcon from '$lib/icons/ShareIcon.svelte';
     import { formatDate } from '$lib/scripts/dateUtils';
@@ -70,7 +70,7 @@
                     class="dy-btn dy-btn-ghost dy-btn-circle"
                     onclick={async () => await shareAnnotations(toSorted(data.notes, sortOrder))}
                 >
-                    <ShareIcon color="white" />
+                    <ShareIcon color={$actionBarColor} />
                 </button>
                 <SortMenu menuaction={(e) => handleSortAction(e)} {...sortMenu} />
             {/snippet}

--- a/src/routes/notes/edit/[noteid]/+page.svelte
+++ b/src/routes/notes/edit/[noteid]/+page.svelte
@@ -78,8 +78,14 @@
                 <div class="grid h-10 place-items-center dy-join-item">
                     {$t[title]}
                 </div>
+
+                <!-- CSS variable indirection: Tailwind JIT scans at build time and won't generate
+                     classes for runtime-interpolated values like after:bg-[{$actionBarColor}].
+                     Setting a CSS var in style= lets the browser resolve the color at runtime
+                     while Tailwind sees the static string var(--divider-color) at build time. -->
                 <div
-                    class="grid sm:flex dy-divider dy-divider-horizontal after:bg-white before:bg-white dy-join-item"
+                    style="--divider-color: {$actionBarColor}"
+                    class="grid sm:flex dy-divider dy-divider-horizontal after:bg-[var(--divider-color)] before:bg-[var(--divider-color)] dy-join-item"
                 ></div>
                 <div class="grid sm:flex h-10 place-items-center dy-join-item">
                     {reference}

--- a/src/routes/notes/edit/[noteid]/+page.svelte
+++ b/src/routes/notes/edit/[noteid]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import Navbar from '$lib/components/Navbar.svelte';
     import { addNote, editNote, removeNote } from '$lib/data/notes';
-    import { selectedVerses, t } from '$lib/data/stores';
+    import { actionBarColor, selectedVerses, t } from '$lib/data/stores';
     import { CheckIcon, DeleteIcon } from '$lib/icons';
     import { onMount } from 'svelte';
     import type { PageData } from './$types';
@@ -90,10 +90,10 @@
         {#snippet end()}
             <div class="dy-join">
                 <button onclick={deleteNote} class="dy-join-item dy-btn dy-btn-ghost dy-btn-circle"
-                    ><DeleteIcon color="white" /></button
+                    ><DeleteIcon color={$actionBarColor} /></button
                 >
                 <button onclick={action} class="dy-join-item dy-btn dy-btn-ghost p-1"
-                    ><CheckIcon color="white" /></button
+                    ><CheckIcon color={$actionBarColor} /></button
                 >
             </div>
         {/snippet}

--- a/src/routes/quiz/[collection]/[id]/+page.svelte
+++ b/src/routes/quiz/[collection]/[id]/+page.svelte
@@ -26,6 +26,7 @@
     import Navbar from '$lib/components/Navbar.svelte';
     import { addQuiz } from '$lib/data/quiz';
     import {
+        actionBarColor,
         bodyFontSize,
         bodyLineHeight,
         modal,
@@ -259,9 +260,9 @@
                             }}
                         >
                             {#if $quizAudioActive}
-                                <AudioIcon.Volume color="white" />
+                                <AudioIcon.Volume color={$actionBarColor} />
                             {:else}
-                                <AudioIcon.Mute color="white" />
+                                <AudioIcon.Mute color={$actionBarColor} />
                             {/if}
                         </button>
                     </div>
@@ -272,7 +273,7 @@
                         class="dy-btn dy-btn-ghost p-0.5 dy-no-animation"
                         onclick={() => modal.open(ModalType.TextAppearance)}
                     >
-                        <TextAppearanceIcon color="white" />
+                        <TextAppearanceIcon color={$actionBarColor} />
                     </label>
                 </div>
             {/snippet}

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -20,6 +20,7 @@
     import TextSelectionToolbar from '$lib/components/TextSelectionToolbar.svelte';
     import { playStop, seekToVerse, updateAudioPlayer } from '$lib/data/audio';
     import {
+        actionBarColor,
         analytics,
         audioActive,
         audioHighlightElements,
@@ -467,9 +468,9 @@
                                 }}
                             >
                                 {#if $audioActive}
-                                    <AudioIcon.Volume color="white" />
+                                    <AudioIcon.Volume color={actionBarColor} />
                                 {:else}
-                                    <AudioIcon.Mute color="white" />
+                                    <AudioIcon.Mute color={actionBarColor} />
                                 {/if}
                             </button>
                         {/if}
@@ -483,7 +484,7 @@
                                 class="dy-btn dy-btn-ghost dy-btn-circle"
                                 onclick={() => goto(resolve(`/search/${$refs.collection}`))}
                             >
-                                <SearchIcon color="white" />
+                                <SearchIcon color={actionBarColor} />
                             </button>
                         {/if}
 
@@ -493,7 +494,7 @@
                                 class="dy-btn dy-btn-ghost dy-btn-circle"
                                 onclick={() => modal.open(ModalType.TextAppearance)}
                             >
-                                <TextAppearanceIcon color="white" />
+                                <TextAppearanceIcon color={actionBarColor} />
                             </button>
                         {/if}
 
@@ -503,7 +504,7 @@
                                 class="dy-btn dy-btn-ghost dy-btn-circle"
                                 onclick={() => modal.open(ModalType.Collection)}
                             >
-                                <BibleIcon color="white" />
+                                <BibleIcon color={actionBarColor} />
                             </button>
                         {/if}
                     </div>
@@ -518,9 +519,9 @@
                         >
                             <!-- tricky logic: this causes the direction of the arrows to switch when rtl -->
                             {#if showOverlowMenu === ($direction === 'ltr')}
-                                <TriangleRightIcon color="white" scale={1.25} />
+                                <TriangleRightIcon color={actionBarColor} scale={1.25} />
                             {:else}
-                                <TriangleLeftIcon color="white" scale={1.25} />
+                                <TriangleLeftIcon color={actionBarColor} scale={1.25} />
                             {/if}
                         </button>
                     {/if}

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -468,9 +468,9 @@
                                 }}
                             >
                                 {#if $audioActive}
-                                    <AudioIcon.Volume color={actionBarColor} />
+                                    <AudioIcon.Volume color={$actionBarColor} />
                                 {:else}
-                                    <AudioIcon.Mute color={actionBarColor} />
+                                    <AudioIcon.Mute color={$actionBarColor} />
                                 {/if}
                             </button>
                         {/if}
@@ -484,7 +484,7 @@
                                 class="dy-btn dy-btn-ghost dy-btn-circle"
                                 onclick={() => goto(resolve(`/search/${$refs.collection}`))}
                             >
-                                <SearchIcon color={actionBarColor} />
+                                <SearchIcon color={$actionBarColor} />
                             </button>
                         {/if}
 
@@ -494,7 +494,7 @@
                                 class="dy-btn dy-btn-ghost dy-btn-circle"
                                 onclick={() => modal.open(ModalType.TextAppearance)}
                             >
-                                <TextAppearanceIcon color={actionBarColor} />
+                                <TextAppearanceIcon color={$actionBarColor} />
                             </button>
                         {/if}
 
@@ -504,7 +504,7 @@
                                 class="dy-btn dy-btn-ghost dy-btn-circle"
                                 onclick={() => modal.open(ModalType.Collection)}
                             >
-                                <BibleIcon color={actionBarColor} />
+                                <BibleIcon color={$actionBarColor} />
                             </button>
                         {/if}
                     </div>
@@ -519,9 +519,9 @@
                         >
                             <!-- tricky logic: this causes the direction of the arrows to switch when rtl -->
                             {#if showOverlowMenu === ($direction === 'ltr')}
-                                <TriangleRightIcon color={actionBarColor} scale={1.25} />
+                                <TriangleRightIcon color={$actionBarColor} scale={1.25} />
                             {:else}
-                                <TriangleLeftIcon color={actionBarColor} scale={1.25} />
+                                <TriangleLeftIcon color={$actionBarColor} scale={1.25} />
                             {/if}
                         </button>
                     {/if}


### PR DESCRIPTION
Fixes #984 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interface icon and label colors across navigation bars, toolbars, menus, and page headers now follow the active theme’s action bar color instead of staying fixed to white (including selector/tab styling).
* **Bug Fixes**
  * Corrected the audio bar repeat button color prop so it passes the intended value.
* **Refactor**
  * Centralized theme color logic via a shared derived theme value (and related tab color) and applied it consistently, including updating the editor divider to use a runtime color variable.
* **Style**
  * Updated a few icons’ default color to use `currentColor` when no explicit color is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->