### PR TITLE
Redirect to First Book In Collection if Current Book is Undefined

### DIFF
--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -88,6 +88,21 @@
     }
 
     let { data }: Props = $props();
+    $effect(() => {
+        const book = scriptureConfig?.bookCollections
+            ?.find((x) => x.id === $refs.collection)
+            ?.books.find((x) => x.id === $refs.book);
+        if (!book) {
+            console.log('No book!');
+            const books = scriptureConfig?.bookCollections?.find(
+                (x) => x.id === $refs.collection
+            )?.books;
+            console.log(books);
+            if (books && books.length > 0) {
+                $refs.book = books[0].id;
+            }
+        }
+    });
 
     let scrollingUp = $state(true);
     let savedScrollPosition = 0;

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -89,15 +89,11 @@
 
     let { data }: Props = $props();
     $effect(() => {
-        const book = scriptureConfig?.bookCollections
-            ?.find((x) => x.id === $refs.collection)
-            ?.books.find((x) => x.id === $refs.book);
+        const books = scriptureConfig?.bookCollections?.find(
+            (x) => x.id === $refs.collection
+        )?.books;
+        const book = books?.find((x) => x.id === $refs.book);
         if (!book) {
-            console.log('No book!');
-            const books = scriptureConfig?.bookCollections?.find(
-                (x) => x.id === $refs.collection
-            )?.books;
-            console.log(books);
             if (books && books.length > 0) {
                 $refs.book = books[0].id;
             }


### PR DESCRIPTION
Fixes #1028. The text route now checks if the current book is undefined, and if it is, it redirects to the first book in the collection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved book selection handling on the text page so it can recover from stale or invalid selections.
  * If the chosen book is no longer available in the selected collection, the page now automatically falls back to the first valid book.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->