### PR TITLE
#995 Fix CSS custom attribute declaration for border image source

### DIFF
--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -564,7 +564,7 @@
             {/if}
         {/if}
         <div
-            style="--borderImageSource=url({borders['./border.png']});"
+            style="--borderImageSource: url({borders['./border.png']});"
             class:borderimg={showBorder}
             class="overflow-y-auto grow"
             bind:this={scrollingDiv}


### PR DESCRIPTION
Fixes #995. When the border image source was parameterized, the CSS variable wasn't declared [properly](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/--*), so no border images were being rendered.

Before/after/Android:

<img width="255" height="567" alt="image" src="https://github.com/user-attachments/assets/a5eee68b-983c-49ae-be6b-3a0697d20ba3" />

<img width="255" height="568" alt="image" src="https://github.com/user-attachments/assets/46125840-6fea-4610-8d06-7ca508c11215" />

<img width="252" height="561" alt="image" src="https://github.com/user-attachments/assets/9d101235-e94d-419d-9434-04ae41fd665a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed border image styling to display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->