### PR TITLE
Tweak new collections route

### DIFF
--- a/src/lib/components/LayoutOptions.svelte
+++ b/src/lib/components/LayoutOptions.svelte
@@ -95,46 +95,39 @@ Displays the three different layout option menus.
             </p>
         {/if}
         {#each $selectedLayouts.sideBySide as collection, i}
-            <div>
-                <div class="max-w-screen-md mx-auto">
-                    <div class="px-3 layout-subtitle">
-                        {i + 1}
+            <div class="px-3 layout-subtitle">
+                {i + 1}
+            </div>
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <div
+                class="flex justify-between layout-item-block rounded-none cursor-pointer"
+                onclick={() => {
+                    modal.open(ModalType.Collection, {
+                        type: 'double-pane',
+                        showBlank: false,
+                        number: i
+                    });
+                }}
+            >
+                {#if collection.image}
+                    <div class="layout-image-block self-start">
+                        <!-- svelte-ignore a11y_missing_attribute -->
+                        <img class="layout-image" src={illustrations['./' + collection.image]} />
                     </div>
-                    <!-- svelte-ignore a11y_click_events_have_key_events -->
-                    <!-- svelte-ignore a11y_no_static_element_interactions -->
-                    <div
-                        class="flex justify-between layout-item-block rounded-none cursor-pointer"
-                        onclick={() => {
-                            modal.open(ModalType.Collection, {
-                                type: 'double-pane',
-                                showBlank: false,
-                                number: i
-                            });
-                        }}
-                    >
-                        {#if collection.image}
-                            <div class="layout-image-block self-start">
-                                <!-- svelte-ignore a11y_missing_attribute -->
-                                <img
-                                    class="layout-image"
-                                    src={illustrations['./' + collection.image]}
-                                />
-                            </div>
-                        {/if}
-                        <div class="layout-text-block">
-                            <div class="layout-item-name">
-                                {collection.name}
-                            </div>
-                            {#if collection.description}
-                                <div class="layout-item-description">
-                                    {collection.description}
-                                </div>
-                            {/if}
-                        </div>
-                        <div class="px-3">
-                            <DropdownIcon color={$s?.['ui.layouts.selector'].color} />
-                        </div>
+                {/if}
+                <div class="layout-text-block">
+                    <div class="layout-item-name">
+                        {collection.name}
                     </div>
+                    {#if collection.description}
+                        <div class="layout-item-description">
+                            {collection.description}
+                        </div>
+                    {/if}
+                </div>
+                <div class="px-3">
+                    <DropdownIcon color={$s?.['ui.layouts.selector'].color} />
                 </div>
             </div>
         {/each}
@@ -146,46 +139,39 @@ Displays the three different layout option menus.
             </p>
         {/if}
         {#each $selectedLayouts.verseByVerse as collection, i}
-            <div>
-                <div class="max-w-screen-md mx-auto">
-                    <div class="px-3 layout-subtitle">
-                        {i + 1}
+            <div class="px-3 layout-subtitle">
+                {i + 1}
+            </div>
+            <!-- svelte-ignore a11y_click_events_have_key_events -->
+            <!-- svelte-ignore a11y_no_static_element_interactions -->
+            <div
+                class="flex justify-between layout-item-block rounded-none cursor-pointer"
+                onclick={() => {
+                    modal.open(ModalType.Collection, {
+                        type: 'verse-by-verse',
+                        showBlank: i === 2,
+                        number: i
+                    });
+                }}
+            >
+                {#if collection.image}
+                    <div class="layout-image-block self-start">
+                        <!-- svelte-ignore a11y_missing_attribute -->
+                        <img class="layout-image" src={illustrations['./' + collection.image]} />
                     </div>
-                    <!-- svelte-ignore a11y_click_events_have_key_events -->
-                    <!-- svelte-ignore a11y_no_static_element_interactions -->
-                    <div
-                        class="flex justify-between layout-item-block rounded-none cursor-pointer"
-                        onclick={() => {
-                            modal.open(ModalType.Collection, {
-                                type: 'verse-by-verse',
-                                showBlank: i === 2,
-                                number: i
-                            });
-                        }}
-                    >
-                        {#if collection.image}
-                            <div class="layout-image-block self-start">
-                                <!-- svelte-ignore a11y_missing_attribute -->
-                                <img
-                                    class="layout-image"
-                                    src={illustrations['./' + collection.image]}
-                                />
-                            </div>
-                        {/if}
-                        <div class="layout-text-block">
-                            <div class="layout-item-name">
-                                {collection.name}
-                            </div>
-                            {#if collection.description}
-                                <div class="layout-item-description">
-                                    {collection.description}
-                                </div>
-                            {/if}
-                        </div>
-                        <div class="px-3">
-                            <DropdownIcon color={$s?.['ui.layouts.selector'].color} />
-                        </div>
+                {/if}
+                <div class="layout-text-block">
+                    <div class="layout-item-name">
+                        {collection.name}
                     </div>
+                    {#if collection.description}
+                        <div class="layout-item-description">
+                            {collection.description}
+                        </div>
+                    {/if}
+                </div>
+                <div class="px-3">
+                    <DropdownIcon color={$s?.['ui.layouts.selector'].color} />
                 </div>
             </div>
         {/each}

--- a/src/lib/components/LayoutOptions.svelte
+++ b/src/lib/components/LayoutOptions.svelte
@@ -15,7 +15,7 @@ Displays the three different layout option menus.
         base: '/src/gen-assets/illustrations'
     }) as Record<string, string>;
 
-    let { layoutOption, menuaction } = $props();
+    let { layoutOption, menuaction, showTitle = true } = $props();
 
     const allDocSets =
         scriptureConfig.bookCollections?.map((ds) => ({
@@ -74,12 +74,14 @@ Displays the three different layout option menus.
     }
 </script>
 
-<div class="max-w-screen-md mx-auto px-2">
+<div>
     <!-- Single Pane -->
     {#if layoutOption === Layout.Single}
-        <p class="py-2 font-bold" style:color={$themeColors['LayoutTitleColor']}>
-            {$t['Layout_Single_Pane']}
-        </p>
+        {#if showTitle}
+            <p class="py-2 font-bold" style:color={$themeColors['LayoutTitleColor']}>
+                {$t['Layout_Single_Pane']}
+            </p>
+        {/if}
         <CollectionList
             docSets={allDocSets.filter((x) => x.singlePane === true)}
             selectedLayouts={$selectedLayouts.singlePane}
@@ -87,9 +89,11 @@ Displays the three different layout option menus.
         />
         <!-- Two Pane -->
     {:else if layoutOption === Layout.Two}
-        <p class="py-2 font-bold" style:color={$themeColors['LayoutTitleColor']}>
-            {$t['Layout_Two_Pane']}
-        </p>
+        {#if showTitle}
+            <p class="py-2 font-bold" style:color={$themeColors['LayoutTitleColor']}>
+                {$t['Layout_Two_Pane']}
+            </p>
+        {/if}
         {#each $selectedLayouts.sideBySide as collection, i}
             <div>
                 <div class="max-w-screen-md mx-auto">
@@ -136,9 +140,11 @@ Displays the three different layout option menus.
         {/each}
         <!-- Verse By Verse -->
     {:else if layoutOption === Layout.VerseByVerse}
-        <p class="py-2 font-bold" style:color={$themeColors['LayoutTitleColor']}>
-            {$t['Layout_Interlinear']}
-        </p>
+        {#if showTitle}
+            <p class="py-2 font-bold" style:color={$themeColors['LayoutTitleColor']}>
+                {$t['Layout_Interlinear']}
+            </p>
+        {/if}
         {#each $selectedLayouts.verseByVerse as collection, i}
             <div>
                 <div class="max-w-screen-md mx-auto">

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -178,7 +178,7 @@ The sidebar/drawer.
             {#if showLayouts}
                 <li>
                     <!-- svelte-ignore a11y_missing_attribute -->
-                    <button style:color={textColor} onclick={() => goto(resolve(`/collections`))}>
+                    <button style:color={textColor} onclick={() => goto(resolve(`/layout`))}>
                         <BibleIcon color={iconColor} />{$t['Menu_Layout']}
                     </button>
                 </li>

--- a/src/lib/data/stores/collection.ts
+++ b/src/lib/data/stores/collection.ts
@@ -2,6 +2,8 @@ import { scriptureConfig } from '$assets/config';
 import { get, writable } from 'svelte/store';
 import { Layout } from './view';
 
+export const testLayouts = false; // Set to true to show all layouts regardless of scriptureConfig
+
 function findCollection(id: string): App.CollectionEntry | undefined {
     const ds = scriptureConfig.bookCollections?.find((x) => x.id === id);
     return (
@@ -21,7 +23,7 @@ function createInitCollections(): App.CollectionGroup {
     const initCollections: App.CollectionGroup = {};
 
     for (const layout of layouts) {
-        if (!layout.enabled) {
+        if (!layout.enabled && !testLayouts) {
             continue;
         }
         const collections: App.CollectionEntry[] = layout.layoutCollections

--- a/src/routes/contents/[id]/+page.svelte
+++ b/src/routes/contents/[id]/+page.svelte
@@ -103,7 +103,7 @@
                         goto(resolve(`/${item.linkLocation}`));
                         break;
                     case 'layout':
-                        goto(resolve(`/collections`));
+                        goto(resolve(`/layout`));
                         break;
                     case 'website':
                         //opens in a separate tab

--- a/src/routes/layout/+page.svelte
+++ b/src/routes/layout/+page.svelte
@@ -12,7 +12,8 @@
         monoIconColor,
         refs,
         selectedLayouts,
-        t
+        t,
+        testLayouts
     } from '$lib/data/stores';
     import { CheckIcon, SideBySideIcon, SinglePaneIcon, VerseByVerseIcon } from '$lib/icons';
 
@@ -40,9 +41,11 @@
     // ToDo: If showSinglePane false, provide first availible visible option instead
     const showSinglePane = !!scriptureConfig.layouts?.find((x) => x.mode === Layout.Single)
         ?.enabled;
-    const showSideBySide = !!scriptureConfig.layouts?.find((x) => x.mode === Layout.Two)?.enabled; //Not yet implemented
-    const showVerseByVerse = !!scriptureConfig.layouts?.find((x) => x.mode === Layout.VerseByVerse)
-        ?.enabled; //Not yet implemented
+    const showSideBySide =
+        testLayouts || !!scriptureConfig.layouts?.find((x) => x.mode === Layout.Two)?.enabled; //Not yet implemented
+    const showVerseByVerse =
+        testLayouts ||
+        !!scriptureConfig.layouts?.find((x) => x.mode === Layout.VerseByVerse)?.enabled; //Not yet implemented
 
     // In the native app, if only showing the single pane, then don't show the title.
     // If showing one of the other two, then show the title.

--- a/src/routes/layout/+page.svelte
+++ b/src/routes/layout/+page.svelte
@@ -35,7 +35,10 @@
     const showSideBySide = !!scriptureConfig.layouts?.find((x) => x.mode === Layout.Two)?.enabled; //Not yet implemented
     const showVerseByVerse = !!scriptureConfig.layouts?.find((x) => x.mode === Layout.VerseByVerse)
         ?.enabled; //Not yet implemented
-    const multipleLayouts = showSideBySide || showVerseByVerse;
+
+    // In the native app, if only showing the single pane, then don't show the title.
+    // If showing one of the other two, then show the title.
+    const showTitle = showSideBySide || showVerseByVerse;
     function getSelectedLayout() {
         const collections = selectedLayouts.collections(tabMenuActive);
         return {
@@ -61,7 +64,7 @@
 </script>
 
 {#snippet layoutOptions(layoutOption: Layout, menuaction: App.MenuActionHandler)}
-    <LayoutOptions {layoutOption} {menuaction} showTitle={multipleLayouts} />
+    <LayoutOptions {layoutOption} {menuaction} {showTitle} />
 {/snippet}
 <!--The background color of the icons should be the DialogBackgroundColor color.-->
 {#snippet icon(mode: Layout)}

--- a/src/routes/layout/+page.svelte
+++ b/src/routes/layout/+page.svelte
@@ -5,7 +5,15 @@
     import LayoutOptions from '$lib/components/LayoutOptions.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
     import TabsMenu from '$lib/components/TabsMenu.svelte';
-    import { actionBarColor, layout, Layout, refs, s, selectedLayouts, t } from '$lib/data/stores';
+    import {
+        actionBarColor,
+        layout,
+        Layout,
+        monoIconColor,
+        refs,
+        selectedLayouts,
+        t
+    } from '$lib/data/stores';
     import { CheckIcon, SideBySideIcon, SinglePaneIcon, VerseByVerseIcon } from '$lib/icons';
 
     const matchingDocSets =
@@ -69,12 +77,12 @@
 <!--The background color of the icons should be the DialogBackgroundColor color.-->
 {#snippet icon(mode: Layout)}
     {#if mode === Layout.Single}
-        <SinglePaneIcon
-            color="black"
-        /><!--The icons are not hardcoded to black in the native app, but I can't figure out what style/color to use.-->
+        <SinglePaneIcon color={$monoIconColor} />
     {:else if mode === Layout.Two}
-        <SideBySideIcon color="black" />
-    {:else}<VerseByVerseIcon color="black" />{/if}
+        <SideBySideIcon color={$monoIconColor} />
+    {:else}
+        <VerseByVerseIcon color={$monoIconColor} />
+    {/if}
 {/snippet}
 <div class="flex flex-col h-screen">
     <div class="navbar h-16">

--- a/src/routes/layout/+page.svelte
+++ b/src/routes/layout/+page.svelte
@@ -35,6 +35,7 @@
     const showSideBySide = !!scriptureConfig.layouts?.find((x) => x.mode === Layout.Two)?.enabled; //Not yet implemented
     const showVerseByVerse = !!scriptureConfig.layouts?.find((x) => x.mode === Layout.VerseByVerse)
         ?.enabled; //Not yet implemented
+    const multipleLayouts = showSideBySide || showVerseByVerse;
     function getSelectedLayout() {
         const collections = selectedLayouts.collections(tabMenuActive);
         return {
@@ -60,7 +61,7 @@
 </script>
 
 {#snippet layoutOptions(layoutOption: Layout, menuaction: App.MenuActionHandler)}
-    <LayoutOptions {layoutOption} {menuaction} />
+    <LayoutOptions {layoutOption} {menuaction} showTitle={multipleLayouts} />
 {/snippet}
 <!--The background color of the icons should be the DialogBackgroundColor color.-->
 {#snippet icon(mode: Layout)}
@@ -89,26 +90,28 @@
             {/snippet}
         </Navbar>
     </div>
-    <TabsMenu
-        bind:active={tabMenuActive}
-        options={{
-            [Layout.Single]: {
-                tab: { icon },
-                snippet: layoutOptions,
-                visible: showSinglePane
-            },
-            [Layout.Two]: {
-                tab: { icon },
-                snippet: layoutOptions,
-                visible: showSideBySide
-            },
-            [Layout.VerseByVerse]: {
-                tab: { icon },
-                snippet: layoutOptions,
-                visible: showVerseByVerse
-            }
-        }}
-        scroll={false}
-        styleType="ui.dialog"
-    />
+    <div class="overflow-y-auto p-2 max-w-screen-md mx-auto w-full">
+        <TabsMenu
+            bind:active={tabMenuActive}
+            options={{
+                [Layout.Single]: {
+                    tab: { icon },
+                    snippet: layoutOptions,
+                    visible: showSinglePane
+                },
+                [Layout.Two]: {
+                    tab: { icon },
+                    snippet: layoutOptions,
+                    visible: showSideBySide
+                },
+                [Layout.VerseByVerse]: {
+                    tab: { icon },
+                    snippet: layoutOptions,
+                    visible: showVerseByVerse
+                }
+            }}
+            scroll={false}
+            styleType="ui.dialog"
+        />
+    </div>
 </div>

--- a/src/routes/layout/+page.svelte
+++ b/src/routes/layout/+page.svelte
@@ -87,7 +87,7 @@
         <VerseByVerseIcon color={$monoIconColor} />
     {/if}
 {/snippet}
-<div class="flex flex-col h-screen">
+<div class="grid grid-rows-[auto,1fr]" style="height:100vh;height:100dvh;">
     <div class="navbar h-16">
         <Navbar {backNavigation}>
             {#snippet center()}

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -399,7 +399,7 @@
         if ($isFirstLaunch) {
             analytics.log('ab_first_run');
             if (showCollectionsOnFirstLaunch && enoughCollections) {
-                goto(resolve(`/collections`));
+                goto(resolve(`/layout`));
             }
         }
     });
@@ -502,7 +502,7 @@
                         {#if showCollectionNavbar && enoughCollections}
                             <button
                                 class="dy-btn dy-btn-ghost dy-btn-circle"
-                                onclick={() => goto(resolve(`/collections`))}
+                                onclick={() => goto(resolve(`/layout`))}
                             >
                                 <BibleIcon color={$actionBarColor} />
                             </button>
@@ -541,7 +541,7 @@
             style:top={navBarHeight}
             style:background-color={convertStyle($s?.['ui.pane1'])}
             style={convertStyle($s?.['ui.pane1.name'])}
-            onclick={() => goto(resolve(`/collections`))}
+            onclick={() => goto(resolve(`/layout`))}
         >
             {scriptureConfig.bookCollections?.find((x) => x.id === $refs.collection)
                 ?.collectionAbbreviation}


### PR DESCRIPTION
- layout is a better name for the route
- some of the tailwind layout classes should have been on the container not on the component
- when it is ONLY the Single Pane, the Native app doesn't display the title.
- when it is ONLY another option other than Single Pane, the Native app does display the title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated layout selection screen and updated related navigation to open it directly.
  * Layout option menu titles are now shown conditionally based on enabled layout choices.

* **Bug Fixes**
  * Corrected multiple navigation targets (sidebar, content links, and text page redirects/buttons) to send users to the layout page instead of the collections page.
  * Improved the layout page’s tab container to better control scrolling and spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->