### PR TITLE
fix: include base path in cache key

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -23,10 +23,8 @@ self.addEventListener('activate', (event) => {
     // Remove previous cached data from disk
     async function deleteOldCaches() {
         const cachePath = CACHE.split(';')[2];
-        console.log(`current path: ${cachePath}`);
         for (const key of await caches.keys()) {
             const keyPath = key.split(';')[2];
-            console.log(keyPath); // TODO: this console log is here for debugging purposes and should be removed before merging
             /**
              * we want to delete the cache if it is missing the path (backwards-compatible), or if its path is the same as the current app (the fix)
              */

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -22,8 +22,15 @@ self.addEventListener('install', (event) => {
 self.addEventListener('activate', (event) => {
     // Remove previous cached data from disk
     async function deleteOldCaches() {
+        const cachePath = CACHE.split(';')[2];
+        console.log(`current path: ${cachePath}`);
         for (const key of await caches.keys()) {
-            if (key !== CACHE) {
+            const keyPath = key.split(';')[2];
+            console.log(keyPath); // TODO: this console log is here for debugging purposes and should be removed before merging
+            /**
+             * we want to delete the cache if it is missing the path (backwards-compatible), or if its path is the same as the current app (the fix)
+             */
+            if (key !== CACHE && (!keyPath || keyPath === cachePath)) {
                 await caches.delete(key);
             }
         }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -46,7 +46,7 @@ const config = {
             }
         },
         version: {
-            name: `${templateVersion}-${buildTimestamp}`
+            name: `${templateVersion};${buildTimestamp};${serviceWorkerScope}`
         }
     }
 };


### PR DESCRIPTION
Modifies cache key to have semicolon separated list of version number, build timestamp, and build base path. The build base path is then used when deleting to delete an old cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced service worker cache deletion logic to use path-aware matching
  * Updated version identifier generation to include service worker scope information for improved cache management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->