### PR TITLE
Implement navigation drawer text size setting

### DIFF
--- a/config/index.d.ts
+++ b/config/index.d.ts
@@ -129,6 +129,7 @@ export type WritingSystemConfig = {
         [key: string]: string;
     };
     fontFamily: string;
+    fontRelativeSize?: string;
     textDirection: string;
 };
 

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -940,6 +940,7 @@ export function parseInterfaceLanguages(document: Document, data: AppConfig, ver
 export function parseWritingSystem(element: Element, verbose: number): WritingSystemConfig {
     const type = element.attributes.getNamedItem('type')!.value;
     const fontFamily = element.getElementsByTagName('font-family')[0].innerHTML;
+    const fontRelativeSize = parseTrait(element, 'font-relative-size');
     const textDirection = parseTrait(element, 'text-direction');
     const displaynamesTag = element.getElementsByTagName('display-names')[0];
     const displayNames: Record<string, string> = {};
@@ -950,6 +951,7 @@ export function parseWritingSystem(element: Element, verbose: number): WritingSy
         type,
         fontFamily,
         textDirection,
+        fontRelativeSize,
         displayNames
     };
 
@@ -1607,8 +1609,6 @@ function filterFeaturesNotReady(data: ScriptureConfig | DictionaryConfig) {
             });
         }
     }
-    // Verse on image is not done
-    //data.mainFeatures['text-on-image'] = false;
 
     // Share only implements links to apps on stores
     data.mainFeatures['share-download-app-link'] = false;

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-    import { SettingsCategory, t, userSettings } from '$lib/data/stores';
+    import config from '$assets/config';
+    import { language, SettingsCategory, t, userSettings } from '$lib/data/stores';
 
     interface Props {
         settings: App.UserPreferenceSetting[];
@@ -14,11 +15,15 @@
                 .filter(([_, v]) => v.length)
         )
     );
+    const fontRelativeSize = $derived(
+        config.interfaceLanguages?.writingSystems[$language]?.fontRelativeSize
+    );
+    const fontSize = $derived(fontRelativeSize ? fontRelativeSize : '100');
 </script>
 
 <!-- loops through the different settings types -->
 {#each Object.keys(categories) as category}
-    <div class="settings-category">
+    <div class="settings-category" style:font-size="{fontSize}%">
         {$t[category]}
     </div>
     {#each categories[category as SettingsCategory] as setting, i}
@@ -29,7 +34,9 @@
             >
                 <label class="dy-label py-0 cursor-pointer">
                     <div class="settings-title">
-                        {$t[setting.title] || setting.title}
+                        <div style:font-size="{fontSize}%">
+                            {$t[setting.title] || setting.title}
+                        </div>
                     </div>
                     <input
                         type="checkbox"
@@ -39,7 +46,9 @@
                 </label>
                 {#if setting.summary}
                     <div class="settings-summary py-0 ps-1">
-                        {$t[setting.summary]}
+                        <div style:font-size="{fontSize}%">
+                            {$t[setting.summary]}
+                        </div>
                     </div>
                 {/if}
             </div>
@@ -50,10 +59,13 @@
                 class:settings-separator={i > 0}
             >
                 <div class="settings-title py-0">
-                    {$t[setting.title] || setting.title}
+                    <div style:font-size="{fontSize}%">
+                        {$t[setting.title] || setting.title}
+                    </div>
                 </div>
                 <select
                     class="dy-select dy-select-ghost dy-select-sm px-0"
+                    style:font-size="{fontSize}%"
                     bind:value={$userSettings[setting.key]}
                 >
                     {#each setting.entries ?? [] as entry, i}
@@ -62,7 +74,9 @@
                 </select>
                 {#if setting.summary}
                     <div class="settings-summary py-0">
-                        {$t[setting.summary]}
+                        <div style:font-size="{fontSize}%">
+                            {$t[setting.summary]}
+                        </div>
                     </div>
                 {/if}
             </div>
@@ -72,12 +86,18 @@
                 class:settings-separator={i > 0}
             >
                 <div class="settings-title py-0">
-                    {$t[setting.title]}
+                    <div style:font-size="{fontSize}%">
+                        {$t[setting.title]}
+                    </div>
                 </div>
                 <!-- TODO: Time Control -->
-                <div class="settings-summary py-0">{setting.defaultValue}</div>
+                <div class="settings-summary py-0">
+                    <div style:font-size="{fontSize}%">{setting.defaultValue}</div>
+                </div>
                 {#if setting.summary}
-                    <div class="settings-summary py-0">{$t[setting.summary]}</div>
+                    <div class="settings-summary py-0">
+                        <div style:font-size="{fontSize}%">{$t[setting.summary]}</div>
+                    </div>
                 {/if}
             </div>
         {/if}

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -86,6 +86,10 @@ The sidebar/drawer.
     const showAccount = !!(
         config.firebase?.features['firebase-database'] && config.mainFeatures['user-accounts']
     );
+    const fontRelativeSize = $derived(
+        config.interfaceLanguages?.writingSystems[$language]?.fontRelativeSize
+    );
+    const fontSize = $derived(fontRelativeSize ? fontRelativeSize : '100');
 
     function imageSrcSet(images: MenuItemConfig['images']) {
         const baseSize = Number(images?.[0]?.width);
@@ -135,6 +139,7 @@ The sidebar/drawer.
             class="dy-menu p-1 w-3/4 sm:w-80 text-base-content min-h-full"
             style:background-color={drawerBackgroundColor}
             style:direction={$direction}
+            style:font-size="{fontSize}%"
         >
             <!-- Sidebar content here -->
             <a class="fill" href={resolve('/')}>


### PR DESCRIPTION
Resolves #1009. The navigation drawer and settings page now scale their text size based on the interface language's text size setting, matching the native app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added language-specific relative font sizing that dynamically adjusts typography in the settings menu and sidebar based on the configured writing system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->