### PR TITLE
Show build info in /settings/dev route

### DIFF
--- a/convert/bumpVersion.ts
+++ b/convert/bumpVersion.ts
@@ -1,0 +1,21 @@
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { exit } from 'node:process';
+
+const bump = process.argv[2] ?? 'minor';
+if (!['major', 'minor', 'patch'].includes(bump)) {
+    console.error('Usage: bump-version [major|minor|patch]');
+    exit(1);
+}
+
+execSync(`npm version ${bump} --no-git-tag-version`, { stdio: 'inherit' });
+
+const version = JSON.parse(readFileSync('package.json').toString()).version as string;
+const branch = `version/${version}`;
+
+execSync(`git checkout -b ${branch}`, { stdio: 'inherit' });
+execSync(`git add package.json package-lock.json`, { stdio: 'inherit' });
+execSync(`git commit -m "Version ${version}"`, { stdio: 'inherit' });
+execSync(`git push -u origin ${branch}`, { stdio: 'inherit' });
+
+console.log(`✅ Bumped to ${version} and pushed branch ${branch}`);

--- a/convert/tagVersion.ts
+++ b/convert/tagVersion.ts
@@ -1,0 +1,13 @@
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const version = JSON.parse(readFileSync('package.json').toString()).version as string;
+const tag = `v${version}`;
+
+const remotes = execSync('git remote').toString().trim().split('\n');
+const remote = remotes.includes('upstream') ? 'upstream' : 'origin';
+
+execSync(`git tag ${tag}`, { stdio: 'inherit' });
+execSync(`git push ${remote} ${tag}`, { stdio: 'inherit' });
+
+console.log(`✅ Tagged and pushed ${tag} to ${remote}`);

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
         "clean:all": "npm run clean && npm run clean:data",
         "test": "vitest",
         "test:ui": "vitest --ui",
-        "version": "npm version --no-git-tag-version",
+        "bump-version": "ts-node convert/bumpVersion.ts",
+        "tag-version": "ts-node convert/tagVersion.ts",
         "enforce-version": "ts-node convert/checkVersion.ts"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "clean:all": "npm run clean && npm run clean:data",
         "test": "vitest",
         "test:ui": "vitest --ui",
+        "version": "npm version --no-git-tag-version",
         "enforce-version": "ts-node convert/checkVersion.ts"
     },
     "devDependencies": {

--- a/src/lib/build-info.ts
+++ b/src/lib/build-info.ts
@@ -1,0 +1,7 @@
+import pkg from '../../package.json' with { type: 'json' };
+
+export const buildInfo = {
+    version: pkg.version,
+    buildDate: import.meta.env.VITE_BUILD_DATE as string | undefined,
+    gitHash: import.meta.env.VITE_GIT_HASH as string | undefined
+};

--- a/src/routes/settings/dev/+page.svelte
+++ b/src/routes/settings/dev/+page.svelte
@@ -1,8 +1,11 @@
 <script lang="ts">
+    import { buildInfo } from '$lib/build-info';
     import Navbar from '$lib/components/Navbar.svelte';
     import Settings from '$lib/components/Settings.svelte';
     import { direction, t } from '$lib/data/stores';
     import { devPreferenceSettings } from '$lib/data/stores/setting';
+
+    const showBuildInfo = buildInfo.version || buildInfo.gitHash || buildInfo.buildDate;
 </script>
 
 <div
@@ -21,5 +24,32 @@
     </div>
     <div class="overflow-y-auto">
         <Settings settings={devPreferenceSettings}></Settings>
+        {#if showBuildInfo}
+            <div class="settings-category">Build Info</div>
+            {#if buildInfo.version}
+                <div class="dy-form-control settings-item w-full max-w-lg">
+                    <div class="dy-label py-0">
+                        <div class="settings-title">Version</div>
+                        <span>{buildInfo.version}</span>
+                    </div>
+                </div>
+            {/if}
+            {#if buildInfo.gitHash}
+                <div class="dy-form-control settings-item w-full max-w-lg">
+                    <div class="dy-label py-0">
+                        <div class="settings-title">Git Hash</div>
+                        <span>{buildInfo.gitHash}</span>
+                    </div>
+                </div>
+            {/if}
+            {#if buildInfo.buildDate}
+                <div class="dy-form-control settings-item w-full max-w-lg">
+                    <div class="dy-label py-0">
+                        <div class="settings-title">Build Date</div>
+                        <span>{buildInfo.buildDate}</span>
+                    </div>
+                </div>
+            {/if}
+        {/if}
     </div>
 </div>


### PR DESCRIPTION
Display Build Info for the PWA in `/settings/dev` route.  The next version of App Builders will include VITE_GIT_HASH (if synced from Git) and VITE_BUILD_DATE env vars in the build script.

<img width="502" height="349" alt="image" src="https://github.com/user-attachments/assets/534eb3b2-dee3-4268-b940-aaef5cb4dd73" />


If it is built with "Latest from the Repository", then the Git Hash is included.

<img width="502" height="405" alt="image" src="https://github.com/user-attachments/assets/2c202935-6ff9-413b-954c-c09635a45601" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Build Info” section to the developer settings page.
  * Shows the app version, and—when available—build date and Git hash.
  * Build details appear conditionally so only existing metadata is displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->