### PR TITLE
Render \b tags

### DIFF
--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -1649,6 +1649,7 @@ LOGGING:
                                             workspace.paragraphDiv.classList.add(paraClass);
                                             if (paraClass === 'b') {
                                                 workspace.paragraphDiv.innerHTML += '<br>';
+                                                workspace.paragraphDiv.classList.add('txs');
                                             }
                                         }
                                         break;

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -1648,8 +1648,7 @@ LOGGING:
                                             workspace.paragraphDiv = document.createElement('div');
                                             workspace.paragraphDiv.classList.add(paraClass);
                                             if (paraClass === 'b') {
-                                                workspace.paragraphDiv.innerHTML += '<br>';
-                                                workspace.paragraphDiv.classList.add('txs');
+                                                workspace.paragraphDiv.innerHTML += '&nbsp;';
                                             }
                                         }
                                         break;

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -1647,6 +1647,9 @@ LOGGING:
                                             }
                                             workspace.paragraphDiv = document.createElement('div');
                                             workspace.paragraphDiv.classList.add(paraClass);
+                                            if (paraClass === 'b') {
+                                                workspace.paragraphDiv.innerHTML += '<br>';
+                                            }
                                         }
                                         break;
                                     }


### PR DESCRIPTION
Implementing #980. This causes \b tags to properly be a line break.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scripture paragraph rendering: when a “main” paragraph resolves to the styling variant “b”, the view now adds an extra non-breaking space to prevent unintended spacing/layout issues and maintain consistent readability across scripture views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->