### PR TITLE
#508 Allow seeking audio to next/previous heading

### DIFF
--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -160,7 +160,15 @@ export function playStop() {
     }
 }
 
-// changes chapter
+/**
+ * If there are headings and timing data in the current chapter,
+ * advances the audio to the nearest heading in the given direction.
+ * Otherwise, moves to the nearest chapter start time in the
+ * given direction (including the start of the current chapter)
+ *
+ * @param direction the direction in which to skip (backwards if negative,
+ *                  forwards otherwise)
+ */
 export async function skip(direction: number) {
     const wasPlaying = currentAudioPlayer?.playing;
     pause();
@@ -171,6 +179,8 @@ export async function skip(direction: number) {
             currentAudioPlayer?.progress &&
             currentAudioPlayer.progress >= AUDIO_SEEK_THRESHOLD
         ) {
+            // If there are no timings, and we are seeking backwards, and the
+            // audio has advanced beyond the threshold, then go to beginning
             seek(0);
             if (wasPlaying) {
                 play();
@@ -187,6 +197,7 @@ export async function skip(direction: number) {
             audioPlayerStore.set(currentAudioPlayer);
         }
 
+        // Locate the last marker before the end of the track
         let finalIntermediateMarker: number | undefined;
         if (headingMarkers.length > 1) {
             // Don't treat the initial marker at 0 as intermediate
@@ -228,6 +239,13 @@ export async function skip(direction: number) {
     updateTime();
 }
 
+/**
+ * Returns an array of numbers. The first number is the beginning of the current
+ * audio track (always at 0.0), the last number is the end of the
+ * last verse of the track, and any intermediate numbers are the start times
+ * of each verse immediately after a heading corresponding to a `\s` tag
+ * in the source UFSM.
+ */
 function getHeadingMarkers() {
     if (currentAudioPlayer?.headingMarkers) {
         return currentAudioPlayer.headingMarkers;
@@ -242,7 +260,7 @@ function getHeadingMarkers() {
             next = nextElementDFS(next);
         }
 
-        // If defined this is the first verse immediately after the heading
+        // If present this is the first verse immediately after the heading
         const verse = next?.getAttribute('data-verse');
         if (verse === null || verse === undefined) {
             return;
@@ -259,11 +277,17 @@ function getHeadingMarkers() {
     const endMarker = currentAudioPlayer?.timing?.at(-1)?.endtime || currentAudioPlayer?.duration;
     if (typeof endMarker === 'number') {
         headingMarkers.push(endMarker);
+    } else {
+        console.error('getHeadingMarkers: failed to locate end of current audio track');
     }
 
     return headingMarkers;
 }
 
+/**
+ * Returns the next Element after `e` in a pre-order DFS traversal of the DOM.
+ * @param e the element from which to perform the traversal step
+ */
 function nextElementDFS(e: Element) {
     const next = e.firstElementChild || e.nextElementSibling;
     if (next instanceof Element) {

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -30,6 +30,8 @@ const timings = import.meta.glob('./*', {
     base: '/src/gen-assets/timings'
 }) as Record<string, string>;
 
+const AUDIO_SEEK_THRESHOLD = 0.1;
+
 const cache = new MRUCache<string, AudioPlayer>(10);
 let currentAudioPlayer: AudioPlayer | undefined = undefined;
 audioPlayerStore.subscribe(async (value: AudioPlayer) => {
@@ -94,6 +96,7 @@ function createAudio(audioSource: string): HTMLAudioElement {
     }
     return audio;
 }
+
 //gets the current audio
 async function getAudio() {
     if (!currentAudioPlayer || currentAudioPlayer.loaded) {
@@ -160,10 +163,86 @@ export function playStop() {
 
 // changes chapter
 export async function skip(direction: number) {
+    console.log('skip');
+    const wasPlaying = currentAudioPlayer?.playing;
     pause();
-    await refs.skip(direction);
-    playMode.reset();
+
+    if (!currentAudioPlayer?.loaded || !currentAudioPlayer.timing) {
+        await refs.skip(direction);
+        playMode.reset();
+        return;
+    }
+
+    if (!currentAudioPlayer?.headingMarkers) {
+        currentAudioPlayer.headingMarkers = getHeadingMarkers();
+        audioPlayerStore.set(currentAudioPlayer);
+    }
+
+    if ((direction < 0 && currentAudioPlayer.progress < AUDIO_SEEK_THRESHOLD) ||
+         (direction >= 0 && (currentAudioPlayer.timing?.at(-1)?.endtime! -
+          currentAudioPlayer.progress) < AUDIO_SEEK_THRESHOLD)
+    ) {
+        await refs.skip(direction);
+        playMode.reset();
+        return;
+    }
+
+    for (let i = 1; i < currentAudioPlayer.headingMarkers.length - 1; i++) {
+        const marker = currentAudioPlayer.headingMarkers[i];
+        if (currentAudioPlayer.progress < (marker + AUDIO_SEEK_THRESHOLD)) {
+            if (direction < 0) {
+                seek(currentAudioPlayer.headingMarkers[i - 1]);
+                break;
+            } else if (currentAudioPlayer.progress > marker) {
+                seek(currentAudioPlayer.headingMarkers[i + 1]);
+                break;
+            } else {
+                seek(marker);
+                break;
+            }
+        }
+    }
+
+    updateHighlights();
+    if (wasPlaying) { play(); }
 }
+
+function getHeadingMarkers() {
+    let headingMarkers = [0.0];
+
+    const headings = document.querySelectorAll('div.s');
+    headings.forEach((h) => {
+        console.log(`found heading ${h.getHTML()}`);
+        let next = nextElementDFS(h);
+        while (next && !next?.getAttribute('data-verse')) {
+            next = nextElementDFS(next);
+        }
+
+        // If defined this is the first verse immediately after the heading
+        const verse = next?.getAttribute('data-verse');
+        console.log(`candidate verse from ${next?.getHTML()}: (${verse})`);
+        if (verse === null || verse === undefined) { return; }
+
+
+        const marker = currentAudioPlayer?.timing?.find((v) => v.tag.includes(verse))?.starttime;
+        console.log(marker);
+        if (marker) {
+            headingMarkers.push(marker);
+        }
+    });
+
+    headingMarkers.push(currentAudioPlayer?.timing?.at(-1)?.endtime ||
+     currentAudioPlayer?.duration!);
+
+    console.log(`final heading markers: ${headingMarkers}`);
+
+    return headingMarkers;
+}
+
+function nextElementDFS(e: Element) {
+    return e.firstElementChild || e.nextElementSibling || e.parentElement?.nextElementSibling;
+}
+
 // formats timing information
 export function format(seconds: number) {
     if (isNaN(seconds)) {

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -204,21 +204,17 @@ export async function skip(direction: number) {
         }
 
 
-        console.log(`(1) skip: currentAudioPlayer: progress is now ${currentAudioPlayer.progress}`);
         for (let i = 1; i < currentAudioPlayer.headingMarkers.length; i++) {
             const marker = currentAudioPlayer.headingMarkers[i];
             if (currentAudioPlayer.progress < marker + AUDIO_SEEK_THRESHOLD) {
                 if (direction < 0) {
-                    console.log(`skip: seeking to previous heading`)
                     seek(currentAudioPlayer.headingMarkers[i - 1]);
                 } else if (
                     i < currentAudioPlayer.headingMarkers.length - 1 &&
                     currentAudioPlayer.progress >= marker
                 ) {
-                    console.log(`skip: seeking to next heading`)
                     seek(currentAudioPlayer.headingMarkers[i + 1]);
                 } else {
-                    console.log(`skip: seeking to current heading`)
                     seek(marker);
                 }
                 if (wasPlaying) {
@@ -243,10 +239,8 @@ function getHeadingMarkers() {
     headings.forEach((h) => {
         let next = nextElementDFS(h);
         while (next && !next?.getAttribute('data-verse')) {
-            // console.log(`searching ${next.outerHTML}...`);
             next = nextElementDFS(next);
         }
-        // console.log(`found ${next}`);
 
         // If defined this is the first verse immediately after the heading
         const verse = next?.getAttribute('data-verse');
@@ -266,8 +260,6 @@ function getHeadingMarkers() {
     if (typeof endMarker === 'number') {
         headingMarkers.push(endMarker);
     }
-
-    console.log(`headingMarkers: ${headingMarkers}`);
 
     return headingMarkers;
 }

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -524,7 +524,7 @@ async function updateTime() {
     if (!currentAudioPlayer.timing) {
         audioPlayerStore.set(currentAudioPlayer);
     }
-    if (currentAudioPlayer.timing) {
+    if (currentAudioPlayer.hasPlayed && currentAudioPlayer.timing) {
         updateHighlights();
     }
     await handlePlayMode();
@@ -588,6 +588,9 @@ export function play() {
     }
 
     if (!currentAudioPlayer.playing) {
+        if (!currentAudioPlayer.hasPlayed) {
+            currentAudioPlayer.hasPlayed = true;
+        }
         currentAudioPlayer.audio?.play();
         currentAudioPlayer.playStart = Date.now();
         logAudioPlay(currentAudioPlayer);

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -30,7 +30,7 @@ const timings = import.meta.glob('./*', {
     base: '/src/gen-assets/timings'
 }) as Record<string, string>;
 
-const AUDIO_SEEK_THRESHOLD = 0.1;
+const AUDIO_SEEK_THRESHOLD = 0.25;
 
 const cache = new MRUCache<string, AudioPlayer>(10);
 let currentAudioPlayer: AudioPlayer | undefined = undefined;
@@ -168,46 +168,66 @@ export async function skip(direction: number) {
     pause();
 
     if (!currentAudioPlayer?.loaded || !currentAudioPlayer.timing) {
-        await refs.skip(direction);
-        playMode.reset();
-        return;
-    }
+        if (
+            direction < 0 &&
+            currentAudioPlayer?.progress &&
+            currentAudioPlayer.progress >= AUDIO_SEEK_THRESHOLD
+        ) {
+            seek(0);
+            if (wasPlaying) {
+                play();
+            }
+        } else {
+            await refs.skip(direction);
+            playMode.reset();
+        }
+    } else {
+        const headingMarkers = getHeadingMarkers();
 
-    if (!currentAudioPlayer?.headingMarkers) {
-        currentAudioPlayer.headingMarkers = getHeadingMarkers();
-        audioPlayerStore.set(currentAudioPlayer);
-    }
+        if (!currentAudioPlayer?.headingMarkers) {
+            currentAudioPlayer.headingMarkers = headingMarkers;
+            audioPlayerStore.set(currentAudioPlayer);
+        }
 
-    if ((direction < 0 && currentAudioPlayer.progress < AUDIO_SEEK_THRESHOLD) ||
-         (direction >= 0 && (currentAudioPlayer.timing?.at(-1)?.endtime! -
-          currentAudioPlayer.progress) < AUDIO_SEEK_THRESHOLD)
-    ) {
-        await refs.skip(direction);
-        playMode.reset();
-        return;
-    }
+        if (
+            (direction < 0 && currentAudioPlayer.progress < AUDIO_SEEK_THRESHOLD) ||
+            (direction >= 0 && currentAudioPlayer.progress >= headingMarkers?.at(-2)!)
+        ) {
+            console.log(
+                `skipping at chapter bookend: ${currentAudioPlayer.progress} >= ${headingMarkers?.at(-2)!}`
+            );
+            await refs.skip(direction);
+            playMode.reset();
+            return;
+        }
 
-    for (let i = 1; i < currentAudioPlayer.headingMarkers.length - 1; i++) {
-        const marker = currentAudioPlayer.headingMarkers[i];
-        if (currentAudioPlayer.progress < (marker + AUDIO_SEEK_THRESHOLD)) {
-            if (direction < 0) {
-                seek(currentAudioPlayer.headingMarkers[i - 1]);
-                break;
-            } else if (currentAudioPlayer.progress > marker) {
-                seek(currentAudioPlayer.headingMarkers[i + 1]);
-                break;
-            } else {
-                seek(marker);
+        for (let i = 1; i < currentAudioPlayer.headingMarkers.length; i++) {
+            const marker = currentAudioPlayer.headingMarkers[i];
+            console.log(`checking marker ${marker}`);
+            if (currentAudioPlayer.progress < marker + AUDIO_SEEK_THRESHOLD) {
+                if (direction < 0) {
+                    seek(currentAudioPlayer.headingMarkers[i - 1]);
+                } else if (currentAudioPlayer.progress > marker) {
+                    seek(currentAudioPlayer.headingMarkers[i + 1]);
+                } else {
+                    seek(marker);
+                }
+                if (wasPlaying) {
+                    play();
+                }
                 break;
             }
         }
     }
 
-    updateHighlights();
-    if (wasPlaying) { play(); }
+    updateTime();
 }
 
 function getHeadingMarkers() {
+    if (currentAudioPlayer?.headingMarkers) {
+        return currentAudioPlayer.headingMarkers;
+    }
+
     let headingMarkers = [0.0];
 
     const headings = document.querySelectorAll('div.s');
@@ -221,8 +241,9 @@ function getHeadingMarkers() {
         // If defined this is the first verse immediately after the heading
         const verse = next?.getAttribute('data-verse');
         console.log(`candidate verse from ${next?.getHTML()}: (${verse})`);
-        if (verse === null || verse === undefined) { return; }
-
+        if (verse === null || verse === undefined) {
+            return;
+        }
 
         const marker = currentAudioPlayer?.timing?.find((v) => v.tag.includes(verse))?.starttime;
         console.log(marker);
@@ -231,8 +252,9 @@ function getHeadingMarkers() {
         }
     });
 
-    headingMarkers.push(currentAudioPlayer?.timing?.at(-1)?.endtime ||
-     currentAudioPlayer?.duration!);
+    headingMarkers.push(
+        currentAudioPlayer?.timing?.at(-1)?.endtime || currentAudioPlayer?.duration!
+    );
 
     console.log(`final heading markers: ${headingMarkers}`);
 

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -503,10 +503,10 @@ async function updateTime() {
         return;
     }
     currentAudioPlayer.progress = currentAudioPlayer.audio?.currentTime ?? 0;
-    if (!currentAudioPlayer.timing && currentAudioPlayer.progress) {
+    if (!currentAudioPlayer.timing) {
         audioPlayerStore.set(currentAudioPlayer);
     }
-    if (currentAudioPlayer.timing && currentAudioPlayer.progress) {
+    if (currentAudioPlayer.timing) {
         updateHighlights();
     }
     await handlePlayMode();

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -203,7 +203,6 @@ export async function skip(direction: number) {
             return;
         }
 
-
         for (let i = 1; i < currentAudioPlayer.headingMarkers.length; i++) {
             const marker = currentAudioPlayer.headingMarkers[i];
             if (currentAudioPlayer.progress < marker + AUDIO_SEEK_THRESHOLD) {
@@ -266,7 +265,7 @@ function getHeadingMarkers() {
 
 function nextElementDFS(e: Element) {
     let next = e.firstElementChild || e.nextElementSibling;
-    if ((next instanceof Element)) {
+    if (next instanceof Element) {
         return next;
     }
 

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -203,17 +203,22 @@ export async function skip(direction: number) {
             return;
         }
 
+
+        console.log(`(1) skip: currentAudioPlayer: progress is now ${currentAudioPlayer.progress}`);
         for (let i = 1; i < currentAudioPlayer.headingMarkers.length; i++) {
             const marker = currentAudioPlayer.headingMarkers[i];
             if (currentAudioPlayer.progress < marker + AUDIO_SEEK_THRESHOLD) {
                 if (direction < 0) {
+                    console.log(`skip: seeking to previous heading`)
                     seek(currentAudioPlayer.headingMarkers[i - 1]);
                 } else if (
                     i < currentAudioPlayer.headingMarkers.length - 1 &&
-                    currentAudioPlayer.progress > marker
+                    currentAudioPlayer.progress >= marker
                 ) {
+                    console.log(`skip: seeking to next heading`)
                     seek(currentAudioPlayer.headingMarkers[i + 1]);
                 } else {
+                    console.log(`skip: seeking to current heading`)
                     seek(marker);
                 }
                 if (wasPlaying) {
@@ -238,10 +243,10 @@ function getHeadingMarkers() {
     headings.forEach((h) => {
         let next = nextElementDFS(h);
         while (next && !next?.getAttribute('data-verse')) {
-            console.log(`searching ${next.outerHTML}...`);
+            // console.log(`searching ${next.outerHTML}...`);
             next = nextElementDFS(next);
         }
-        console.log(`found ${next}`);
+        // console.log(`found ${next}`);
 
         // If defined this is the first verse immediately after the heading
         const verse = next?.getAttribute('data-verse');

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -30,7 +30,7 @@ const timings = import.meta.glob('./*', {
     base: '/src/gen-assets/timings'
 }) as Record<string, string>;
 
-const AUDIO_SEEK_THRESHOLD = 0.25;
+const AUDIO_SEEK_THRESHOLD = 2.0;
 
 const cache = new MRUCache<string, AudioPlayer>(10);
 let currentAudioPlayer: AudioPlayer | undefined = undefined;
@@ -96,7 +96,6 @@ function createAudio(audioSource: string): HTMLAudioElement {
     }
     return audio;
 }
-
 //gets the current audio
 async function getAudio() {
     if (!currentAudioPlayer || currentAudioPlayer.loaded) {
@@ -163,7 +162,6 @@ export function playStop() {
 
 // changes chapter
 export async function skip(direction: number) {
-    console.log('skip');
     const wasPlaying = currentAudioPlayer?.playing;
     pause();
 
@@ -200,9 +198,6 @@ export async function skip(direction: number) {
                 finalIntermediateMarker &&
                 currentAudioPlayer.progress >= finalIntermediateMarker)
         ) {
-            console.log(
-                `skipping at chapter bookend: ${currentAudioPlayer.progress} >= ${headingMarkers?.at(-2)!}`
-            );
             await refs.skip(direction);
             playMode.reset();
             return;
@@ -210,7 +205,6 @@ export async function skip(direction: number) {
 
         for (let i = 1; i < currentAudioPlayer.headingMarkers.length; i++) {
             const marker = currentAudioPlayer.headingMarkers[i];
-            console.log(`checking marker ${marker}`);
             if (currentAudioPlayer.progress < marker + AUDIO_SEEK_THRESHOLD) {
                 if (direction < 0) {
                     seek(currentAudioPlayer.headingMarkers[i - 1]);
@@ -242,7 +236,6 @@ function getHeadingMarkers() {
 
     const headings = document.querySelectorAll('div.s');
     headings.forEach((h) => {
-        console.log(`found heading ${h.getHTML()}`);
         let next = nextElementDFS(h);
         while (next && !next?.getAttribute('data-verse')) {
             next = nextElementDFS(next);
@@ -250,13 +243,13 @@ function getHeadingMarkers() {
 
         // If defined this is the first verse immediately after the heading
         const verse = next?.getAttribute('data-verse');
-        console.log(`candidate verse from ${next?.getHTML()}: (${verse})`);
         if (verse === null || verse === undefined) {
             return;
         }
 
+        // find() always returns the first element it matches, so
+        // this will locate the beginning of the first phrase of the verse
         const marker = currentAudioPlayer?.timing?.find((v) => v.tag.includes(verse))?.starttime;
-        console.log(marker);
         if (marker) {
             headingMarkers.push(marker);
         }
@@ -266,8 +259,6 @@ function getHeadingMarkers() {
     if (typeof endMarker === 'number') {
         headingMarkers.push(endMarker);
     }
-
-    console.log(`final heading markers: ${headingMarkers}`);
 
     return headingMarkers;
 }

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -238,8 +238,10 @@ function getHeadingMarkers() {
     headings.forEach((h) => {
         let next = nextElementDFS(h);
         while (next && !next?.getAttribute('data-verse')) {
+            console.log(`searching ${next.outerHTML}...`);
             next = nextElementDFS(next);
         }
+        console.log(`found ${next}`);
 
         // If defined this is the first verse immediately after the heading
         const verse = next?.getAttribute('data-verse');
@@ -260,11 +262,22 @@ function getHeadingMarkers() {
         headingMarkers.push(endMarker);
     }
 
+    console.log(`headingMarkers: ${headingMarkers}`);
+
     return headingMarkers;
 }
 
 function nextElementDFS(e: Element) {
-    return e.firstElementChild || e.nextElementSibling || e.parentElement?.nextElementSibling;
+    let next = e.firstElementChild || e.nextElementSibling;
+    if ((next instanceof Element)) {
+        return next;
+    }
+
+    let ancestor = e.parentElement;
+    while (ancestor instanceof Element && !ancestor.nextElementSibling) {
+        ancestor = ancestor.parentElement;
+    }
+    return ancestor?.nextElementSibling || null;
 }
 
 // formats timing information

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -189,9 +189,16 @@ export async function skip(direction: number) {
             audioPlayerStore.set(currentAudioPlayer);
         }
 
+        let finalIntermediateMarker;
+        if (headingMarkers.length > 1) {
+            finalIntermediateMarker = headingMarkers.at(-2);
+        }
+
         if (
             (direction < 0 && currentAudioPlayer.progress < AUDIO_SEEK_THRESHOLD) ||
-            (direction >= 0 && currentAudioPlayer.progress >= headingMarkers?.at(-2)!)
+            (direction >= 0 &&
+                finalIntermediateMarker &&
+                currentAudioPlayer.progress >= finalIntermediateMarker)
         ) {
             console.log(
                 `skipping at chapter bookend: ${currentAudioPlayer.progress} >= ${headingMarkers?.at(-2)!}`
@@ -207,7 +214,10 @@ export async function skip(direction: number) {
             if (currentAudioPlayer.progress < marker + AUDIO_SEEK_THRESHOLD) {
                 if (direction < 0) {
                     seek(currentAudioPlayer.headingMarkers[i - 1]);
-                } else if (currentAudioPlayer.progress > marker) {
+                } else if (
+                    i < currentAudioPlayer.headingMarkers.length - 1 &&
+                    currentAudioPlayer.progress > marker
+                ) {
                     seek(currentAudioPlayer.headingMarkers[i + 1]);
                 } else {
                     seek(marker);
@@ -228,7 +238,7 @@ function getHeadingMarkers() {
         return currentAudioPlayer.headingMarkers;
     }
 
-    let headingMarkers = [0.0];
+    const headingMarkers = [0.0];
 
     const headings = document.querySelectorAll('div.s');
     headings.forEach((h) => {
@@ -252,9 +262,10 @@ function getHeadingMarkers() {
         }
     });
 
-    headingMarkers.push(
-        currentAudioPlayer?.timing?.at(-1)?.endtime || currentAudioPlayer?.duration!
-    );
+    const endMarker = currentAudioPlayer?.timing?.at(-1)?.endtime || currentAudioPlayer?.duration;
+    if (typeof endMarker === 'number') {
+        headingMarkers.push(endMarker);
+    }
 
     console.log(`final heading markers: ${headingMarkers}`);
 

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -187,16 +187,17 @@ export async function skip(direction: number) {
             audioPlayerStore.set(currentAudioPlayer);
         }
 
-        let finalIntermediateMarker;
+        let finalIntermediateMarker: number | undefined;
         if (headingMarkers.length > 1) {
-            finalIntermediateMarker = headingMarkers.at(-2);
+            // Don't treat the initial marker at 0 as intermediate
+            finalIntermediateMarker = headingMarkers.at(-2) || undefined;
         }
 
         if (
             (direction < 0 && currentAudioPlayer.progress < AUDIO_SEEK_THRESHOLD) ||
             (direction >= 0 &&
-                finalIntermediateMarker &&
-                currentAudioPlayer.progress >= finalIntermediateMarker)
+                (!finalIntermediateMarker ||
+                    currentAudioPlayer.progress >= finalIntermediateMarker))
         ) {
             await refs.skip(direction);
             playMode.reset();
@@ -264,7 +265,7 @@ function getHeadingMarkers() {
 }
 
 function nextElementDFS(e: Element) {
-    let next = e.firstElementChild || e.nextElementSibling;
+    const next = e.firstElementChild || e.nextElementSibling;
     if (next instanceof Element) {
         return next;
     }
@@ -512,10 +513,10 @@ async function updateTime() {
         return;
     }
     currentAudioPlayer.progress = currentAudioPlayer.audio?.currentTime ?? 0;
-    if (!currentAudioPlayer.timing) {
+    if (!currentAudioPlayer.timing && currentAudioPlayer.hasPlayed) {
         audioPlayerStore.set(currentAudioPlayer);
     }
-    if (currentAudioPlayer.hasPlayed && currentAudioPlayer.timing) {
+    if (currentAudioPlayer.timing && currentAudioPlayer.hasPlayed) {
         updateHighlights();
     }
     await handlePlayMode();

--- a/src/lib/data/stores/audio.ts
+++ b/src/lib/data/stores/audio.ts
@@ -37,6 +37,7 @@ export interface AudioPlayer {
     playing: boolean;
     timeIndex: number;
     timing: Timing[] | null;
+    headingMarkers?: number[];
     collection?: string;
     book?: string;
     chapter?: string;

--- a/src/lib/data/stores/audio.ts
+++ b/src/lib/data/stores/audio.ts
@@ -35,6 +35,7 @@ export interface AudioPlayer {
     duration: number;
     progress: number;
     playing: boolean;
+    hasPlayed: boolean;
     timeIndex: number;
     timing: Timing[] | null;
     headingMarkers?: number[];
@@ -50,6 +51,7 @@ export const audioPlayerDefault = {
     duration: 0,
     progress: 0,
     playing: false,
+    hasPlayed: false,
     timeIndex: 0,
     timing: null,
     timer: null,


### PR DESCRIPTION
Fixes #508.

I tested this on Mark 1 in the CUK Bible with a generated timing file from `aeneas`. The heading search works even with several nested HTML elements between the heading and the next verse.

<img width="1368" height="412" alt="image" src="https://github.com/user-attachments/assets/f79319eb-f3d8-4329-af8c-e5b17d3c8034" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Improvements**
  * Enhanced skip/seek behavior with more accurate navigation around chapter/verse boundaries.
  * More intelligent handling when timing is available vs. unavailable, including safer delegation and targeted seek jumps.
  * Added lazy detection and caching of heading markers to improve repeated navigation performance.
  * Playback now tracks first-play state to ensure highlights and time updates start at the correct moment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->