### PR TITLE
Fix resolve() with BUILD_BASE_PATH and hash routes

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,7 +22,7 @@ export default ts.config(
         }
     },
     {
-        files: ['**/*.ts'],
+        files: ['src/**/*.ts'],
         languageOptions: {
             parserOptions: {
                 projectService: true

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,10 @@ export default ts.config(
         }
     },
     {
+        // Enable project-wide type information for TypeScript files.
+        // This allows rules that require type information to work correctly.
+        // Specifically, non-svelte files (like src/lib/navigate/index.ts) needed
+        // for svelte/no-navigation-without-resolve
         files: ['src/**/*.ts'],
         languageOptions: {
             parserOptions: {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,14 @@ export default ts.config(
         }
     },
     {
+        files: ['**/*.ts'],
+        languageOptions: {
+            parserOptions: {
+                projectService: true
+            }
+        }
+    },
+    {
         files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],
         // See more details at: https://typescript-eslint.io/packages/parser/
         languageOptions: {

--- a/src/lib/components/BookSelector.svelte
+++ b/src/lib/components/BookSelector.svelte
@@ -3,7 +3,6 @@
 The navbar component.
 -->
 <script lang="ts">
-    import { resolve } from '$app/paths';
     import config, { scriptureConfig } from '$assets/config';
     import type { BookConfig } from '$config';
     import {
@@ -18,6 +17,7 @@ The navbar component.
     import { DropdownIcon } from '$lib/icons';
     import { navigateToText, navigateToUrl } from '$lib/navigate';
     import * as numerals from '$lib/scripts/numeralSystem';
+    import { resolve } from '$lib/utils/paths';
     import Dropdown from './Dropdown.svelte';
     import SelectGrid from './SelectGrid.svelte';
     import SelectList from './SelectList.svelte';

--- a/src/lib/components/BottomNavigationBar.svelte
+++ b/src/lib/components/BottomNavigationBar.svelte
@@ -3,7 +3,7 @@
 -->
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import config, { scriptureConfig } from '$assets/config';
     import contents from '$assets/contents';
     import { language, languageDefault, refs, s, theme } from '$lib/data/stores';

--- a/src/lib/components/BottomNavigationBar.svelte
+++ b/src/lib/components/BottomNavigationBar.svelte
@@ -3,10 +3,10 @@
 -->
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import config, { scriptureConfig } from '$assets/config';
     import contents from '$assets/contents';
     import { language, languageDefault, refs, s, theme } from '$lib/data/stores';
+    import { resolve } from '$lib/utils/paths';
 
     const menuIcons = import.meta.glob('./*', {
         import: 'default',

--- a/src/lib/components/HistoryCard.svelte
+++ b/src/lib/components/HistoryCard.svelte
@@ -6,7 +6,7 @@ TODO:
 -->
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import { scriptureConfig } from '$assets/config';
     import type { HistoryItem } from '$lib/data/history';
     import { refs } from '$lib/data/stores';

--- a/src/lib/components/HistoryCard.svelte
+++ b/src/lib/components/HistoryCard.svelte
@@ -6,11 +6,11 @@ TODO:
 -->
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import { scriptureConfig } from '$assets/config';
     import type { HistoryItem } from '$lib/data/history';
     import { refs } from '$lib/data/stores';
     import { formatDateAndTime } from '$lib/scripts/dateUtils';
+    import { resolve } from '$lib/utils/paths';
 
     interface Props {
         history: HistoryItem;

--- a/src/lib/components/IconCard.svelte
+++ b/src/lib/components/IconCard.svelte
@@ -5,9 +5,9 @@ TODO:
 - handle the book and collection specific styles
 -->
 <script lang="ts">
-    import { resolve } from '$lib/utils/paths';
     import { scriptureConfig } from '$assets/config';
     import { direction, refs } from '$lib/data/stores';
+    import { resolve } from '$lib/utils/paths';
     import CardMenu from './CardMenu.svelte';
 
     let {

--- a/src/lib/components/IconCard.svelte
+++ b/src/lib/components/IconCard.svelte
@@ -5,7 +5,7 @@ TODO:
 - handle the book and collection specific styles
 -->
 <script lang="ts">
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import { scriptureConfig } from '$assets/config';
     import { direction, refs } from '$lib/data/stores';
     import CardMenu from './CardMenu.svelte';
@@ -24,7 +24,7 @@ TODO:
         alt = '',
         icon,
         menuaction,
-        href = resolve(`/#/text`)
+        href = resolve(`/text`)
     } = $props();
 
     const bc = scriptureConfig.bookCollections?.find((x) => x.id === collection);

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -4,7 +4,6 @@ The navbar component.
 -->
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import { page } from '$app/state';
     import {
         actionBarColor,
@@ -17,6 +16,7 @@ The navbar component.
         showDesktopSidebar
     } from '$lib/data/stores';
     import { ArrowBackIcon, ArrowForwardIcon, HamburgerIcon } from '$lib/icons';
+    import { resolve } from '$lib/utils/paths';
     import type { Snippet } from 'svelte';
 
     interface Props {

--- a/src/lib/components/Navbar.svelte
+++ b/src/lib/components/Navbar.svelte
@@ -4,7 +4,7 @@ The navbar component.
 -->
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import { page } from '$app/state';
     import {
         actionBarColor,

--- a/src/lib/components/NoteDialog.svelte
+++ b/src/lib/components/NoteDialog.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import { bodyFontSize, currentFont } from '$lib/data/stores';
     import { EditIcon } from '$lib/icons';
+    import { resolve } from '$lib/utils/paths';
     import Modal from './Modal.svelte';
 
     let id = $state('note');

--- a/src/lib/components/NoteDialog.svelte
+++ b/src/lib/components/NoteDialog.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import { bodyFontSize, currentFont } from '$lib/data/stores';
     import { EditIcon } from '$lib/icons';
     import Modal from './Modal.svelte';

--- a/src/lib/components/PlanStopDialog.svelte
+++ b/src/lib/components/PlanStopDialog.svelte
@@ -5,7 +5,7 @@ Plan Stop Modal Dialog component.
 
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import { deleteAllProgressItemsForPlan } from '$lib/data/planProgressItems';
     import { addPlanState } from '$lib/data/planStates';
     import { t } from '$lib/data/stores';

--- a/src/lib/components/PlanStopDialog.svelte
+++ b/src/lib/components/PlanStopDialog.svelte
@@ -5,10 +5,10 @@ Plan Stop Modal Dialog component.
 
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import { deleteAllProgressItemsForPlan } from '$lib/data/planProgressItems';
     import { addPlanState } from '$lib/data/planStates';
     import { t } from '$lib/data/stores';
+    import { resolve } from '$lib/utils/paths';
     import Modal from './Modal.svelte';
 
     let { planId = $bindable(undefined), vertOffset = '1rem' } = $props();

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -36,7 +36,7 @@ LOGGING:
 
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     /* eslint-disable svelte/no-dom-manipulating */
 
     import { scriptureConfig } from '$assets/config';

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -36,7 +36,6 @@ LOGGING:
 
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     /* eslint-disable svelte/no-dom-manipulating */
 
     import { scriptureConfig } from '$assets/config';
@@ -81,6 +80,7 @@ LOGGING:
         onClickText,
         updateSelections
     } from '$lib/scripts/verseSelectUtil';
+    import { resolve } from '$lib/utils/paths';
     import { addVideoLinks, createVideoBlock, createVideoBlockFromUrl } from '$lib/video';
     import { SofriaRenderFromProskomma } from 'proskomma-json-tools';
     import { onDestroy, onMount } from 'svelte';

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -4,7 +4,7 @@ The sidebar/drawer.
 -->
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import config, { scriptureConfig } from '$assets/config';
     import contents from '$assets/contents';
     import nav_drawer_image from '$assets/images/nav_drawer.png';

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -4,7 +4,6 @@ The sidebar/drawer.
 -->
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import config, { scriptureConfig } from '$assets/config';
     import contents from '$assets/contents';
     import nav_drawer_image from '$assets/images/nav_drawer.png';
@@ -42,6 +41,7 @@ The sidebar/drawer.
         ShareIcon,
         TextAppearanceIcon
     } from '$lib/icons';
+    import { resolve } from '$lib/utils/paths';
     import { showTextAppearance } from './TextAppearanceSelector.svelte';
 
     const menuIcons = import.meta.glob('./*', {

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -13,7 +13,6 @@ TODO:
 -->
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import { scriptureConfig } from '$assets/config';
     import { getBook, logShareContent } from '$lib/data/analytics';
     import { playVerses } from '$lib/data/audio';
@@ -31,6 +30,7 @@ TODO:
     } from '$lib/data/stores';
     import { AudioIcon, CopyContentIcon, HighlightIcon, NoteIcon, ShareIcon } from '$lib/icons';
     import { ImageIcon } from '$lib/icons/image';
+    import { resolve } from '$lib/utils/paths';
     import BookmarkButton from './BookmarkButton.svelte';
 
     const isAudioPlayable = scriptureConfig?.mainFeatures['text-select-play-audio'];

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -13,7 +13,7 @@ TODO:
 -->
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import { scriptureConfig } from '$assets/config';
     import { getBook, logShareContent } from '$lib/data/analytics';
     import { playVerses } from '$lib/data/audio';

--- a/src/lib/components/VerseOnImage.svelte
+++ b/src/lib/components/VerseOnImage.svelte
@@ -4,7 +4,6 @@ The verse on image component.
 -->
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import { scriptureConfig } from '$assets/config';
     import FontList from '$lib/components/FontList.svelte';
     import { getAudioSourceInfo } from '$lib/data/audio';
@@ -24,6 +23,7 @@ The verse on image component.
     import { TextAppearanceIcon } from '$lib/icons';
     import { ImageIcon } from '$lib/icons/image';
     import ImagesIcon from '$lib/icons/image/ImagesIcon.svelte';
+    import { resolve } from '$lib/utils/paths';
     import { toPng } from 'html-to-image';
     import {
         AudioBufferSource,

--- a/src/lib/components/VerseOnImage.svelte
+++ b/src/lib/components/VerseOnImage.svelte
@@ -4,7 +4,7 @@ The verse on image component.
 -->
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import { scriptureConfig } from '$assets/config';
     import FontList from '$lib/components/FontList.svelte';
     import { getAudioSourceInfo } from '$lib/data/audio';

--- a/src/lib/navigate/index.ts
+++ b/src/lib/navigate/index.ts
@@ -1,9 +1,9 @@
 import { goto } from '$app/navigation';
-import { resolve } from '$lib/utils/paths';
 import { logScreenView } from '$lib/data/analytics';
 import { playStop } from '$lib/data/audio';
 import { addHistory, type HistoryItem } from '$lib/data/history';
 import { refs } from '$lib/data/stores';
+import { resolve } from '$lib/utils/paths';
 import { get } from 'svelte/store';
 
 function logHistoryItemAdded(itemAdded: HistoryItem) {

--- a/src/lib/navigate/index.ts
+++ b/src/lib/navigate/index.ts
@@ -1,5 +1,5 @@
 import { goto } from '$app/navigation';
-import { resolve } from '$app/paths';
+import { resolve } from '$lib/utils/paths';
 import { logScreenView } from '$lib/data/analytics';
 import { playStop } from '$lib/data/audio';
 import { addHistory, type HistoryItem } from '$lib/data/history';

--- a/src/lib/utils/paths.ts
+++ b/src/lib/utils/paths.ts
@@ -1,0 +1,21 @@
+import { base } from '$app/paths';
+import type { ResolvedPathname } from '$app/types';
+
+/**
+ * Replacement for SvelteKit's `resolve()` from `$app/paths` when using hash routing with `BUILD_BASE_PATH`.
+ *
+ * Bug in SvelteKit ≤ 2.59.x: `resolve('/path')` with `base='/foobar'` generates `/foobar#/path`
+ * (URL pathname = `/foobar`), but `location.pathname` is always `/foobar/` (with trailing slash
+ * after the server redirect `/foobar` → `/foobar/`). `is_external_url()` sees `/foobar` ≠ `/foobar/`
+ * and treats the navigation as external, calling `native_navigation()` → full page reload → all
+ * in-memory Svelte store state is lost.
+ *
+ * Fix: generate `BASE/#/path` so `url.pathname = BASE/` matches `location.pathname = BASE/`.
+ * Works when base is empty too: `'' + '/#' + '/path'` = `/#/path` → pathname `/` matches `/`.
+ *
+ * Returning `ResolvedPathname` satisfies `eslint-plugin-svelte`'s `no-navigation-without-resolve`
+ * rule via its TypeScript type-check path, since our function serves the same role as the original.
+ */
+export function resolve(path: string): ResolvedPathname {
+    return (base + '/#' + path) as ResolvedPathname;
+}

--- a/src/lib/utils/paths.ts
+++ b/src/lib/utils/paths.ts
@@ -1,21 +1,22 @@
-import { base } from '$app/paths';
+import { resolve as svelteKitResolve } from '$app/paths';
 import type { ResolvedPathname } from '$app/types';
 
 /**
- * Replacement for SvelteKit's `resolve()` from `$app/paths` when using hash routing with `BUILD_BASE_PATH`.
+ * Thin wrapper around SvelteKit's `resolve()` from `$app/paths` that fixes a bug with hash
+ * routing + `BUILD_BASE_PATH` (https://github.com/sveltejs/kit/issues/14894).
  *
- * Bug in SvelteKit ≤ 2.59.x: `resolve('/path')` with `base='/foobar'` generates `/foobar#/path`
- * (URL pathname = `/foobar`), but `location.pathname` is always `/foobar/` (with trailing slash
- * after the server redirect `/foobar` → `/foobar/`). `is_external_url()` sees `/foobar` ≠ `/foobar/`
- * and treats the navigation as external, calling `native_navigation()` → full page reload → all
- * in-memory Svelte store state is lost.
+ * Bug: `resolve('/path')` with `base='/foobar'` calls `resolve_route` internally and returns
+ * `BASE#/path` (url.pathname = `BASE`, no trailing slash). But `location.pathname` is always
+ * `BASE/` (with trailing slash, after the server's `/foobar` → `/foobar/` redirect).
+ * `is_external_url()` sees `BASE` ≠ `BASE/` and calls `native_navigation()` → full page reload
+ * → all in-memory Svelte stores are lost.
  *
- * Fix: generate `BASE/#/path` so `url.pathname = BASE/` matches `location.pathname = BASE/`.
- * Works when base is empty too: `'' + '/#' + '/path'` = `/#/path` → pathname `/` matches `/`.
+ * Fix: insert `/` before the `#` so url.pathname becomes `BASE/`, matching `location.pathname`.
+ * Works when base is empty: `#/path` → `/#/path` → url.pathname `/` matches location.pathname `/`.
  *
  * Returning `ResolvedPathname` satisfies `eslint-plugin-svelte`'s `no-navigation-without-resolve`
- * rule via its TypeScript type-check path, since our function serves the same role as the original.
+ * rule via its TypeScript type-check path, since this function serves the same role as the original.
  */
 export function resolve(path: string): ResolvedPathname {
-    return (base + '/#' + path) as ResolvedPathname;
+    return (svelteKitResolve(path as any) as string).replace(/#/, '/#') as ResolvedPathname;
 }

--- a/src/lib/utils/paths.ts
+++ b/src/lib/utils/paths.ts
@@ -17,6 +17,9 @@ import type { ResolvedPathname } from '$app/types';
  * Returning `ResolvedPathname` satisfies `eslint-plugin-svelte`'s `no-navigation-without-resolve`
  * rule via its TypeScript type-check path, since this function serves the same role as the original.
  */
-export function resolve(path: string): ResolvedPathname {
+// Rejects paths that already include a hash prefix — resolve() adds it internally.
+type HashFreePath<T extends string> = T extends `#${string}` | `/#${string}` ? never : T;
+
+export function resolve<T extends string>(path: HashFreePath<T>): ResolvedPathname {
     return (svelteKitResolve(path as any) as string).replace(/#/, '/#') as ResolvedPathname;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import config from '$assets/config';
     import contents from '$assets/contents';
     import { audioActive, isDAB, isFirstLaunch } from '$lib/data/stores';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import config from '$assets/config';
     import contents from '$assets/contents';
     import { audioActive, isDAB, isFirstLaunch } from '$lib/data/stores';
     import { navigateToTextReference } from '$lib/navigate';
+    import { resolve } from '$lib/utils/paths';
     import { onMount } from 'svelte';
     import type { PageData } from './$types';
 

--- a/src/routes/bookmarks/+page.svelte
+++ b/src/routes/bookmarks/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import IconCard from '$lib/components/IconCard.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
     import SortMenu from '$lib/components/SortMenu.svelte';
@@ -12,6 +11,7 @@
     import ShareIcon from '$lib/icons/ShareIcon.svelte';
     import { formatDate } from '$lib/scripts/dateUtils';
     import type { MenuActionEvent } from '$lib/types';
+    import { resolve } from '$lib/utils/paths';
     import type { PageData } from './$types';
 
     interface Props {

--- a/src/routes/bookmarks/+page.svelte
+++ b/src/routes/bookmarks/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import IconCard from '$lib/components/IconCard.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
     import SortMenu from '$lib/components/SortMenu.svelte';

--- a/src/routes/contents/[id]/+page.svelte
+++ b/src/routes/contents/[id]/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
     import { asset } from '$app/paths';
-    import { resolve } from '$lib/utils/paths';
     import config, { scriptureConfig } from '$assets/config';
     import type { ContentItem } from '$config';
     import BottomNavigationBar from '$lib/components/BottomNavigationBar.svelte';
@@ -27,6 +26,7 @@
     import { navigateToText } from '$lib/navigate';
     import { getDisplayString } from '$lib/scripts/scripture-reference-utils';
     import { compareVersions } from '$lib/scripts/stringUtils';
+    import { resolve } from '$lib/utils/paths';
     import { SvelteMap } from 'svelte/reactivity';
     import type { PageData } from './$types';
 

--- a/src/routes/contents/[id]/+page.svelte
+++ b/src/routes/contents/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { asset, resolve } from '$app/paths';
+    import { asset } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import config, { scriptureConfig } from '$assets/config';
     import type { ContentItem } from '$config';
     import BottomNavigationBar from '$lib/components/BottomNavigationBar.svelte';

--- a/src/routes/contents/[id]/+page.svelte
+++ b/src/routes/contents/[id]/+page.svelte
@@ -116,7 +116,6 @@
                 // For other book types (e.g. quiz), the linkType will be
                 // the book type and the linkLocation will have the route
                 // to the viewer of the book type.
-                // @ts-expect-error I don't have a good way to fix this for now. -Aidan
                 goto(resolve(`/${item.linkLocation}`));
                 break;
         }

--- a/src/routes/dev/icons/+page.svelte
+++ b/src/routes/dev/icons/+page.svelte
@@ -2,7 +2,7 @@
 <script lang="ts">
     import { dev } from '$app/environment';
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import { onMount } from 'svelte';
 
     // Redirect to home if not in development mode

--- a/src/routes/highlights/+page.svelte
+++ b/src/routes/highlights/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import IconCard from '$lib/components/IconCard.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
     import SortMenu from '$lib/components/SortMenu.svelte';

--- a/src/routes/highlights/+page.svelte
+++ b/src/routes/highlights/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import IconCard from '$lib/components/IconCard.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
     import SortMenu from '$lib/components/SortMenu.svelte';
@@ -11,6 +10,7 @@
     import ShareIcon from '$lib/icons/ShareIcon.svelte';
     import { formatDate } from '$lib/scripts/dateUtils';
     import type { MenuActionEvent } from '$lib/types';
+    import { resolve } from '$lib/utils/paths';
     import type { PageData } from './$types';
 
     async function handleMenuaction(event: MenuActionEvent, highlight: HighlightItem) {

--- a/src/routes/image/upload/+page.svelte
+++ b/src/routes/image/upload/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import Navbar from '$lib/components/Navbar.svelte';
     import { actionBarColor, t, voiCustomImage } from '$lib/data/stores';
     import { CheckIcon } from '$lib/icons';
+    import { resolve } from '$lib/utils/paths';
     import { onDestroy, onMount } from 'svelte';
 
     let image: HTMLImageElement;

--- a/src/routes/image/upload/+page.svelte
+++ b/src/routes/image/upload/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import Navbar from '$lib/components/Navbar.svelte';
     import { actionBarColor, t, voiCustomImage } from '$lib/data/stores';
     import { CheckIcon } from '$lib/icons';

--- a/src/routes/lexicon/+layout.svelte
+++ b/src/routes/lexicon/+layout.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import { page } from '$app/state';
     import config from '$assets/config';
     import Navbar from '$lib/components/Navbar.svelte';
@@ -9,6 +8,7 @@
     import { selectedWord, selectWord } from '$lib/data/stores/lexicon.svelte';
     import SearchIcon from '$lib/icons/SearchIcon.svelte';
     import TextAppearanceIcon from '$lib/icons/TextAppearanceIcon.svelte';
+    import { resolve } from '$lib/utils/paths';
     import type { Snippet } from 'svelte';
     import type { LayoutData } from './$types';
 

--- a/src/routes/lexicon/+layout.svelte
+++ b/src/routes/lexicon/+layout.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import { page } from '$app/state';
     import config from '$assets/config';
     import Navbar from '$lib/components/Navbar.svelte';

--- a/src/routes/lexicon/+page.svelte
+++ b/src/routes/lexicon/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import config from '$assets/config';
     import {
         currentReversal,

--- a/src/routes/lexicon/+page.svelte
+++ b/src/routes/lexicon/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import config from '$assets/config';
     import {
         currentReversal,
@@ -15,6 +14,7 @@
     import EntryView from '$lib/lexicon/components/EntryView.svelte';
     import HomonymSubscript from '$lib/lexicon/components/HomonymSubscript.svelte';
     import WordNavigationStrip from '$lib/lexicon/components/WordNavigationStrip.svelte';
+    import { resolve } from '$lib/utils/paths';
     import { onMount, tick } from 'svelte';
     import { expoInOut } from 'svelte/easing';
     import { fly } from 'svelte/transition';

--- a/src/routes/notes/+page.svelte
+++ b/src/routes/notes/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import IconCard from '$lib/components/IconCard.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
     import SortMenu from '$lib/components/SortMenu.svelte';
@@ -12,6 +11,7 @@
     import ShareIcon from '$lib/icons/ShareIcon.svelte';
     import { formatDate } from '$lib/scripts/dateUtils';
     import type { MenuActionEvent } from '$lib/types';
+    import { resolve } from '$lib/utils/paths';
     import type { PageData } from './$types';
 
     interface Props {

--- a/src/routes/notes/+page.svelte
+++ b/src/routes/notes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import IconCard from '$lib/components/IconCard.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
     import SortMenu from '$lib/components/SortMenu.svelte';

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import config, { scriptureConfig } from '$assets/config';
     import type { PlanItem } from '$config';
     import BottomNavigationBar from '$lib/components/BottomNavigationBar.svelte';

--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import config, { scriptureConfig } from '$assets/config';
     import type { PlanItem } from '$config';
     import BottomNavigationBar from '$lib/components/BottomNavigationBar.svelte';
@@ -8,6 +7,7 @@
     import { getLastPlanState } from '$lib/data/planStates';
     import { convertStyle, language, s, t } from '$lib/data/stores';
     import { compareVersions } from '$lib/scripts/stringUtils';
+    import { resolve } from '$lib/utils/paths';
 
     const imageFolder: Record<string, string> =
         compareVersions(config.programVersion, '12.0') < 0

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import config from '$assets/config';
     import Navbar from '$lib/components/Navbar.svelte';
     import { getFirstIncompleteDay, getNextPlanReference } from '$lib/data/planProgressItems';
@@ -17,6 +16,7 @@
     import { getDisplayString } from '$lib/scripts/scripture-reference-utils';
     import { getReferenceFromString } from '$lib/scripts/scripture-reference-utils-common';
     import { compareVersions } from '$lib/scripts/stringUtils';
+    import { resolve } from '$lib/utils/paths';
     import type { PageData } from './$types';
 
     interface Props {

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import config from '$assets/config';
     import Navbar from '$lib/components/Navbar.svelte';
     import { getFirstIncompleteDay, getNextPlanReference } from '$lib/data/planProgressItems';

--- a/src/routes/plans/[id]/settings/+page.svelte
+++ b/src/routes/plans/[id]/settings/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import Navbar from '$lib/components/Navbar.svelte';
     import { addPlanState } from '$lib/data/planStates';
     import { language, t } from '$lib/data/stores';
+    import { resolve } from '$lib/utils/paths';
     import type { PageData } from './$types';
 
     interface Props {

--- a/src/routes/plans/[id]/settings/+page.svelte
+++ b/src/routes/plans/[id]/settings/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import Navbar from '$lib/components/Navbar.svelte';
     import { addPlanState } from '$lib/data/planStates';
     import { language, t } from '$lib/data/stores';

--- a/src/routes/search/[collection]/[[savedResults]]/+page.svelte
+++ b/src/routes/search/[collection]/[[savedResults]]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import Navbar from '$lib/components/Navbar.svelte';
     import SearchForm from '$lib/components/SearchForm.svelte';
     import SearchResultList from '$lib/components/SearchResultList.svelte';

--- a/src/routes/search/[collection]/[[savedResults]]/+page.svelte
+++ b/src/routes/search/[collection]/[[savedResults]]/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import Navbar from '$lib/components/Navbar.svelte';
     import SearchForm from '$lib/components/SearchForm.svelte';
     import SearchResultList from '$lib/components/SearchResultList.svelte';
@@ -12,6 +11,7 @@
     } from '$lib/search/domain/interfaces/presentation-interfaces';
     import { makeSearchSession } from '$lib/search/factories';
     import type { SearchFormSubmitEvent } from '$lib/types';
+    import { resolve } from '$lib/utils/paths';
     import { onMount } from 'svelte';
 
     let { data } = $props();

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$app/paths';
+    import { resolve } from '$lib/utils/paths';
     import config, { scriptureConfig } from '$assets/config';
     import contents from '$assets/contents';
     import AudioBar from '$lib/components/AudioBar.svelte';

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { resolve } from '$lib/utils/paths';
     import config, { scriptureConfig } from '$assets/config';
     import contents from '$assets/contents';
     import AudioBar from '$lib/components/AudioBar.svelte';
@@ -60,6 +59,7 @@
     } from '$lib/icons';
     import { navigateToTextChapterInDirection } from '$lib/navigate';
     import { getFeatureValueBoolean, getFeatureValueString } from '$lib/scripts/configUtils';
+    import { resolve } from '$lib/utils/paths';
     import { onDestroy, onMount } from 'svelte';
     import {
         pinch,


### PR DESCRIPTION
This was causing creating notes to fail since a full refresh was caused and loss of state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized URL/path resolution in a shared utility and updated navigation across components and pages to use it, improving consistency for hash-based routes.
* **Bug Fixes**
  * Corrected the default navigation link for the Icon Card to point to the proper text route.
* **Chores**
  * Improved TypeScript linting by enabling project-wide type information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->