### PR TITLE
Update search location for SAB binary on win32

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -28,11 +28,11 @@ const getExecutionCommand = (program: string): string => {
             return `${javaPath} -jar "${appPath}/Resources/Java/bin/${jarName}"`;
         }
         case 'win32': {
-            const programFilesX86 = process.env['ProgramFiles(x86)'];
-            if (!programFilesX86) {
-                throw new Error('Environment variable "ProgramFiles(x86)" is not set on Windows');
+            const programFiles = process.env['ProgramFiles'];
+            if (!programFiles) {
+                throw new Error('Environment variable "ProgramFiles" is not set on Windows');
             }
-            const appPath = path.join(programFilesX86, 'SIL', appName);
+            const appPath = path.join(programFiles, 'SIL', appName);
             javaPath = path.join(appPath, 'runtime', 'bin', 'java');
             const jarPath = path.join(appPath, 'bin', jarName);
             if (javaPath.endsWith('java')) {


### PR DESCRIPTION
SAB is now installed in `Program Files` by default on Windows, not `Program Files (x86)`. Closes #993.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows application path resolution and error handling for missing system environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->