### PR TITLE
Implement Audio Sharing for Selected Text

### DIFF
--- a/src/lib/components/AudioAlertModal.svelte
+++ b/src/lib/components/AudioAlertModal.svelte
@@ -7,10 +7,13 @@ No Connection Modal Dialog component.
     import { t } from '$lib/data/stores';
     import Modal from './Modal.svelte';
 
-    const modalId = 'noConnectionModal';
+    const modalId = 'audioAlertModal';
     let modal: Modal | undefined = $state(undefined);
 
-    export function showModal() {
+    let messageKey = $state('');
+
+    export function showModal(_messageKey: string) {
+        messageKey = _messageKey;
         modal?.showModal();
     }
 </script>
@@ -20,7 +23,7 @@ No Connection Modal Dialog component.
         <div class="message-body" id="message-body">
             <div class="message-header"></div>
             <div class="message-text">
-                {$t['Audio_Download_Connect']}
+                {$t[messageKey]}
             </div>
         </div>
 

--- a/src/lib/components/AudioDownloadModal.svelte
+++ b/src/lib/components/AudioDownloadModal.svelte
@@ -6,7 +6,7 @@ Audio Download Modal Dialog component.
 <script lang="ts">
     import { updateAudioPlayer } from '$lib/data/audio';
     import { addAudioClip } from '$lib/data/audioclipsDB';
-    import { refs, t, userSettings } from '$lib/data/stores';
+    import { modal as alert, ModalType, refs, t, userSettings } from '$lib/data/stores';
     import { CheckboxIcon, CheckboxOutlineIcon } from '$lib/icons';
     import { tick } from 'svelte';
     import Modal from './Modal.svelte';
@@ -56,10 +56,8 @@ Audio Download Modal Dialog component.
     async function finishModal() {
         const addedAudioClip = await downloadAudio(audioUrl);
         if (!addedAudioClip && !abortController?.signal.aborted) {
-            error = 'Audio clip could not be downloaded';
-            setTimeout(() => {
-                error = '';
-            }, 2000);
+            modal?.close();
+            alert.open(ModalType.AudioAlert, 'Audio_Download_Error');
             return false;
         }
     }
@@ -117,15 +115,6 @@ Audio Download Modal Dialog component.
         </div>
     </div>
 </Modal>
-{#if error}
-    <div class="absolute inset-0 flex items-center justify-center z-50 pointer-events-none">
-        <div
-            class="dy-modal-box overflow-y-visible relative opacity-100 text-red-500 text-center pointer-events-auto"
-        >
-            {error}
-        </div>
-    </div>
-{/if}
 {#if downloadProgress > 0}
     <div class="fixed inset-0 bg-black/50 backdrop-blur-xs flex items-center justify-center z-50">
         <div class="message" id="container">

--- a/src/lib/components/DownloadSelector.svelte
+++ b/src/lib/components/DownloadSelector.svelte
@@ -4,7 +4,7 @@ A component for verse-on-image providing a dropdown where you can choose to down
 -->
 
 <script lang="ts">
-    import { convertStyle, s, t, themeColors } from '$lib/data/stores';
+    import { getPositioningCSS, t, themeColors } from '$lib/data/stores';
     import { ImageIcon, VideoIcon } from '$lib/icons';
     import Modal from './Modal.svelte';
 
@@ -15,18 +15,14 @@ A component for verse-on-image providing a dropdown where you can choose to down
     export function showModal() {
         modalThis.showModal();
     }
-    const positioningCSS = $derived(
-        'position:absolute; top:' +
-            (Number(vertOffset.replace('rem', '')) + 1) +
-            'rem; inset-inline-end:1rem; width:auto;'
-    );
+    const positioningCSS = $derived(getPositioningCSS(vertOffset, 'top'));
 </script>
 
 <!-- svelte-ignore a11y_consider_explicit_label -->
 <Modal
     bind:this={modalThis}
     id={modalId}
-    styling="background-color:{$themeColors['PopupBackgroundColor']}; {positioningCSS}"
+    styling="background-color:{$themeColors['PopupBackgroundColor']}; width:auto; {positioningCSS}"
 >
     <div class="grid gap-2 m-2">
         <button

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -28,6 +28,10 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
     export function showModal() {
         dialog?.showModal();
     }
+
+    export function close() {
+        dialog?.close();
+    }
 </script>
 
 <dialog

--- a/src/lib/components/PlanStopDialog.svelte
+++ b/src/lib/components/PlanStopDialog.svelte
@@ -11,7 +11,7 @@ Plan Stop Modal Dialog component.
     import { resolve } from '$lib/utils/paths';
     import Modal from './Modal.svelte';
 
-    let { planId = $bindable(undefined), vertOffset = '1rem' } = $props();
+    let { planId = $bindable(undefined) } = $props();
 
     const modalId = 'planStopDialog';
     let modal: Modal | undefined = $state(undefined);
@@ -31,13 +31,6 @@ Plan Stop Modal Dialog component.
             goto(resolve(`/plans`));
         });
     }
-
-    //The positioningCSS positions the modal 1rem below the navbar and 1rem from the right edge of the screen (on mobile it will be centered)
-    const positioningCSS = $derived(
-        'position:absolute; top:' +
-            (Number(vertOffset.replace('rem', '')) + 1) +
-            'rem; inset-inline-end:1rem;'
-    );
 </script>
 
 <Modal bind:this={modal} id={modalId}>

--- a/src/lib/components/ShareSelector.svelte
+++ b/src/lib/components/ShareSelector.svelte
@@ -66,7 +66,6 @@ A component providing a dropdown where you can choose to download audio or video
             const audioSource = new AudioBufferSource(audioConfig);
             output.addAudioTrack(audioSource);
             await output.start();
-            console.log(audioSourceInfo?.source);
             let isRemote;
 
             try {
@@ -78,11 +77,12 @@ A component providing a dropdown where you can choose to download audio or video
             if (isRemote) {
                 try {
                     let verses = await selectedVerses.getCompositeText();
-                    navigator.share({
+                    await navigator.share({
                         title: reference,
                         text: verses,
                         url: audioSourceInfo.source
                     });
+                    return;
                 } catch (error) {
                     if ((error as { name?: string })?.name === 'AbortError') {
                         return; // user intentionally dismissed native share UI

--- a/src/lib/components/ShareSelector.svelte
+++ b/src/lib/components/ShareSelector.svelte
@@ -31,9 +31,12 @@ A component providing a dropdown where you can choose to download audio or video
         const bookCol = $selectedVerses[0].collection;
         const fullBook = getBook({ collection: bookCol, book: book });
         const bookAbbrev = fullBook?.abbreviation ?? fullBook?.name;
+        const copyShareMessage = scriptureConfig.bookCollections?.find(
+            (x) => x.id === bookCol
+        )?.copyShareMessage;
         shareText(
             scriptureConfig.name ?? '',
-            scriptureConfig.name + '\n\n' + text + '\n' + reference,
+            text + '\n' + reference + (copyShareMessage ? '\n' + copyShareMessage : ''),
             book + '.txt'
         );
         logShareContent('Text', bookCol, bookAbbrev ?? '', reference);
@@ -209,8 +212,12 @@ A component providing a dropdown where you can choose to download audio or video
     } //This is used to determine a supported audio configuration. It first tries AAC, but then falls back to opus if AAC isn't supported. This is a duplicate of the function with the same name in VerseOnImage.svelte, so maybe it should be moved to somewhere that exports it for any place that needs it to use it?
     let modalId = 'shareSelector';
     let modalThis: Modal;
-    export function showModal() {
-        modalThis.showModal();
+    export function showModal(shareTextOnly: boolean) {
+        if (shareTextOnly) {
+            shareSelectedText();
+        } else {
+            modalThis.showModal();
+        }
     }
     const positioningCSS = $derived(
         'position:absolute; bottom:' +

--- a/src/lib/components/ShareSelector.svelte
+++ b/src/lib/components/ShareSelector.svelte
@@ -1,0 +1,182 @@
+<!--
+@component
+A component for verse-on-image providing a dropdown where you can choose to download an image or a video
+-->
+
+<script lang="ts">
+    import { scriptureConfig } from '$assets/config';
+    import { getBook, logShareContent } from '$lib/data/analytics';
+    import { getAudioSourceInfo } from '$lib/data/audio';
+    import { shareText } from '$lib/data/share';
+    import { refs, selectedVerses, t } from '$lib/data/stores';
+    import { AudioIcon } from '$lib/icons';
+    import FormatAlignLeftIcon from '$lib/icons/image/FormatAlignLeftIcon.svelte';
+    import {
+        AudioBufferSource,
+        BufferTarget,
+        canEncodeAudio,
+        Mp4OutputFormat,
+        Output,
+        WebMOutputFormat
+    } from 'mediabunny';
+    import type { AudioEncodingConfig } from 'mediabunny';
+    import Modal from './Modal.svelte';
+
+    let { vertOffset = '1rem' } = $props();
+    const reference = $derived(selectedVerses.getCompositeReference());
+    async function shareSelectedText() {
+        const book = $selectedVerses[0].book;
+        const reference = selectedVerses.getCompositeReference();
+        const text = await selectedVerses.getCompositeText();
+        const bookCol = $selectedVerses[0].collection;
+        const fullBook = getBook({ collection: bookCol, book: book });
+        const bookAbbrev = fullBook?.abbreviation ?? fullBook?.name;
+        shareText(
+            scriptureConfig.name ?? '',
+            scriptureConfig.name + '\n\n' + text + '\n' + reference,
+            book + '.txt'
+        );
+        logShareContent('Text', bookCol, bookAbbrev ?? '', reference);
+    }
+    async function shareAudio() {
+        const audioCtx = new AudioContext();
+        try {
+            const audioConfig: AudioEncodingConfig = await pickSupportedAudioConfig();
+            const useWebm = audioConfig.codec === 'opus';
+            const output = new Output({
+                format: useWebm ? new WebMOutputFormat() : new Mp4OutputFormat(),
+                target: new BufferTarget()
+            });
+
+            const audioSourceInfo = await getAudioSourceInfo({
+                collection: $refs.collection,
+                book: $refs.book,
+                chapter: $refs.chapter
+            });
+            if (!audioSourceInfo?.source) {
+                throw new Error('No audio source available for this chapter');
+            }
+
+            const audioSource = new AudioBufferSource(audioConfig);
+            output.addAudioTrack(audioSource);
+            await output.start();
+
+            const audioBlob = await fetch(audioSourceInfo?.source).then((r) => r.blob());
+            const audioBuffer = await audioCtx.decodeAudioData(await audioBlob.arrayBuffer());
+
+            const sampleRate = audioBuffer.sampleRate;
+
+            for (let i = 0; i < $selectedVerses.length; i++) {
+                let startFrame = 0;
+                let endFrame = 0;
+                for (var j = 0; j < (audioSourceInfo?.timing?.length || 0); j++) {
+                    const timing = audioSourceInfo?.timing?.[j];
+                    const verse = timing?.tag?.replace(/\D/g, '');
+                    if (verse === $selectedVerses[i].verse) {
+                        if (!startFrame) {
+                            startFrame = Math.floor((timing?.starttime || 0) * sampleRate);
+                            endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
+                        } else {
+                            endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
+                        }
+                    }
+                }
+                if (endFrame <= startFrame) {
+                    console.warn(`No timing found for verse ${$selectedVerses[i].verse}, skipping`);
+                    continue;
+                }
+                const trimmedBuffer = audioCtx.createBuffer(
+                    audioBuffer.numberOfChannels,
+                    endFrame - startFrame,
+                    sampleRate
+                );
+
+                for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
+                    const src = audioBuffer.getChannelData(ch);
+                    const dst = trimmedBuffer.getChannelData(ch);
+                    dst.set(src.slice(startFrame, endFrame));
+                }
+
+                await audioSource.add(trimmedBuffer);
+            }
+            await output.finalize();
+
+            const buffer = output.target.buffer as BlobPart;
+            const blob = new Blob([buffer], {
+                type: useWebm ? 'audio/webm' : 'audio/mp4'
+            });
+            const filename = reference + (useWebm ? '.webm' : '.mp4');
+            const file = new File([blob], filename, {
+                type: useWebm ? 'audio/webm' : 'audio/mp4'
+            });
+            const url = URL.createObjectURL(file);
+
+            const anchor = document.createElement('a');
+            anchor.href = url;
+            anchor.download = filename;
+            anchor.click();
+
+            URL.revokeObjectURL(url);
+        } catch (error) {
+            console.error('Error generating audio export:', error);
+        } finally {
+            await audioCtx?.close();
+        }
+    } //I'll need to have it share it rather than downloading it.
+    async function pickSupportedAudioConfig() {
+        const candidates: AudioEncodingConfig[] = [
+            { codec: 'aac', bitrate: 128000 },
+            { codec: 'aac', bitrate: 96000 },
+            { codec: 'aac', bitrate: 64000 },
+            {
+                codec: 'opus',
+                bitrate: 96000
+            }
+        ];
+
+        for (const cfg of candidates) {
+            if (await canEncodeAudio(cfg.codec, cfg)) {
+                return cfg;
+            }
+        }
+
+        throw new Error('No supported AAC configuration found.');
+    } //This is used to determine a supported audio configuration. It first tries AAC, but then falls back to opus if AAC isn't supported. This is a duplicate of the function with the same name in VerseOnImage.svelte, so maybe it should be moved to somewhere that exports it for any place that needs it to use it?
+    let modalId = 'shareSelector';
+    let modalThis: Modal;
+    export function showModal() {
+        modalThis.showModal();
+    }
+    const positioningCSS = $derived(
+        'position:absolute; bottom:' +
+            (Number(vertOffset.replace('rem', '')) + 1) +
+            'rem; inset-inline-end:1rem; width:auto;'
+    );
+</script>
+
+<!-- svelte-ignore a11y_consider_explicit_label -->
+<Modal bind:this={modalThis} id={modalId} addCSS={positioningCSS}>
+    <div class="grid gap-2 m-2">
+        <button
+            class="dy-btn dy-btn-sm flex items-center justify-center gap-2"
+            onclick={() => shareSelectedText()}
+        >
+            <FormatAlignLeftIcon />
+            {$t['Share_Text']}
+        </button>
+        <button
+            class="dy-btn dy-btn-sm flex items-center justify-center gap-2"
+            onclick={() => shareAudio()}
+        >
+            <AudioIcon.Volume />
+            {$t['Share_Audio']}
+        </button>
+        <!--<button
+            class="dy-btn dy-btn-sm flex items-center justify-center gap-2"
+            onclick={() => downloadVideo()}
+        >
+            <VideoIcon />
+            {$t['Share_Video']}
+        </button>-->
+    </div>
+</Modal>

--- a/src/lib/components/ShareSelector.svelte
+++ b/src/lib/components/ShareSelector.svelte
@@ -1,6 +1,6 @@
 <!--
 @component
-A component for verse-on-image providing a dropdown where you can choose to download an image or a video
+A component providing a dropdown where you can choose to download audio or video for selected text
 -->
 
 <script lang="ts">

--- a/src/lib/components/ShareSelector.svelte
+++ b/src/lib/components/ShareSelector.svelte
@@ -8,7 +8,7 @@ A component providing a dropdown where you can choose to download audio or video
     import { getBook, logShareContent } from '$lib/data/analytics';
     import { getAudioSourceInfo } from '$lib/data/audio';
     import { shareText } from '$lib/data/share';
-    import { refs, selectedVerses, t } from '$lib/data/stores';
+    import { refs, selectedVerses, t, themeColors } from '$lib/data/stores';
     import { AudioIcon } from '$lib/icons';
     import FormatAlignLeftIcon from '$lib/icons/image/FormatAlignLeftIcon.svelte';
     import {
@@ -220,7 +220,11 @@ A component providing a dropdown where you can choose to download audio or video
 </script>
 
 <!-- svelte-ignore a11y_consider_explicit_label -->
-<Modal bind:this={modalThis} id={modalId} addCSS={positioningCSS}>
+<Modal
+    bind:this={modalThis}
+    id={modalId}
+    styling="background-color:{$themeColors['PopupBackgroundColor']}; {positioningCSS}"
+>
     <div class="grid gap-2 m-2">
         <button
             class="dy-btn dy-btn-sm flex items-center justify-center gap-2"

--- a/src/lib/components/ShareSelector.svelte
+++ b/src/lib/components/ShareSelector.svelte
@@ -8,7 +8,7 @@ A component providing a dropdown where you can choose to download audio or video
     import { getBook, logShareContent } from '$lib/data/analytics';
     import { getAudioSourceInfo } from '$lib/data/audio';
     import { shareText } from '$lib/data/share';
-    import { refs, selectedVerses, t, themeColors } from '$lib/data/stores';
+    import { getPositioningCSS, refs, selectedVerses, t } from '$lib/data/stores';
     import { AudioIcon } from '$lib/icons';
     import FormatAlignLeftIcon from '$lib/icons/image/FormatAlignLeftIcon.svelte';
     import {
@@ -23,7 +23,7 @@ A component providing a dropdown where you can choose to download audio or video
     import type { AudioEncodingConfig } from 'mediabunny';
     import Modal from './Modal.svelte';
 
-    let { vertOffset = '1rem' } = $props();
+    let { vertOffset = '2rem' } = $props();
     async function shareSelectedText() {
         const book = $selectedVerses[0].book;
         const reference = selectedVerses.getCompositeReference();
@@ -219,36 +219,32 @@ A component providing a dropdown where you can choose to download audio or video
             modalThis.showModal();
         }
     }
-    const positioningCSS = $derived(
-        'position:absolute; bottom:' +
-            (Number(vertOffset.replace('rem', '')) + 1) +
-            'rem; inset-inline-end:1rem; width:auto;'
-    );
+    const positioningCSS = $derived(getPositioningCSS(vertOffset, 'bottom'));
 </script>
 
 <!-- svelte-ignore a11y_consider_explicit_label -->
 <Modal
     bind:this={modalThis}
     id={modalId}
-    styling="background-color:{$themeColors['PopupBackgroundColor']}; {positioningCSS}"
+    styling="background-color:red; box-shadow:none; padding:0; width:auto; {positioningCSS}"
 >
-    <div class="grid gap-2 m-2">
+    <div class="grid">
         <button
-            class="dy-btn dy-btn-sm flex items-center justify-center gap-2"
+            class="dy-btn flex items-center justify-center rounded-none"
             onclick={() => shareSelectedText()}
         >
             <FormatAlignLeftIcon />
             {$t['Share_Text']}
         </button>
         <button
-            class="dy-btn dy-btn-sm flex items-center justify-center gap-2"
+            class="dy-btn flex items-center justify-center rounded-none"
             onclick={() => shareAudio()}
         >
             <AudioIcon.Volume />
             {$t['Share_Audio']}
         </button>
         <!--<button
-            class="dy-btn dy-btn-sm flex items-center justify-center gap-2"
+            class="dy-btn flex items-center justify-center rounded-none"
             onclick={() => downloadVideo()}
         >
             <VideoIcon />

--- a/src/lib/components/ShareSelector.svelte
+++ b/src/lib/components/ShareSelector.svelte
@@ -122,6 +122,9 @@ A component for verse-on-image providing a dropdown where you can choose to down
                     return;
                 }
             } catch (error) {
+                if ((error as { name?: string })?.name === 'AbortError') {
+                    return; // user intentionally dismissed native share UI
+                }
                 console.error('Error sharing: ', error);
             }
 

--- a/src/lib/components/ShareSelector.svelte
+++ b/src/lib/components/ShareSelector.svelte
@@ -66,83 +66,119 @@ A component providing a dropdown where you can choose to download audio or video
             const audioSource = new AudioBufferSource(audioConfig);
             output.addAudioTrack(audioSource);
             await output.start();
+            console.log(audioSourceInfo?.source);
+            let isRemote;
 
-            const audioBlob = await fetch(audioSourceInfo?.source).then((r) => r.blob());
-            const audioBuffer = await audioCtx.decodeAudioData(await audioBlob.arrayBuffer());
+            try {
+                let url = new URL(audioSourceInfo.source);
+                isRemote = url.protocol === 'http:' || url.protocol === 'https:';
+            } catch (_) {
+                isRemote = false;
+            }
+            if (isRemote) {
+                try {
+                    let verses = await selectedVerses.getCompositeText();
+                    navigator.share({
+                        title: reference,
+                        text: verses,
+                        url: audioSourceInfo.source
+                    });
+                } catch (error) {
+                    if ((error as { name?: string })?.name === 'AbortError') {
+                        return; // user intentionally dismissed native share UI
+                    }
+                    console.error('Error sharing: ', error);
+                }
 
-            const sampleRate = audioBuffer.sampleRate;
+                // if we're here, we failed to share, so we'll try to use the download link. This generally is just going to open the URL rather than downloading it.
+                const anchor = document.createElement('a');
+                anchor.href = audioSourceInfo.source;
+                anchor.download = '';
+                anchor.click();
+            } else {
+                const audioBlob = await fetch(audioSourceInfo?.source).then((r) => r.blob());
+                const audioBuffer = await audioCtx.decodeAudioData(await audioBlob.arrayBuffer());
 
-            for (let i = 0; i < $selectedVerses.length; i++) {
-                let startFrame = 0;
-                let endFrame = 0;
-                for (var j = 0; j < (audioSourceInfo?.timing?.length || 0); j++) {
-                    const timing = audioSourceInfo?.timing?.[j];
-                    const verse = timing?.tag?.replace(/\D/g, '');
-                    if (verse === $selectedVerses[i].verse) {
-                        if (!startFrame) {
-                            startFrame = Math.floor((timing?.starttime || 0) * sampleRate);
-                            endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
-                        } else {
-                            endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
+                const sampleRate = audioBuffer.sampleRate;
+
+                for (let i = 0; i < $selectedVerses.length; i++) {
+                    let startFrame = 0;
+                    let endFrame = 0;
+                    for (var j = 0; j < (audioSourceInfo?.timing?.length || 0); j++) {
+                        const timing = audioSourceInfo?.timing?.[j];
+                        const verse = timing?.tag?.replace(/\D/g, '');
+                        if (verse === $selectedVerses[i].verse) {
+                            if (!startFrame) {
+                                startFrame = Math.floor((timing?.starttime || 0) * sampleRate);
+                                endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
+                            } else {
+                                endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
+                            }
                         }
                     }
-                }
-                if (endFrame <= startFrame) {
-                    console.warn(`No timing found for verse ${$selectedVerses[i].verse}, skipping`);
-                    continue;
-                }
-                const trimmedBuffer = audioCtx.createBuffer(
-                    audioBuffer.numberOfChannels,
-                    endFrame - startFrame,
-                    sampleRate
-                );
+                    if (endFrame <= startFrame) {
+                        console.warn(
+                            `No timing found for verse ${$selectedVerses[i].verse}, skipping`
+                        );
+                        continue;
+                    }
+                    const trimmedBuffer = audioCtx.createBuffer(
+                        audioBuffer.numberOfChannels,
+                        endFrame - startFrame,
+                        sampleRate
+                    );
 
-                for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
-                    const src = audioBuffer.getChannelData(ch);
-                    const dst = trimmedBuffer.getChannelData(ch);
-                    dst.set(src.slice(startFrame, endFrame));
+                    for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
+                        const src = audioBuffer.getChannelData(ch);
+                        const dst = trimmedBuffer.getChannelData(ch);
+                        dst.set(src.slice(startFrame, endFrame));
+                    }
+
+                    await audioSource.add(trimmedBuffer);
+                }
+                await output.finalize();
+
+                const buffer = output.target.buffer as BlobPart;
+                const blob = new Blob([buffer], {
+                    type: 'audio/' + outputFormat.name
+                });
+                const filename = reference + '.' + outputFormat.name;
+                const file = new File([blob], filename, {
+                    type: 'audio/' + outputFormat.name
+                });
+                try {
+                    if (
+                        navigator.share &&
+                        navigator.canShare &&
+                        navigator.canShare({ files: [file] })
+                    ) {
+                        let verses = await selectedVerses.getCompositeText();
+                        const shareData: ShareData = {
+                            title: reference,
+                            text: verses,
+                            files: [file]
+                        };
+
+                        await navigator.share(shareData);
+                        return;
+                    }
+                } catch (error) {
+                    if ((error as { name?: string })?.name === 'AbortError') {
+                        return; // user intentionally dismissed native share UI
+                    }
+                    console.error('Error sharing: ', error);
                 }
 
-                await audioSource.add(trimmedBuffer);
+                // if we're here, we failed to share, so we'll try to use the download link
+                const url = URL.createObjectURL(file);
+
+                const anchor = document.createElement('a');
+                anchor.href = url;
+                anchor.download = filename;
+                anchor.click();
+
+                URL.revokeObjectURL(url);
             }
-            await output.finalize();
-
-            const buffer = output.target.buffer as BlobPart;
-            const blob = new Blob([buffer], {
-                type: 'audio/' + outputFormat.name
-            });
-            const filename = reference + '.' + outputFormat.name;
-            const file = new File([blob], filename, {
-                type: 'audio/' + outputFormat.name
-            });
-            try {
-                if (
-                    navigator.share &&
-                    navigator.canShare &&
-                    navigator.canShare({ files: [file] })
-                ) {
-                    let verses = await selectedVerses.getCompositeText();
-                    const shareData: ShareData = { title: reference, text: verses, files: [file] };
-
-                    await navigator.share(shareData);
-                    return;
-                }
-            } catch (error) {
-                if ((error as { name?: string })?.name === 'AbortError') {
-                    return; // user intentionally dismissed native share UI
-                }
-                console.error('Error sharing: ', error);
-            }
-
-            // if we're here, we failed to share, so we'll try to use the download link
-            const url = URL.createObjectURL(file);
-
-            const anchor = document.createElement('a');
-            anchor.href = url;
-            anchor.download = filename;
-            anchor.click();
-
-            URL.revokeObjectURL(url);
         } catch (error) {
             console.error('Error generating audio export:', error);
         } finally {

--- a/src/lib/components/ShareSelector.svelte
+++ b/src/lib/components/ShareSelector.svelte
@@ -109,6 +109,23 @@ A component for verse-on-image providing a dropdown where you can choose to down
             const file = new File([blob], filename, {
                 type: useWebm ? 'audio/webm' : 'audio/mp4'
             });
+            try {
+                if (
+                    navigator.share &&
+                    navigator.canShare &&
+                    navigator.canShare({ files: [file] })
+                ) {
+                    let verses = await selectedVerses.getCompositeText();
+                    const shareData: ShareData = { title: reference, text: verses, files: [file] };
+
+                    await navigator.share(shareData);
+                    return;
+                }
+            } catch (error) {
+                console.error('Error sharing: ', error);
+            }
+
+            // if we're here, we failed to share, so we'll try to use the download link
             const url = URL.createObjectURL(file);
 
             const anchor = document.createElement('a');

--- a/src/lib/components/ShareSelector.svelte
+++ b/src/lib/components/ShareSelector.svelte
@@ -17,6 +17,7 @@ A component for verse-on-image providing a dropdown where you can choose to down
         canEncodeAudio,
         Mp4OutputFormat,
         Output,
+        WavOutputFormat,
         WebMOutputFormat
     } from 'mediabunny';
     import type { AudioEncodingConfig } from 'mediabunny';
@@ -42,9 +43,14 @@ A component for verse-on-image providing a dropdown where you can choose to down
         const audioCtx = new AudioContext();
         try {
             const audioConfig: AudioEncodingConfig = await pickSupportedAudioConfig();
-            const useWebm = audioConfig.codec === 'opus';
+            const outputFormat =
+                audioConfig.codec === 'aac'
+                    ? { name: 'mp4', format: new Mp4OutputFormat() }
+                    : audioConfig.codec === 'opus'
+                      ? { name: 'webm', format: new WebMOutputFormat() }
+                      : { name: 'wav', format: new WavOutputFormat() };
             const output = new Output({
-                format: useWebm ? new WebMOutputFormat() : new Mp4OutputFormat(),
+                format: outputFormat.format,
                 target: new BufferTarget()
             });
 
@@ -103,11 +109,11 @@ A component for verse-on-image providing a dropdown where you can choose to down
 
             const buffer = output.target.buffer as BlobPart;
             const blob = new Blob([buffer], {
-                type: useWebm ? 'audio/webm' : 'audio/mp4'
+                type: 'audio/' + outputFormat.name
             });
-            const filename = reference + (useWebm ? '.webm' : '.mp4');
+            const filename = reference + '.' + outputFormat.name;
             const file = new File([blob], filename, {
-                type: useWebm ? 'audio/webm' : 'audio/mp4'
+                type: 'audio/' + outputFormat.name
             });
             try {
                 if (
@@ -151,7 +157,10 @@ A component for verse-on-image providing a dropdown where you can choose to down
             {
                 codec: 'opus',
                 bitrate: 96000
-            }
+            },
+            { codec: 'pcm-f32' },
+            { codec: 'pcm-s24' },
+            { codec: 'pcm-s16' }
         ];
 
         for (const cfg of candidates) {
@@ -160,7 +169,7 @@ A component for verse-on-image providing a dropdown where you can choose to down
             }
         }
 
-        throw new Error('No supported AAC configuration found.');
+        throw new Error('No supported audio configuration found.');
     } //This is used to determine a supported audio configuration. It first tries AAC, but then falls back to opus if AAC isn't supported. This is a duplicate of the function with the same name in VerseOnImage.svelte, so maybe it should be moved to somewhere that exports it for any place that needs it to use it?
     let modalId = 'shareSelector';
     let modalThis: Modal;

--- a/src/lib/components/ShareSelector.svelte
+++ b/src/lib/components/ShareSelector.svelte
@@ -24,7 +24,6 @@ A component for verse-on-image providing a dropdown where you can choose to down
     import Modal from './Modal.svelte';
 
     let { vertOffset = '1rem' } = $props();
-    const reference = $derived(selectedVerses.getCompositeReference());
     async function shareSelectedText() {
         const book = $selectedVerses[0].book;
         const reference = selectedVerses.getCompositeReference();
@@ -40,6 +39,7 @@ A component for verse-on-image providing a dropdown where you can choose to down
         logShareContent('Text', bookCol, bookAbbrev ?? '', reference);
     }
     async function shareAudio() {
+        const reference = selectedVerses.getCompositeReference();
         const audioCtx = new AudioContext();
         try {
             const audioConfig: AudioEncodingConfig = await pickSupportedAudioConfig();
@@ -148,7 +148,7 @@ A component for verse-on-image providing a dropdown where you can choose to down
         } finally {
             await audioCtx?.close();
         }
-    } //I'll need to have it share it rather than downloading it.
+    }
     async function pickSupportedAudioConfig() {
         const candidates: AudioEncodingConfig[] = [
             { codec: 'aac', bitrate: 128000 },

--- a/src/lib/components/ShareSelector.svelte
+++ b/src/lib/components/ShareSelector.svelte
@@ -8,7 +8,16 @@ A component providing a dropdown where you can choose to download audio or video
     import { getBook, logShareContent } from '$lib/data/analytics';
     import { getAudioSourceInfo } from '$lib/data/audio';
     import { shareAudio, shareText } from '$lib/data/share';
-    import { convertStyle, getPositioningCSS, refs, s, selectedVerses, t } from '$lib/data/stores';
+    import {
+        convertStyle,
+        getPositioningCSS,
+        modal,
+        ModalType,
+        refs,
+        s,
+        selectedVerses,
+        t
+    } from '$lib/data/stores';
     import { AudioIcon } from '$lib/icons';
     import FormatAlignLeftIcon from '$lib/icons/image/FormatAlignLeftIcon.svelte';
     import {
@@ -122,6 +131,7 @@ A component providing a dropdown where you can choose to download audio or video
                 outputFormat.mimeType
             );
         } catch (error) {
+            modal.open(ModalType.AudioAlert, 'Audio_Download_Error');
             console.error('Error generating audio export:', error);
         } finally {
             await audioCtx?.close();

--- a/src/lib/components/ShareSelector.svelte
+++ b/src/lib/components/ShareSelector.svelte
@@ -7,7 +7,7 @@ A component providing a dropdown where you can choose to download audio or video
     import { scriptureConfig } from '$assets/config';
     import { getBook, logShareContent } from '$lib/data/analytics';
     import { getAudioSourceInfo } from '$lib/data/audio';
-    import { shareText } from '$lib/data/share';
+    import { shareAudio, shareText } from '$lib/data/share';
     import { getPositioningCSS, refs, selectedVerses, t } from '$lib/data/stores';
     import { AudioIcon } from '$lib/icons';
     import FormatAlignLeftIcon from '$lib/icons/image/FormatAlignLeftIcon.svelte';
@@ -41,19 +41,19 @@ A component providing a dropdown where you can choose to download audio or video
         );
         logShareContent('Text', bookCol, bookAbbrev ?? '', reference);
     }
-    async function shareAudio() {
+    async function shareAudioFile() {
         const reference = selectedVerses.getCompositeReference();
         const audioCtx = new AudioContext();
         try {
             const audioConfig: AudioEncodingConfig = await pickSupportedAudioConfig();
             const outputFormat =
                 audioConfig.codec === 'aac'
-                    ? { name: 'mp4', format: new Mp4OutputFormat() }
+                    ? new Mp4OutputFormat()
                     : audioConfig.codec === 'opus'
-                      ? { name: 'webm', format: new WebMOutputFormat() }
-                      : { name: 'wav', format: new WavOutputFormat() };
+                      ? new WebMOutputFormat()
+                      : new WavOutputFormat();
             const output = new Output({
-                format: outputFormat.format,
+                format: outputFormat,
                 target: new BufferTarget()
             });
 
@@ -69,119 +69,56 @@ A component providing a dropdown where you can choose to download audio or video
             const audioSource = new AudioBufferSource(audioConfig);
             output.addAudioTrack(audioSource);
             await output.start();
-            let isRemote;
 
-            try {
-                let url = new URL(audioSourceInfo.source);
-                isRemote = url.protocol === 'http:' || url.protocol === 'https:';
-            } catch (_) {
-                isRemote = false;
-            }
-            if (isRemote) {
-                try {
-                    let verses = await selectedVerses.getCompositeText();
-                    await navigator.share({
-                        title: reference,
-                        text: verses,
-                        url: audioSourceInfo.source
-                    });
-                    return;
-                } catch (error) {
-                    if ((error as { name?: string })?.name === 'AbortError') {
-                        return; // user intentionally dismissed native share UI
-                    }
-                    console.error('Error sharing: ', error);
-                }
+            const audioBlob = await fetch(audioSourceInfo?.source).then((r) => r.blob());
+            const audioBuffer = await audioCtx.decodeAudioData(await audioBlob.arrayBuffer());
 
-                // if we're here, we failed to share, so we'll try to use the download link. This generally is just going to open the URL rather than downloading it.
-                const anchor = document.createElement('a');
-                anchor.href = audioSourceInfo.source;
-                anchor.download = '';
-                anchor.click();
-            } else {
-                const audioBlob = await fetch(audioSourceInfo?.source).then((r) => r.blob());
-                const audioBuffer = await audioCtx.decodeAudioData(await audioBlob.arrayBuffer());
+            const sampleRate = audioBuffer.sampleRate;
 
-                const sampleRate = audioBuffer.sampleRate;
-
-                for (let i = 0; i < $selectedVerses.length; i++) {
-                    let startFrame = 0;
-                    let endFrame = 0;
-                    for (var j = 0; j < (audioSourceInfo?.timing?.length || 0); j++) {
-                        const timing = audioSourceInfo?.timing?.[j];
-                        const verse = timing?.tag?.replace(/\D/g, '');
-                        if (verse === $selectedVerses[i].verse) {
-                            if (!startFrame) {
-                                startFrame = Math.floor((timing?.starttime || 0) * sampleRate);
-                                endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
-                            } else {
-                                endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
-                            }
+            for (let i = 0; i < $selectedVerses.length; i++) {
+                let startFrame = 0;
+                let endFrame = 0;
+                for (var j = 0; j < (audioSourceInfo?.timing?.length || 0); j++) {
+                    const timing = audioSourceInfo?.timing?.[j];
+                    const verse = timing?.tag?.replace(/\D/g, '');
+                    if (verse === $selectedVerses[i].verse) {
+                        if (!startFrame) {
+                            startFrame = Math.floor((timing?.starttime || 0) * sampleRate);
+                            endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
+                        } else {
+                            endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
                         }
                     }
-                    if (endFrame <= startFrame) {
-                        console.warn(
-                            `No timing found for verse ${$selectedVerses[i].verse}, skipping`
-                        );
-                        continue;
-                    }
-                    const trimmedBuffer = audioCtx.createBuffer(
-                        audioBuffer.numberOfChannels,
-                        endFrame - startFrame,
-                        sampleRate
-                    );
-
-                    for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
-                        const src = audioBuffer.getChannelData(ch);
-                        const dst = trimmedBuffer.getChannelData(ch);
-                        dst.set(src.slice(startFrame, endFrame));
-                    }
-
-                    await audioSource.add(trimmedBuffer);
                 }
-                await output.finalize();
+                if (endFrame <= startFrame) {
+                    console.warn(`No timing found for verse ${$selectedVerses[i].verse}, skipping`);
+                    continue;
+                }
+                const trimmedBuffer = audioCtx.createBuffer(
+                    audioBuffer.numberOfChannels,
+                    endFrame - startFrame,
+                    sampleRate
+                );
 
-                const buffer = output.target.buffer as BlobPart;
-                const blob = new Blob([buffer], {
-                    type: 'audio/' + outputFormat.name
-                });
-                const filename = reference + '.' + outputFormat.name;
-                const file = new File([blob], filename, {
-                    type: 'audio/' + outputFormat.name
-                });
-                try {
-                    if (
-                        navigator.share &&
-                        navigator.canShare &&
-                        navigator.canShare({ files: [file] })
-                    ) {
-                        let verses = await selectedVerses.getCompositeText();
-                        const shareData: ShareData = {
-                            title: reference,
-                            text: verses,
-                            files: [file]
-                        };
-
-                        await navigator.share(shareData);
-                        return;
-                    }
-                } catch (error) {
-                    if ((error as { name?: string })?.name === 'AbortError') {
-                        return; // user intentionally dismissed native share UI
-                    }
-                    console.error('Error sharing: ', error);
+                for (let ch = 0; ch < audioBuffer.numberOfChannels; ch++) {
+                    const src = audioBuffer.getChannelData(ch);
+                    const dst = trimmedBuffer.getChannelData(ch);
+                    dst.set(src.slice(startFrame, endFrame));
                 }
 
-                // if we're here, we failed to share, so we'll try to use the download link
-                const url = URL.createObjectURL(file);
-
-                const anchor = document.createElement('a');
-                anchor.href = url;
-                anchor.download = filename;
-                anchor.click();
-
-                URL.revokeObjectURL(url);
+                await audioSource.add(trimmedBuffer);
             }
+            await output.finalize();
+
+            await shareAudio(
+                reference,
+                await selectedVerses.getCompositeText(),
+                reference + outputFormat.fileExtension,
+                new Blob([output.target.buffer as BlobPart], {
+                    type: outputFormat.mimeType
+                }),
+                outputFormat.mimeType
+            );
         } catch (error) {
             console.error('Error generating audio export:', error);
         } finally {
@@ -238,7 +175,7 @@ A component providing a dropdown where you can choose to download audio or video
         </button>
         <button
             class="dy-btn flex items-center justify-center rounded-none"
-            onclick={() => shareAudio()}
+            onclick={() => shareAudioFile()}
         >
             <AudioIcon.Volume />
             {$t['Share_Audio']}

--- a/src/lib/components/ShareSelector.svelte
+++ b/src/lib/components/ShareSelector.svelte
@@ -78,11 +78,13 @@ A component providing a dropdown where you can choose to download audio or video
             for (let i = 0; i < $selectedVerses.length; i++) {
                 let startFrame = 0;
                 let endFrame = 0;
+                let foundVerseTiming = false;
                 for (var j = 0; j < (audioSourceInfo?.timing?.length || 0); j++) {
                     const timing = audioSourceInfo?.timing?.[j];
                     const verse = timing?.tag?.replace(/\D/g, '');
                     if (verse === $selectedVerses[i].verse) {
-                        if (!startFrame) {
+                        if (!foundVerseTiming) {
+                            foundVerseTiming = true;
                             startFrame = Math.floor((timing?.starttime || 0) * sampleRate);
                             endFrame = Math.floor((timing?.endtime || 0) * sampleRate);
                         } else {
@@ -90,7 +92,7 @@ A component providing a dropdown where you can choose to download audio or video
                         }
                     }
                 }
-                if (endFrame <= startFrame) {
+                if (!foundVerseTiming || endFrame <= startFrame) {
                     console.warn(`No timing found for verse ${$selectedVerses[i].verse}, skipping`);
                     continue;
                 }
@@ -113,7 +115,7 @@ A component providing a dropdown where you can choose to download audio or video
             await shareAudio(
                 reference,
                 await selectedVerses.getCompositeText(),
-                reference + outputFormat.fileExtension,
+                reference.replace(/[\\/:*?"<>|]/g, '_') + outputFormat.fileExtension,
                 new Blob([output.target.buffer as BlobPart], {
                     type: outputFormat.mimeType
                 }),

--- a/src/lib/components/ShareSelector.svelte
+++ b/src/lib/components/ShareSelector.svelte
@@ -8,7 +8,7 @@ A component providing a dropdown where you can choose to download audio or video
     import { getBook, logShareContent } from '$lib/data/analytics';
     import { getAudioSourceInfo } from '$lib/data/audio';
     import { shareAudio, shareText } from '$lib/data/share';
-    import { getPositioningCSS, refs, selectedVerses, t } from '$lib/data/stores';
+    import { convertStyle, getPositioningCSS, refs, s, selectedVerses, t } from '$lib/data/stores';
     import { AudioIcon } from '$lib/icons';
     import FormatAlignLeftIcon from '$lib/icons/image/FormatAlignLeftIcon.svelte';
     import {
@@ -157,27 +157,30 @@ A component providing a dropdown where you can choose to download audio or video
         }
     }
     const positioningCSS = $derived(getPositioningCSS(vertOffset, 'bottom'));
+    const iconColor = $derived($s?.['ui.bar.audio.hint.text']?.['color'] || 'black');
 </script>
 
 <!-- svelte-ignore a11y_consider_explicit_label -->
 <Modal
     bind:this={modalThis}
     id={modalId}
-    styling="background-color:red; box-shadow:none; padding:0; width:auto; {positioningCSS}"
+    styling="box-shadow:none; padding:0; width:auto; {positioningCSS}"
 >
-    <div class="grid">
+    <div class="grid message" id="container">
         <button
-            class="dy-btn flex items-center justify-center rounded-none"
+            class="dy-btn flex items-center justify-center rounded-none border-transparent"
+            style={convertStyle($s?.['ui.bar.audio.hint.text'])}
             onclick={() => shareSelectedText()}
         >
-            <FormatAlignLeftIcon />
+            <FormatAlignLeftIcon color={iconColor} />
             {$t['Share_Text']}
         </button>
         <button
-            class="dy-btn flex items-center justify-center rounded-none"
+            class="dy-btn flex items-center justify-center rounded-none border-transparent"
+            style={convertStyle($s?.['ui.bar.audio.hint.text'])}
             onclick={() => shareAudioFile()}
         >
-            <AudioIcon.Volume />
+            <AudioIcon.Volume color={iconColor} />
             {$t['Share_Audio']}
         </button>
         <!--<button

--- a/src/lib/components/TextAppearanceSelector.svelte
+++ b/src/lib/components/TextAppearanceSelector.svelte
@@ -35,6 +35,7 @@ The navbar component. We have sliders that update reactively to both font size a
         contentsFontSize,
         currentFont,
         fontChoices,
+        getPositioningCSS,
         language,
         languages,
         modal,
@@ -68,11 +69,7 @@ The navbar component. We have sliders that update reactively to both font size a
 
     const contentsMode = $derived(options?.contentsMode ?? false);
     //The positioningCSS positions the modal 1rem below the navbar and 1rem from the right edge of the screen (on mobile it will be centered)
-    const positioningCSS = $derived(
-        'position:absolute; top:' +
-            (Number(vertOffset.replace('rem', '')) + 1) +
-            'rem; inset-inline-end:1rem;'
-    );
+    const positioningCSS = $derived(getPositioningCSS(vertOffset, 'top'));
     const barColor = $derived($themeColors['SliderBarColor']);
     const progressColor = $derived($themeColors['SliderProgressColor']);
     const _showFontSize = showFontSize();

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -2,22 +2,13 @@
 @component
 Taken from modifying a copy of the AudioBar.svelte file
 Enables users to copy, highlight, bookmark, share, and annotate selected verses.
-TODO:
-- Implement functionality for
- -> Share
- -> Play
- -> Play Repeat
-- Add note dialog
-- Add highlight colors
 -->
 <script lang="ts">
     import { goto } from '$app/navigation';
     import { scriptureConfig } from '$assets/config';
-    import { getBook, logShareContent } from '$lib/data/analytics';
     import { playVerses } from '$lib/data/audio';
     import { addBookmark, findBookmark, removeBookmark } from '$lib/data/bookmarks';
     import { addHighlights, removeHighlights } from '$lib/data/highlights';
-    import { shareText } from '$lib/data/share';
     import {
         audioActive,
         modal,

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -7,7 +7,6 @@ TODO:
  -> Share
  -> Play
  -> Play Repeat
- -> Verse On Image
 - Add note dialog
 - Add highlight colors
 -->
@@ -21,6 +20,8 @@ TODO:
     import { shareText } from '$lib/data/share';
     import {
         audioActive,
+        modal,
+        ModalType,
         refs,
         s,
         selectedVerses,
@@ -137,21 +138,25 @@ TODO:
     }
 
     async function shareSelectedText() {
-        const book = $selectedVerses[0].book;
-        const reference = selectedVerses.getCompositeReference();
-        const text = await selectedVerses.getCompositeText();
-        const bookCol = $selectedVerses[0].collection;
-        const fullBook = getBook({ collection: bookCol, book: book });
-        const bookAbbrev = fullBook?.abbreviation ?? fullBook?.name;
-        const copyShareMessage = scriptureConfig.bookCollections?.find(
-            (x) => x.id === bookCol
-        )?.copyShareMessage;
-        shareText(
-            scriptureConfig.name ?? '',
-            text + '\n' + reference + (copyShareMessage ? '\n' + copyShareMessage : ''),
-            book + '.txt'
-        );
-        logShareContent('Text', bookCol, bookAbbrev ?? '', reference);
+        if ($refs.hasAudio?.timingFile) {
+            modal.open(ModalType.Share);
+        } else {
+            const book = $selectedVerses[0].book;
+            const reference = selectedVerses.getCompositeReference();
+            const text = await selectedVerses.getCompositeText();
+            const bookCol = $selectedVerses[0].collection;
+            const fullBook = getBook({ collection: bookCol, book: book });
+            const bookAbbrev = fullBook?.abbreviation ?? fullBook?.name;
+            const copyShareMessage = scriptureConfig.bookCollections?.find(
+                (x) => x.id === bookCol
+            )?.copyShareMessage;
+            shareText(
+                scriptureConfig.name ?? '',
+                text + '\n' + reference + (copyShareMessage ? '\n' + copyShareMessage : ''),
+                book + '.txt'
+            );
+            logShareContent('Text', bookCol, bookAbbrev ?? '', reference);
+        }
     }
 
     const backgroundColor = $derived($s['ui.bar.text-select']['background-color']);

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -141,21 +141,7 @@ TODO:
         if ($refs.hasAudio?.timingFile) {
             modal.open(ModalType.Share);
         } else {
-            const book = $selectedVerses[0].book;
-            const reference = selectedVerses.getCompositeReference();
-            const text = await selectedVerses.getCompositeText();
-            const bookCol = $selectedVerses[0].collection;
-            const fullBook = getBook({ collection: bookCol, book: book });
-            const bookAbbrev = fullBook?.abbreviation ?? fullBook?.name;
-            const copyShareMessage = scriptureConfig.bookCollections?.find(
-                (x) => x.id === bookCol
-            )?.copyShareMessage;
-            shareText(
-                scriptureConfig.name ?? '',
-                text + '\n' + reference + (copyShareMessage ? '\n' + copyShareMessage : ''),
-                book + '.txt'
-            );
-            logShareContent('Text', bookCol, bookAbbrev ?? '', reference);
+            modal.open(ModalType.Share, true); //Just share the text rather than giving the user a choice about how to share it
         }
     }
 

--- a/src/lib/components/VerseOnImage.svelte
+++ b/src/lib/components/VerseOnImage.svelte
@@ -647,7 +647,7 @@ The verse on image component.
             downloadProgress = 0;
             await audioCtx?.close();
         }
-    } //Most of this is AI-generated, so serious testing is needed. I've done a lot of testing, but it would be good to make sure there aren't subtle problems with this code.
+    }
 
     // EditorTabs centering feature:
 

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -718,50 +718,42 @@ export async function getAudioSourceInfo(
     }
 
     const audioSource = scriptureConfig.audio?.sources[audio.src];
-    let audioPath = null;
+    let audioPath: string | null = null;
 
-    if (audioSource?.type === 'fcbh') {
-        if (audioSource.accessMethods?.includes('download')) {
+    if (audioSource?.accessMethods?.includes('download')) {
+        const clipKey = `${item.collection}-${item.book}-${item.chapter}`;
+        audioPath = audioClipUrls.get(clipKey);
+        if (!audioPath) {
             const foundAudioClip = await findAudioClip({
                 collection: item.collection || '',
                 book: item.book || '',
                 chapter: item.chapter || ''
             }); //If the audio has been downloaded already, use that.
             if (foundAudioClip) {
-                const clipKey = `${item.collection}-${item.book}-${item.chapter}`;
                 if (!audioClipUrls.get(clipKey)) {
                     audioClipUrls.put(clipKey, URL.createObjectURL(foundAudioClip.blob));
                 }
                 audioPath = audioClipUrls.get(clipKey)!;
             }
         }
-        if (!audioPath) {
+    }
+
+    if (!audioPath) {
+        if (audioSource?.type === 'fcbh') {
             const result = await getBibleBrainUrl(audioSource, item, getDamId);
             if (result.error) {
                 throw new Error(`Failed to connect to BibleBrain: ${result.error}`);
             }
 
-            audioPath = result.path;
-        }
-    } else if (audioSource?.type === 'assets') {
-        const audioKey = `./${audio.filename}`;
-        if (!audioSources[audioKey]) {
-            throw new Error(`Audio file not found in generated assets: ${audio.filename}`);
-        }
-        audioPath = audioSources[audioKey];
-    } else if (audioSource?.type === 'download') {
-        audioPath = pathJoin([audioSource.address, audio.filename]);
-        const foundAudioClip = await findAudioClip({
-            collection: item.collection || '',
-            book: item.book || '',
-            chapter: item.chapter || ''
-        }); //If the audio has been downloaded already, use that.
-        if (foundAudioClip) {
-            const clipKey = `${item.collection}-${item.book}-${item.chapter}`;
-            if (!audioClipUrls.get(clipKey)) {
-                audioClipUrls.put(clipKey, URL.createObjectURL(foundAudioClip.blob));
+            audioPath = result.path || null;
+        } else if (audioSource?.type === 'assets') {
+            const audioKey = `./${audio.filename}`;
+            if (!audioSources[audioKey]) {
+                throw new Error(`Audio file not found in generated assets: ${audio.filename}`);
             }
-            audioPath = audioClipUrls.get(clipKey)!;
+            audioPath = audioSources[audioKey];
+        } else if (audioSource?.type === 'download') {
+            audioPath = pathJoin([audioSource.address, audio.filename]);
         }
     }
     //parse timing file
@@ -800,10 +792,12 @@ export async function getAudioSourceInfo(
             }
         }
     }
-    return {
-        source: audioPath,
-        timing: timing.length > 0 ? timing : null
-    };
+    return audioPath
+        ? {
+              source: audioPath,
+              timing: timing.length > 0 ? timing : null
+          }
+        : undefined;
 }
 
 /**

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -889,7 +889,7 @@ export async function checkAudioAvailability() {
                 audioPath = pathJoin([audioSource.address, audio.filename]);
             } else if (audioSource?.type === 'fcbh') {
                 if (!get(appOnline)) {
-                    modal.open(ModalType.NoConnection);
+                    modal.open(ModalType.AudioAlert, 'Audio_Download_Connect');
                 } else {
                     const result = await getBibleBrainUrl(
                         audioSource,
@@ -910,7 +910,7 @@ export async function checkAudioAvailability() {
             }
             if (audioSource?.accessMethods?.includes('download')) {
                 if (!get(appOnline)) {
-                    modal.open(ModalType.NoConnection);
+                    modal.open(ModalType.AudioAlert, 'Audio_Download_Connect');
                 } else {
                     if (get(userSettings)['audio-auto-download'] === 'auto') {
                         modal.open(ModalType.DownloadAudio, { audioPath, show: false }); //Just download it without showing the modal

--- a/src/lib/data/share.ts
+++ b/src/lib/data/share.ts
@@ -28,15 +28,7 @@ export async function shareText(
     }
 
     // if we're here, we failed to share, so we'll try to use the download link
-    const shareFile = createShareFile(title + '\n\n' + text, filename);
-    const url = URL.createObjectURL(shareFile);
-
-    const anchor = document.createElement('a');
-    anchor.href = url;
-    anchor.download = filename;
-    anchor.click();
-
-    URL.revokeObjectURL(url);
+    downloadObject(createShareFile(title + '\n\n' + text, filename));
 }
 
 export async function shareImage(title: string, text: string, filename: string, image: Blob) {
@@ -53,11 +45,41 @@ export async function shareImage(title: string, text: string, filename: string, 
     }
 
     // if we're here, we failed to share, so we'll try to use the download link
+    downloadObject(file);
+}
+
+export async function shareAudio(
+    title: string,
+    text: string,
+    filename: string,
+    audio: Blob,
+    type: string
+) {
+    const file = new File([audio], filename, { type });
+    try {
+        if (navigator.share && navigator.canShare && navigator.canShare({ files: [file] })) {
+            const shareData: ShareData = { title, text, files: [file] };
+
+            await navigator.share(shareData);
+            return;
+        }
+    } catch (error) {
+        if ((error as { name?: string })?.name === 'AbortError') {
+            return; // user intentionally dismissed native share UI
+        }
+        console.error('Error sharing: ', error);
+    }
+
+    // if we're here, we failed to share, so we'll try to use the download link
+    downloadObject(file);
+}
+
+function downloadObject(file: File) {
     const url = URL.createObjectURL(file);
 
     const anchor = document.createElement('a');
     anchor.href = url;
-    anchor.download = filename;
+    anchor.download = file.name;
     anchor.click();
 
     URL.revokeObjectURL(url);

--- a/src/lib/data/stores/view.ts
+++ b/src/lib/data/stores/view.ts
@@ -13,6 +13,15 @@ export const isFirstLaunch = derived(
     [firstLaunchTime, launchTime],
     ([$firstLaunchTime, $launchTime]) => $firstLaunchTime === $launchTime
 );
+export function getPositioningCSS(vertOffset: string, position: string) {
+    return (
+        'position:absolute; ' +
+        position +
+        ':' +
+        (Number(vertOffset.replace('rem', '')) + 1) +
+        'rem; inset-inline-end:1rem;'
+    );
+}
 
 /**the current view/layout mode*/
 export const Layout = {

--- a/src/lib/data/stores/view.ts
+++ b/src/lib/data/stores/view.ts
@@ -44,7 +44,7 @@ export const ModalType = {
     Download: 'download',
     Collection: 'collection',
     DownloadAudio: 'download-audio',
-    NoConnection: 'no-connection',
+    AudioAlert: 'audio-alert',
     Share: 'share'
 } as const;
 export type ModalType = (typeof ModalType)[keyof typeof ModalType];

--- a/src/lib/data/stores/view.ts
+++ b/src/lib/data/stores/view.ts
@@ -35,7 +35,8 @@ export const ModalType = {
     Download: 'download',
     Collection: 'collection',
     DownloadAudio: 'download-audio',
-    NoConnection: 'no-connection'
+    NoConnection: 'no-connection',
+    Share: 'share'
 } as const;
 export type ModalType = (typeof ModalType)[keyof typeof ModalType];
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
     import NoConnectionModal from '$lib/components/NoConnectionModal.svelte';
     import NoteDialog from '$lib/components/NoteDialog.svelte';
     import PlanStopDialog from '$lib/components/PlanStopDialog.svelte';
+    import ShareSelector from '$lib/components/ShareSelector.svelte';
     import Sidebar from '$lib/components/Sidebar.svelte';
     import TextAppearanceSelector from '$lib/components/TextAppearanceSelector.svelte';
     import catalog from '$lib/data/catalogData';
@@ -132,6 +133,7 @@
 
     let textAppearanceSelector: TextAppearanceSelector | undefined = $state();
     let fontSelector: FontSelector | undefined = $state();
+    let shareSelector: ShareSelector | undefined = $state();
     let noteDialog: NoteDialog | undefined = $state();
     let collectionModal: CollectionModal | undefined = $state();
     let planStopDialog: PlanStopDialog | undefined = $state(undefined);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -188,11 +188,7 @@
                     vertOffset={NAVBAR_HEIGHT}
                 />
                 <CollectionModal bind:this={collectionModal} />
-                <PlanStopDialog
-                    bind:this={planStopDialog}
-                    bind:planId={planStopId}
-                    vertOffset={NAVBAR_HEIGHT}
-                />
+                <PlanStopDialog bind:this={planStopDialog} bind:planId={planStopId} />
                 <AudioDownloadModal bind:this={audioDownloadModal} />
                 <NoConnectionModal bind:this={noConnectionModal} />
                 <AudioPlaybackSpeed bind:this={audioPlaybackSpeed} />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,11 +5,11 @@
     import '$lib/styles/app.css';
     import { dev } from '$app/environment';
     import config from '$assets/config';
+    import AudioAlertModal from '$lib/components/AudioAlertModal.svelte';
     import AudioDownloadModal from '$lib/components/AudioDownloadModal.svelte';
     import AudioPlaybackSpeed from '$lib/components/AudioPlaybackSpeed.svelte';
     import CollectionModal from '$lib/components/CollectionModal.svelte';
     import FontSelector from '$lib/components/FontSelector.svelte';
-    import NoConnectionModal from '$lib/components/NoConnectionModal.svelte';
     import NoteDialog from '$lib/components/NoteDialog.svelte';
     import PlanStopDialog from '$lib/components/PlanStopDialog.svelte';
     import ShareSelector from '$lib/components/ShareSelector.svelte';
@@ -110,8 +110,8 @@
                     case ModalType.PlaybackSpeed:
                         audioPlaybackSpeed?.showModal();
                         break;
-                    case ModalType.NoConnection:
-                        noConnectionModal?.showModal();
+                    case ModalType.AudioAlert:
+                        audioAlertModal?.showModal(data as string);
                         break;
                     case ModalType.Collection:
                         collectionModal?.showModal(
@@ -141,7 +141,7 @@
     let collectionModal: CollectionModal | undefined = $state();
     let planStopDialog: PlanStopDialog | undefined = $state(undefined);
     let audioDownloadModal: AudioDownloadModal | undefined = $state();
-    let noConnectionModal: NoConnectionModal | undefined = $state();
+    let audioAlertModal: AudioAlertModal | undefined = $state();
     let planStopId: string = $state('');
     let audioPlaybackSpeed: AudioPlaybackSpeed | undefined = $state();
 </script>
@@ -190,7 +190,7 @@
                 <CollectionModal bind:this={collectionModal} />
                 <PlanStopDialog bind:this={planStopDialog} bind:planId={planStopId} />
                 <AudioDownloadModal bind:this={audioDownloadModal} />
-                <NoConnectionModal bind:this={noConnectionModal} />
+                <AudioAlertModal bind:this={audioAlertModal} />
                 <AudioPlaybackSpeed bind:this={audioPlaybackSpeed} />
                 <FontSelector bind:this={fontSelector} />
                 <ShareSelector bind:this={shareSelector} />

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -90,6 +90,9 @@
                     case ModalType.Font:
                         fontSelector?.showModal();
                         break;
+                    case ModalType.Share:
+                        shareSelector?.showModal(data as boolean);
+                        break;
                     case ModalType.StopPlan:
                         planStopId = data as string;
                         planStopDialog?.showModal();
@@ -194,6 +197,7 @@
                 <NoConnectionModal bind:this={noConnectionModal} />
                 <AudioPlaybackSpeed bind:this={audioPlaybackSpeed} />
                 <FontSelector bind:this={fontSelector} />
+                <ShareSelector bind:this={shareSelector} />
             </div>
             {@render children()}
         </div>


### PR DESCRIPTION
Resolves #377. If there is audio timing data, this causes the share button when text is selected to open a modal that gives the user a choice between sharing text and sharing audio.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a Share dialog to share selected verses as text.
  * Added the ability to generate and share a trimmed chapter audio extract for the selected verses.

* **Improvements**
  * Integrated sharing into the app’s modal workflow, using native sharing when available and automatically falling back to download.
  * Improved audio sharing output selection and reliability, producing timing-accurate trimmed audio.

* **Bug Fixes**
  * Fixed the sharing flow to open the correct share modal and offer “text-only” sharing when verse timing data isn’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->