### PR TITLE
#1028 Add fallbacks to reference parsing and navigation

### DIFF
--- a/src/lib/data/navigation.ts
+++ b/src/lib/data/navigation.ts
@@ -85,7 +85,12 @@ export class NavigationContext {
         const chapterNum = parseInt(chapter, 10);
         const chapterRange = book?.chaptersN?.split('-').map((n) => parseInt(n, 10));
         const fallbackChapter = String(chapterRange?.[0] || 1);
-        if (!chapterRange || chapterNum < chapterRange[0] || chapterNum > chapterRange[1]) {
+        if (
+            (isNaN(chapterNum) && chapter !== 'i') ||
+            !chapterRange ||
+            chapterNum < chapterRange[0] ||
+            chapterNum > chapterRange[1]
+        ) {
             console.error(
                 `chapter '${chapter}' falls outside of chapter range '${book?.chaptersN}'. Defaulting to '${fallbackChapter}'.`
             );

--- a/src/lib/data/navigation.ts
+++ b/src/lib/data/navigation.ts
@@ -40,43 +40,62 @@ export class NavigationContext {
         const parts = ref.split('.');
         const hasCollection = parts.length !== 2;
 
-        const parsedDocSet = hasCollection ? parts[0] : this.docSets[0];
+        const docSet = hasCollection ? parts[0] : this.docSets[0];
 
         const collection = this.config.bookCollections?.find(
-            (c) => parsedDocSet === c.id || parsedDocSet === this.docSetFromCollection(c)
+            (c) => docSet === c.id || docSet === this.docSetFromCollection(c)
         );
 
-        let docSet = this.docSets[0];
+        const book = parts[hasCollection ? 1 : 0];
 
-        if (!collection || parsedDocSet !== this.docSetFromCollection(collection)) {
-            console.error(
-                `docSet '${parsedDocSet}' not found in collections. Defaulting to '${docSet}'`
+        return {
+            docSet: collection ? this.docSetFromCollection(collection) : docSet,
+            book: book,
+            chapter: parts[hasCollection ? 2 : 1],
+            verse: parts[3] || '1'
+        };
+    }
+
+    private handleFallbacks(docSet: string, bookId: string, chapter: string) {
+        let useFallbackDocSet = false;
+        const fallbackDocSet = this.docSets[0];
+        const collection =
+            this.config.bookCollections?.find((c) => docSet === this.docSetFromCollection(c)) ??
+            this.config.bookCollections?.find(
+                (c) => fallbackDocSet === this.docSetFromCollection(c)
             );
-        } else {
-            docSet = this.docSetFromCollection(collection);
+        if (!collection || docSet !== this.docSetFromCollection(collection)) {
+            console.error(
+                `docSet '${docSet}' not found in collections. Defaulting to '${fallbackDocSet}'.`
+            );
+            useFallbackDocSet = true;
         }
 
-        let bookId = parts[hasCollection ? 1 : 0];
-
+        let useFallbackBookId = false;
+        const fallbackBookId = collection?.books[0]?.id ?? '';
         const book = collection?.books.find((b) => b.id === bookId) ?? collection?.books[0];
         if (!book || bookId !== book.id) {
             console.error(
-                `book '${bookId}' not found in '${docSet}'. Defaulting to '${collection?.books[0]?.id ?? ''}'`
+                `book '${bookId}' not found in '${docSet}'. Defaulting to '${fallbackBookId}'.`
             );
-            bookId = collection?.books[0]?.id ?? '';
+            useFallbackBookId = true;
+        }
+
+        let useFallbackChapter = false;
+        const chapterNum = parseInt(chapter, 10);
+        const chapterRange = book?.chaptersN?.split('-').map((n) => parseInt(n, 10));
+        const fallbackChapter = String(chapterRange?.[0] || 1);
+        if (!chapterRange || chapterNum < chapterRange[0] || chapterNum > chapterRange[1]) {
+            console.error(
+                `chapter '${chapter}' falls outside of chapter range '${book?.chaptersN}'. Defaulting to '${fallbackChapter}'.`
+            );
+            useFallbackChapter = true;
         }
 
         return {
-            docSet,
-            book: bookId,
-            // TODO: handle bad chapter??
-            chapter:
-                parts[hasCollection ? 2 : 1] ||
-                this.config.bookCollections?.[0].books
-                    .find((b) => b.id === ref[0])
-                    ?.chaptersN?.split('-')[0] ||
-                '1',
-            verse: parts[3] || '1'
+            docSet: useFallbackDocSet ? fallbackDocSet : docSet,
+            book: useFallbackBookId ? fallbackBookId : bookId,
+            chapter: useFallbackChapter ? fallbackChapter : chapter
         };
     }
 
@@ -98,7 +117,13 @@ export class NavigationContext {
         if (!this.initialized) {
             throw new Error('NavigationContext is not initialized; please call gotoInitial()');
         }
-        await this.updateLocation(docSet, book, chapter, verse);
+        const withFallbacks = this.handleFallbacks(docSet, book, chapter);
+        await this.updateLocation(
+            withFallbacks.docSet,
+            withFallbacks.book,
+            withFallbacks.chapter,
+            verse
+        );
         this.updateAudio();
         this.updateHeadings();
         this.updateNextPrev();

--- a/src/lib/data/navigation.ts
+++ b/src/lib/data/navigation.ts
@@ -1,6 +1,6 @@
 import { scriptureConfig } from '$assets/config';
-import type { BookCollectionAudioConfig } from '$config';
-import { isBlank } from '$lib/scripts/stringUtils';
+import type { BookCollectionAudioConfig, BookCollectionConfig } from '$config';
+import { isBlank, isNotBlank } from '$lib/scripts/stringUtils';
 import { loadCatalog, type CatalogData } from './catalogData';
 
 /**
@@ -32,49 +32,66 @@ export class NavigationContext {
     private books: string[];
     private versesByChapters: { [chapter: string]: { [verse: string]: string } };
 
+    private docSetFromCollection(coll: Pick<BookCollectionConfig, 'id' | 'languageCode'>) {
+        return `${coll.languageCode}_${coll.id}`;
+    }
+
+    private parseReference(ref: string = '') {
+        const parts = ref.split('.');
+        const hasCollection = parts.length !== 2;
+
+        const parsedDocSet = hasCollection ? parts[0] : this.docSets[0];
+
+        const collection = this.config.bookCollections?.find(
+            (c) => parsedDocSet === c.id || parsedDocSet === this.docSetFromCollection(c)
+        );
+
+        let docSet = this.docSets[0];
+
+        if (!collection || parsedDocSet !== this.docSetFromCollection(collection)) {
+            console.error(
+                `docSet '${parsedDocSet}' not found in collections. Defaulting to '${docSet}'`
+            );
+        } else {
+            docSet = this.docSetFromCollection(collection);
+        }
+
+        let bookId = parts[hasCollection ? 1 : 0];
+
+        const book = collection?.books.find((b) => b.id === bookId) ?? collection?.books[0];
+        if (!book || bookId !== book.id) {
+            console.error(
+                `book '${bookId}' not found in '${docSet}'. Defaulting to '${collection?.books[0]?.id ?? ''}'`
+            );
+            bookId = collection?.books[0]?.id ?? '';
+        }
+
+        return {
+            docSet,
+            book: bookId,
+            // TODO: handle bad chapter??
+            chapter:
+                parts[hasCollection ? 2 : 1] ||
+                this.config.bookCollections?.[0].books
+                    .find((b) => b.id === ref[0])
+                    ?.chaptersN?.split('-')[0] ||
+                '1',
+            verse: parts[3] || '1'
+        };
+    }
+
     async gotoInitial(start: string = '') {
         this.docSets =
             this.config.bookCollections?.map((bc) => `${bc.languageCode}_${bc.id}`) ?? [];
         this.initialized = true;
         start = start || (this.config.mainFeatures['start-at-reference'] as string);
-        if (start) {
-            await this.gotoReference(start);
-        } else {
-            const collection = this.config.bookCollections![0];
-            await this.goto(
-                this.docSets[0],
-                collection.books[0].id,
-                collection.books[0].chaptersN?.split('-')?.[0] ?? '1', //TODO: what if chaptersN is undefined?
-                '1'
-            );
-        }
+        // validation handled in gotoReference
+        await this.gotoReference(start);
     }
 
     async gotoReference(reference: string) {
-        const ref = reference.split('.');
-        if (ref.length === 2) {
-            // Book and chapter specified but only one collection
-            if (isBlank(ref[1])) {
-                // Only book specified
-                const firstChapter =
-                    this.config.bookCollections?.[0].books
-                        .find((b) => b.id === ref[0])
-                        ?.chaptersN?.split('-')[0] ?? '1'; //TODO: what if chaptersN is undefined?
-                await this.goto(this.docSets[0], ref[0], firstChapter, '1');
-            } else {
-                await this.goto(this.docSets[0], ref[0], ref[1], '1');
-            }
-        } else {
-            let docSet = ref[0];
-            if (!ref[0].includes('_')) {
-                // This is a collection id.
-                const collection = this.config.bookCollections?.find((c) => c.id === ref[0]);
-                docSet = collection
-                    ? `${collection.languageCode}_${collection.id}`
-                    : this.docSets[0];
-            }
-            await this.goto(docSet, ref[1], ref[2], '1');
-        }
+        const ref = this.parseReference(reference);
+        await this.goto(ref.docSet, ref.book, ref.chapter, ref.verse);
     }
 
     async goto(docSet: string, book: string, chapter: string, verse: string = '') {

--- a/src/lib/data/navigation.ts
+++ b/src/lib/data/navigation.ts
@@ -39,7 +39,8 @@ export class NavigationContext {
     private parseReference(ref: string = '') {
         const parts = ref.split('.');
         const hasCollection =
-            parts.length !== 2 || !(isPositiveInteger(parts[1]) && isPositiveInteger(parts[2]));
+            parts.length !== 2 &&
+            !(parts.length === 3 && isPositiveInteger(parts[1]) && isPositiveInteger(parts[2]));
 
         const docSet = hasCollection ? parts[0] : this.docSets[0];
 

--- a/src/lib/data/navigation.ts
+++ b/src/lib/data/navigation.ts
@@ -90,7 +90,7 @@ export class NavigationContext {
             (isNaN(chapterNum) && chapter !== 'i') ||
             !chapterRange ||
             chapterNum < chapterRange[0] ||
-            chapterNum > chapterRange[1]
+            chapterNum > (chapterRange[1] || chapterRange[0])
         ) {
             console.error(
                 `chapter '${chapter}' falls outside of chapter range '${book?.chaptersN}'. Defaulting to '${fallbackChapter}'.`

--- a/src/lib/data/navigation.ts
+++ b/src/lib/data/navigation.ts
@@ -1,6 +1,6 @@
 import { scriptureConfig } from '$assets/config';
 import type { BookCollectionAudioConfig, BookCollectionConfig } from '$config';
-import { isBlank, isNotBlank } from '$lib/scripts/stringUtils';
+import { isBlank, isNotBlank, isPositiveInteger } from '$lib/scripts/stringUtils';
 import { loadCatalog, type CatalogData } from './catalogData';
 
 /**
@@ -38,7 +38,8 @@ export class NavigationContext {
 
     private parseReference(ref: string = '') {
         const parts = ref.split('.');
-        const hasCollection = parts.length !== 2;
+        const hasCollection =
+            parts.length !== 2 || !(isPositiveInteger(parts[1]) && isPositiveInteger(parts[2]));
 
         const docSet = hasCollection ? parts[0] : this.docSets[0];
 
@@ -52,7 +53,7 @@ export class NavigationContext {
             docSet: collection ? this.docSetFromCollection(collection) : docSet,
             book: book,
             chapter: parts[hasCollection ? 2 : 1],
-            verse: parts[3] || '1'
+            verse: parts[hasCollection ? 3 : 2] || '1'
         };
     }
 


### PR DESCRIPTION
Fixes #1028 

Before navigating to a reference:
- provide fallback to first collection and log an error
- provide fallback to first book in collection and log an error
- provide fallback to first chapter in book if provided chapter is outside of chapter range and log an error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation for opening references and deep links, making start positions resolve more consistently.
  * Refined reference parsing to more reliably derive doc set, book, chapter, and optional verse from dot-separated strings.
  * Added validation and fallback behavior when references don’t match configured collections/books or chapter ranges, preventing navigation from failing or landing in incorrect locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->