### PR TITLE
Implement Quiz Access Codes

### DIFF
--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -679,8 +679,13 @@ export function parseBookCollections(document: Document, dataDir: string, verbos
             if (quizFeaturesTag) {
                 quizFeatures = {};
                 for (const quizFeature of quizFeaturesTag) {
-                    quizFeatures[quizFeature.attributes.getNamedItem('name')!.value] =
-                        parseConfigValue(quizFeature.attributes.getNamedItem('value')!.value);
+                    if (quizFeature.attributes.getNamedItem('name')!.value === 'access-code') {
+                        quizFeatures[quizFeature.attributes.getNamedItem('name')!.value] =
+                            quizFeature.attributes.getNamedItem('value')!.value; //The access code needs to be a string so it doesn't drop leading 0s.
+                    } else {
+                        quizFeatures[quizFeature.attributes.getNamedItem('name')!.value] =
+                            parseConfigValue(quizFeature.attributes.getNamedItem('value')!.value);
+                    }
                 }
             }
             const bkStyle = book.getElementsByTagName('styles-info')[0];

--- a/src/lib/data/quizUnlocked.ts
+++ b/src/lib/data/quizUnlocked.ts
@@ -1,0 +1,66 @@
+import { scriptureConfig } from '$assets/config';
+import { openDB, type DBSchema } from 'idb';
+
+export interface QuizSpecification {
+    collection: string;
+    book: string;
+    bookIndex: number;
+}
+
+interface QuizUnlocked extends DBSchema {
+    quizUnlocked: {
+        key: number;
+        value: QuizSpecification;
+        indexes: {
+            'collection, book': [string, string];
+        };
+    };
+}
+
+let quizDB: Awaited<ReturnType<typeof openDB<QuizUnlocked>>> | null = null;
+async function openQuizUnlocked() {
+    if (!quizDB) {
+        quizDB = await openDB<QuizUnlocked>('quizUnlocked', 1, {
+            upgrade(db) {
+                const quizStore = db.createObjectStore('quizUnlocked', {
+                    keyPath: 'bookIndex'
+                });
+                quizStore.createIndex('collection, book', ['collection', 'book']);
+            }
+        });
+    }
+    return quizDB;
+}
+
+export async function addQuizUnlocked(item: { collection: string; book: string }) {
+    try {
+        const quiz = await openQuizUnlocked();
+        if (!quiz) {
+            console.error('Failed to open quiz unlocked database');
+            return;
+        }
+        const bookCollection = scriptureConfig.bookCollections?.find(
+            (x) => x.id === item.collection
+        );
+        const bookIndex = bookCollection?.books.findIndex((x) => x.id === item.book);
+
+        if (bookIndex !== undefined && bookIndex >= 0) {
+            const nextItem = {
+                ...item,
+                bookIndex: bookIndex
+            };
+            await quiz.add('quizUnlocked', nextItem);
+        }
+    } catch (error) {
+        console.error('Error adding quiz unlock:', error);
+    }
+}
+
+export async function checkQuizUnlocked(quizId: string) {
+    const quiz = await openQuizUnlocked();
+    const result: QuizSpecification[] = await quiz.getAllFromIndex(
+        'quizUnlocked',
+        'collection, book'
+    );
+    return result.some((item) => item.book === quizId);
+}

--- a/src/lib/data/quizUnlocked.ts
+++ b/src/lib/data/quizUnlocked.ts
@@ -4,12 +4,11 @@ import { openDB, type DBSchema } from 'idb';
 export interface QuizSpecification {
     collection: string;
     book: string;
-    bookIndex: number;
 }
 
 interface QuizUnlocked extends DBSchema {
     quizUnlocked: {
-        key: number;
+        key: [string, string];
         value: QuizSpecification;
         indexes: {
             'collection, book': [string, string];
@@ -23,9 +22,9 @@ async function openQuizUnlocked() {
         quizDB = await openDB<QuizUnlocked>('quizUnlocked', 1, {
             upgrade(db) {
                 const quizStore = db.createObjectStore('quizUnlocked', {
-                    keyPath: 'bookIndex'
+                    keyPath: ['collection', 'book']
                 });
-                quizStore.createIndex('collection, book', ['collection', 'book']);
+                quizStore.createIndex('collection, book', ['collection', 'book'], { unique: true });
             }
         });
     }
@@ -39,28 +38,13 @@ export async function addQuizUnlocked(item: { collection: string; book: string }
             console.error('Failed to open quiz unlocked database');
             return;
         }
-        const bookCollection = scriptureConfig.bookCollections?.find(
-            (x) => x.id === item.collection
-        );
-        const bookIndex = bookCollection?.books.findIndex((x) => x.id === item.book);
-
-        if (bookIndex !== undefined && bookIndex >= 0) {
-            const nextItem = {
-                ...item,
-                bookIndex: bookIndex
-            };
-            await quiz.add('quizUnlocked', nextItem);
-        }
+        await quiz.add('quizUnlocked', item);
     } catch (error) {
         console.error('Error adding quiz unlock:', error);
     }
 }
 
-export async function checkQuizUnlocked(quizId: string) {
+export async function checkQuizUnlocked(item: { collection: string; book: string }) {
     const quiz = await openQuizUnlocked();
-    const result: QuizSpecification[] = await quiz.getAllFromIndex(
-        'quizUnlocked',
-        'collection, book'
-    );
-    return result.some((item) => item.book === quizId);
+    return Boolean(await quiz.get('quizUnlocked', [item.collection, item.book]));
 }

--- a/src/lib/icons/BackspaceIcon.svelte
+++ b/src/lib/icons/BackspaceIcon.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+    // Backspace from https://fonts.google.com/icons
+    // Filled = 0
+    // Weight = 400
+    // Grade = 0
+    // Optical size = 24px
+    let { color = 'black' } = $props();
+</script>
+
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="24px"
+    viewBox="0 -960 960 960"
+    width="24px"
+    fill={color}
+    ><path
+        d="m456-320 104-104 104 104 56-56-104-104 104-104-56-56-104 104-104-104-56 56 104 104-104 104 56 56Zm-96 160q-19 0-36-8.5T296-192L80-480l216-288q11-15 28-23.5t36-8.5h440q33 0 56.5 23.5T880-720v480q0 33-23.5 56.5T800-160H360ZM180-480l180 240h440v-480H360L180-480Zm400 0Z"
+    /></svg
+>

--- a/src/lib/icons/LockOpenIcon.svelte
+++ b/src/lib/icons/LockOpenIcon.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+    // Lock Open from https://fonts.google.com/icons
+    // Filled = 1
+    // Weight = 400
+    // Grade = 0
+    // Optical size = 24px
+    let { color = 'black' } = $props();
+</script>
+
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="24px"
+    viewBox="0 -960 960 960"
+    width="24px"
+    fill={color}
+    ><path
+        d="M240-640h360v-80q0-50-35-85t-85-35q-50 0-85 35t-35 85h-80q0-83 58.5-141.5T480-920q83 0 141.5 58.5T680-720v80h40q33 0 56.5 23.5T800-560v400q0 33-23.5 56.5T720-80H240q-33 0-56.5-23.5T160-160v-400q0-33 23.5-56.5T240-640Zm296.5 336.5Q560-327 560-360t-23.5-56.5Q513-440 480-440t-56.5 23.5Q400-393 400-360t23.5 56.5Q447-280 480-280t56.5-23.5Z"
+    /></svg
+>

--- a/src/lib/icons/index.ts
+++ b/src/lib/icons/index.ts
@@ -4,6 +4,7 @@ import AccountIcon from './AccountIcon.svelte';
 import ArrowBackIcon from './ArrowBackIcon.svelte';
 import ArrowForwardIcon from './ArrowForwardIcon.svelte';
 import { AudioIcon } from './audio';
+import BackspaceIcon from './BackspaceIcon.svelte';
 import BibleIcon from './BibleIcon.svelte';
 import BookmarkIcon from './BookmarkIcon.svelte';
 import BookmarkOutlineIcon from './BookmarkOutlineIcon.svelte';
@@ -26,6 +27,7 @@ import HomeIcon from './HomeIcon.svelte';
 import { ImageIcon } from './image';
 import InfoIcon from './InfoIcon.svelte';
 import LaunchIcon from './LaunchIcon.svelte';
+import LockOpenIcon from './LockOpenIcon.svelte';
 import MoreVertIcon from './MoreVertIcon.svelte';
 import NoteIcon from './NoteIcon.svelte';
 import SearchIcon from './SearchIcon.svelte';
@@ -45,6 +47,7 @@ export {
     ArrowBackIcon,
     ArrowForwardIcon,
     AudioIcon,
+    BackspaceIcon,
     BibleIcon,
     BookmarkIcon,
     BookmarkOutlineIcon,
@@ -66,6 +69,7 @@ export {
     ImageIcon,
     InfoIcon,
     LaunchIcon,
+    LockOpenIcon,
     MoreVertIcon,
     NoteIcon,
     SearchIcon,

--- a/src/routes/quiz/[collection]/[id]/+page.svelte
+++ b/src/routes/quiz/[collection]/[id]/+page.svelte
@@ -259,10 +259,7 @@
     }
     function attemptUnlock() {
         if (accessCode?.toString() === passwordInput) {
-            if (book?.quizFeatures) {
-                locked = false;
-                addQuizUnlocked({ collection, book: quizId }).then(() => invalidateAll());
-            }
+            addQuizUnlocked({ collection, book: quizId }).then(() => invalidateAll());
         }
     }
     function handleKeyInput(e: KeyboardEvent) {
@@ -317,7 +314,7 @@
     {#if locked}
         {#if data.dependentQuizName || data.dependentQuizId}
             <div class="quiz-locked">
-                <div class="quiz-locked-title">{quizId}</div>
+                <div class="quiz-locked-title">{displayLabel}</div>
                 <div class="quiz-locked-message">
                     {$t['Quiz_Access_After_Message']}
                 </div>
@@ -325,7 +322,7 @@
             </div>
         {:else if accessCode}
             <div class="quiz-locked">
-                <div class="quiz-locked-title">{quizId}</div>
+                <div class="quiz-locked-title">{displayLabel}</div>
                 <div class="quiz-locked-message">
                     {$t['Quiz_Access_Code_Message']}
                 </div>

--- a/src/routes/quiz/[collection]/[id]/+page.svelte
+++ b/src/routes/quiz/[collection]/[id]/+page.svelte
@@ -321,9 +321,9 @@
                 <div class="quiz-locked-name">{data.dependentQuizName || data.dependentQuizId}</div>
             </div>
         {:else if accessCode}
-            <div class="quiz-locked">
-                <div class="quiz-locked-title">{displayLabel}</div>
-                <div class="quiz-locked-message">
+            <div class="quiz-keypad max-w-breakpoint-md mx-auto">
+                <div class="quiz-keypad-title">{displayLabel}</div>
+                <div class="quiz-keypad-message">
                     {$t['Quiz_Access_Code_Message']}
                 </div>
                 <input
@@ -333,41 +333,41 @@
                     readonly
                     onkeydown={handleKeyInput}
                 />
-            </div>
-            <div class="grid grid-cols-3 gap-4 text-center p-10 text-[30px]">
-                {#each Array(9) as _, i}
+                <div class="grid grid-cols-3 gap-4 text-center p-10 text-[30px]">
+                    {#each Array(9) as _, i}
+                        <!-- svelte-ignore a11y_click_events_have_key_events -->
+                        <!-- svelte-ignore a11y_no_static_element_interactions -->
+                        <div
+                            class="m-[5px] py-[15px] bg-white active:bg-gray-300 select-none"
+                            onclick={() => addNumber(i + 1)}
+                        >
+                            {i + 1}
+                        </div>
+                    {/each}
+                    <!-- svelte-ignore a11y_click_events_have_key_events -->
+                    <!-- svelte-ignore a11y_no_static_element_interactions -->
+                    <div
+                        class="m-[5px] py-[15px] bg-white active:bg-gray-300 select-none flex justify-center items-center"
+                        onclick={backspaceInput}
+                    >
+                        <BackspaceIcon />
+                    </div>
                     <!-- svelte-ignore a11y_click_events_have_key_events -->
                     <!-- svelte-ignore a11y_no_static_element_interactions -->
                     <div
                         class="m-[5px] py-[15px] bg-white active:bg-gray-300 select-none"
-                        onclick={() => addNumber(i + 1)}
+                        onclick={() => addNumber(0)}
                     >
-                        {i + 1}
+                        0
                     </div>
-                {/each}
-                <!-- svelte-ignore a11y_click_events_have_key_events -->
-                <!-- svelte-ignore a11y_no_static_element_interactions -->
-                <div
-                    class="m-[5px] py-[15px] bg-white active:bg-gray-300 select-none flex justify-center items-center"
-                    onclick={backspaceInput}
-                >
-                    <BackspaceIcon />
-                </div>
-                <!-- svelte-ignore a11y_click_events_have_key_events -->
-                <!-- svelte-ignore a11y_no_static_element_interactions -->
-                <div
-                    class="m-[5px] py-[15px] bg-white active:bg-gray-300 select-none"
-                    onclick={() => addNumber(0)}
-                >
-                    0
-                </div>
-                <!-- svelte-ignore a11y_click_events_have_key_events -->
-                <!-- svelte-ignore a11y_no_static_element_interactions -->
-                <div
-                    class="m-[5px] py-[15px] bg-white active:bg-gray-300 select-none flex justify-center items-center"
-                    onclick={attemptUnlock}
-                >
-                    <LockOpenIcon />
+                    <!-- svelte-ignore a11y_click_events_have_key_events -->
+                    <!-- svelte-ignore a11y_no_static_element_interactions -->
+                    <div
+                        class="m-[5px] py-[15px] bg-white active:bg-gray-300 select-none flex justify-center items-center"
+                        onclick={attemptUnlock}
+                    >
+                        <LockOpenIcon />
+                    </div>
                 </div>
             </div>
         {/if}

--- a/src/routes/quiz/[collection]/[id]/+page.svelte
+++ b/src/routes/quiz/[collection]/[id]/+page.svelte
@@ -35,7 +35,13 @@
         t
     } from '$lib/data/stores';
     import { refs } from '$lib/data/stores/scripture';
-    import { ArrowForwardIcon, AudioIcon, TextAppearanceIcon } from '$lib/icons';
+    import {
+        ArrowForwardIcon,
+        AudioIcon,
+        BackspaceIcon,
+        LockOpenIcon,
+        TextAppearanceIcon
+    } from '$lib/icons';
     import { compareVersions } from '$lib/scripts/stringUtils';
     import { onDestroy } from 'svelte';
     import type { ClassValue } from 'svelte/elements';
@@ -61,13 +67,12 @@
         query: '?url',
         base: '/src/gen-assets/quiz'
     });
-
     interface Props {
         data: PageData;
     }
     let { data }: Props = $props();
 
-    let { locked, quiz, quizId, displayLabel, passScore, collection } = $derived(data);
+    let { locked, accessCode, quiz, quizId, displayLabel, passScore, collection } = $derived(data);
 
     let highlightIdx = $state(-1);
     let score = $state(0);
@@ -78,6 +83,7 @@
     let showCorrectAnswer = $state(false);
 
     let currentAudio: HTMLAudioElement | null = null;
+    let passwordInput = $state('');
 
     let explanation = $state('');
 
@@ -242,6 +248,21 @@
             reset();
         }
     });
+    function addNumber(number: number) {
+        passwordInput += number;
+    }
+    function backspaceInput() {
+        if (passwordInput.length > 0) {
+            passwordInput = passwordInput.slice(0, -1);
+        }
+    }
+    function attemptUnlock() {
+        if (accessCode?.toString() === passwordInput) {
+            console.log('Matches');
+        } else {
+            console.log("Doesn't match");
+        }
+    }
 </script>
 
 <div class="grid grid-rows-[auto_1fr] h-screen overflow-y-auto" style:font-size="{$bodyFontSize}px">
@@ -281,13 +302,64 @@
     </div>
 
     {#if locked}
-        <div class="quiz-locked">
-            <div class="quiz-locked-title">{quizId}</div>
-            <div class="quiz-locked-message">
-                {$t['Quiz_Access_After_Message']}
+        {#if data.dependentQuizName || data.dependentQuizId}
+            <div class="quiz-locked">
+                <div class="quiz-locked-title">{quizId}</div>
+                <div class="quiz-locked-message">
+                    {$t['Quiz_Access_After_Message']}
+                </div>
+                <div class="quiz-locked-name">{data.dependentQuizName || data.dependentQuizId}</div>
             </div>
-            <div class="quiz-locked-name">{data.dependentQuizName || data.dependentQuizId}</div>
-        </div>
+        {:else if accessCode}
+            <div class="quiz-locked">
+                <div class="quiz-locked-title">{quizId}</div>
+                <div class="quiz-locked-message">
+                    {$t['Quiz_Access_Code_Message']}
+                </div>
+                <input
+                    id="input-box"
+                    class="text-black w-[90%] text-[30px] text-center p-[10px] border bg-white mx-auto block"
+                    bind:value={passwordInput}
+                    readonly
+                />
+            </div>
+            <div class="grid grid-cols-3 gap-4 text-center p-10 text-[30px]">
+                {#each Array(9) as _, i}
+                    <!-- svelte-ignore a11y_click_events_have_key_events -->
+                    <!-- svelte-ignore a11y_no_static_element_interactions -->
+                    <div
+                        class="m-[5px] py-[15px] bg-white active:bg-gray-300 select-none"
+                        onclick={() => addNumber(i + 1)}
+                    >
+                        {i + 1}
+                    </div>
+                {/each}
+                <!-- svelte-ignore a11y_click_events_have_key_events -->
+                <!-- svelte-ignore a11y_no_static_element_interactions -->
+                <div
+                    class="m-[5px] py-[15px] bg-white active:bg-gray-300 select-none flex justify-center items-center"
+                    onclick={backspaceInput}
+                >
+                    <BackspaceIcon />
+                </div>
+                <!-- svelte-ignore a11y_click_events_have_key_events -->
+                <!-- svelte-ignore a11y_no_static_element_interactions -->
+                <div
+                    class="m-[5px] py-[15px] bg-white active:bg-gray-300 select-none"
+                    onclick={() => addNumber(0)}
+                >
+                    0
+                </div>
+                <!-- svelte-ignore a11y_click_events_have_key_events -->
+                <!-- svelte-ignore a11y_no_static_element_interactions -->
+                <div
+                    class="m-[5px] py-[15px] bg-white active:bg-gray-300 select-none flex justify-center items-center"
+                    onclick={attemptUnlock}
+                >
+                    <LockOpenIcon />
+                </div>
+            </div>
+        {/if}
     {:else if currentQuestionIdx === questions.length}
         <div class="score">
             <div id="content" class="text-center">

--- a/src/routes/quiz/[collection]/[id]/+page.svelte
+++ b/src/routes/quiz/[collection]/[id]/+page.svelte
@@ -258,7 +258,7 @@
         }
     }
     function attemptUnlock() {
-        if (accessCode?.toString() === passwordInput) {
+        if (accessCode === passwordInput) {
             addQuizUnlocked({ collection, book: quizId }).then(() => invalidateAll());
         }
     }

--- a/src/routes/quiz/[collection]/[id]/+page.svelte
+++ b/src/routes/quiz/[collection]/[id]/+page.svelte
@@ -333,41 +333,19 @@
                     readonly
                     onkeydown={handleKeyInput}
                 />
-                <div class="grid grid-cols-3 gap-4 text-center p-10 text-[30px]">
+                <div class="grid grid-cols-3 gap-4 text-center p-10">
                     {#each Array(9) as _, i}
-                        <!-- svelte-ignore a11y_click_events_have_key_events -->
-                        <!-- svelte-ignore a11y_no_static_element_interactions -->
-                        <div
-                            class="m-[5px] py-[15px] bg-white active:bg-gray-300 select-none"
-                            onclick={() => addNumber(i + 1)}
-                        >
+                        <button class="quiz-keypad-button" onclick={() => addNumber(i + 1)}>
                             {i + 1}
-                        </div>
+                        </button>
                     {/each}
-                    <!-- svelte-ignore a11y_click_events_have_key_events -->
-                    <!-- svelte-ignore a11y_no_static_element_interactions -->
-                    <div
-                        class="m-[5px] py-[15px] bg-white active:bg-gray-300 select-none flex justify-center items-center"
-                        onclick={backspaceInput}
-                    >
+                    <button class="quiz-keypad-button" onclick={backspaceInput}>
                         <BackspaceIcon />
-                    </div>
-                    <!-- svelte-ignore a11y_click_events_have_key_events -->
-                    <!-- svelte-ignore a11y_no_static_element_interactions -->
-                    <div
-                        class="m-[5px] py-[15px] bg-white active:bg-gray-300 select-none"
-                        onclick={() => addNumber(0)}
-                    >
-                        0
-                    </div>
-                    <!-- svelte-ignore a11y_click_events_have_key_events -->
-                    <!-- svelte-ignore a11y_no_static_element_interactions -->
-                    <div
-                        class="m-[5px] py-[15px] bg-white active:bg-gray-300 select-none flex justify-center items-center"
-                        onclick={attemptUnlock}
-                    >
+                    </button>
+                    <button class="quiz-keypad-button" onclick={() => addNumber(0)}> 0 </button>
+                    <button class="quiz-keypad-button" onclick={attemptUnlock}>
                         <LockOpenIcon />
-                    </div>
+                    </button>
                 </div>
             </div>
         {/if}
@@ -490,5 +468,20 @@
     .quiz-question-block img {
         max-width: 100%;
         max-height: 250px;
+    }
+    .quiz-keypad-button {
+        margin: 5px 1%;
+        padding: 15px 0;
+        font-size: 30px;
+
+        background-color: white;
+        user-select: none;
+
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+    .quiz-keypad-button:active {
+        background-color: #d1d5db;
     }
 </style>

--- a/src/routes/quiz/[collection]/[id]/+page.svelte
+++ b/src/routes/quiz/[collection]/[id]/+page.svelte
@@ -265,6 +265,17 @@
             }
         }
     }
+    function handleKeyInput(e: KeyboardEvent) {
+        if (e.key >= '0' && e.key <= '9') {
+            addNumber(parseInt(e.key));
+        }
+        if (e.key === 'Backspace') {
+            backspaceInput();
+        }
+        if (e.key === 'Enter') {
+            attemptUnlock();
+        }
+    }
 </script>
 
 <div class="grid grid-rows-[auto_1fr] h-screen overflow-y-auto" style:font-size="{$bodyFontSize}px">
@@ -323,6 +334,7 @@
                     class="text-black w-[90%] text-[30px] text-center p-[10px] border bg-white mx-auto block"
                     bind:value={passwordInput}
                     readonly
+                    onkeydown={handleKeyInput}
                 />
             </div>
             <div class="grid grid-cols-3 gap-4 text-center p-10 text-[30px]">

--- a/src/routes/quiz/[collection]/[id]/+page.svelte
+++ b/src/routes/quiz/[collection]/[id]/+page.svelte
@@ -19,12 +19,13 @@
 </script>
 
 <script lang="ts">
-    import { beforeNavigate } from '$app/navigation';
+    import { beforeNavigate, invalidateAll } from '$app/navigation';
     import { scriptureConfig } from '$assets/config';
     import type { QuizAnswer, QuizQuestion } from '$config';
     import BookSelector from '$lib/components/BookSelector.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
     import { addQuiz } from '$lib/data/quiz';
+    import { addQuizUnlocked } from '$lib/data/quizUnlocked.js';
     import {
         actionBarColor,
         bodyFontSize,
@@ -258,9 +259,10 @@
     }
     function attemptUnlock() {
         if (accessCode?.toString() === passwordInput) {
-            console.log('Matches');
-        } else {
-            console.log("Doesn't match");
+            if (book?.quizFeatures) {
+                locked = false;
+                addQuizUnlocked({ collection, book: quizId }).then(() => invalidateAll());
+            }
         }
     }
 </script>

--- a/src/routes/quiz/[collection]/[id]/+page.ts
+++ b/src/routes/quiz/[collection]/[id]/+page.ts
@@ -1,6 +1,7 @@
 import config from '$assets/config';
 import type { Quiz, ScriptureConfig } from '$config';
 import { checkQuizAccess } from '$lib/data/quiz';
+import { checkQuizUnlocked } from '$lib/data/quizUnlocked';
 import type { PageLoad } from './$types';
 
 const quizzes: Record<string, string> = import.meta.glob('./**/quizzes/*.json', {
@@ -30,8 +31,11 @@ export const load: PageLoad = async ({ params, fetch }) => {
         locked = !accessGranted;
     }
     if (book?.quizFeatures?.['access-type'] === 'code' && book.quizFeatures['access-code']) {
-        locked = true; //It'll need to check to see if it's already been unlocked, but that hasn't been implemented yet
-        accessCode = book.quizFeatures['access-code'] as number;
+        const quizUnlocked = await checkQuizUnlocked(id);
+        if (!quizUnlocked) {
+            locked = true;
+            accessCode = book.quizFeatures['access-code'] as number;
+        }
     }
 
     if (locked && dependentQuizId) {

--- a/src/routes/quiz/[collection]/[id]/+page.ts
+++ b/src/routes/quiz/[collection]/[id]/+page.ts
@@ -22,11 +22,16 @@ export const load: PageLoad = async ({ params, fetch }) => {
     let locked = false;
     let dependentQuizId: string | null = null;
     let dependentQuizName: string | null = null;
+    let accessCode: number | null = null;
 
     if (book?.quizFeatures?.['access-type'] === 'after' && book.quizFeatures['access-after']) {
         dependentQuizId = book.quizFeatures['access-after'] as string;
         const accessGranted = await checkQuizAccess(dependentQuizId);
         locked = !accessGranted;
+    }
+    if (book?.quizFeatures?.['access-type'] === 'code' && book.quizFeatures['access-code']) {
+        locked = true; //It'll need to check to see if it's already been unlocked, but that hasn't been implemented yet
+        accessCode = book.quizFeatures['access-code'] as number;
     }
 
     if (locked && dependentQuizId) {
@@ -56,6 +61,7 @@ export const load: PageLoad = async ({ params, fetch }) => {
     return {
         quiz: quizData,
         locked,
+        accessCode,
         collection: params.collection,
         quizId: id,
         displayLabel: book?.name || 'Quiz',

--- a/src/routes/quiz/[collection]/[id]/+page.ts
+++ b/src/routes/quiz/[collection]/[id]/+page.ts
@@ -23,7 +23,7 @@ export const load: PageLoad = async ({ params, fetch }) => {
     let locked = false;
     let dependentQuizId: string | null = null;
     let dependentQuizName: string | null = null;
-    let accessCode: number | null = null;
+    let accessCode: string | null = null;
 
     if (book?.quizFeatures?.['access-type'] === 'after' && book.quizFeatures['access-after']) {
         dependentQuizId = book.quizFeatures['access-after'] as string;
@@ -37,7 +37,7 @@ export const load: PageLoad = async ({ params, fetch }) => {
                 : false;
         if (!quizUnlocked) {
             locked = true;
-            accessCode = book.quizFeatures['access-code'] as number;
+            accessCode = book.quizFeatures['access-code'] as string;
         }
     }
 

--- a/src/routes/quiz/[collection]/[id]/+page.ts
+++ b/src/routes/quiz/[collection]/[id]/+page.ts
@@ -31,7 +31,10 @@ export const load: PageLoad = async ({ params, fetch }) => {
         locked = !accessGranted;
     }
     if (book?.quizFeatures?.['access-type'] === 'code' && book.quizFeatures['access-code']) {
-        const quizUnlocked = await checkQuizUnlocked(id);
+        const quizUnlocked =
+            bookCollection && book
+                ? await checkQuizUnlocked({ collection: bookCollection?.id, book: book?.id })
+                : false;
         if (!quizUnlocked) {
             locked = true;
             accessCode = book.quizFeatures['access-code'] as number;


### PR DESCRIPTION
Resolve #551. If a quiz is set to require a password to enter, then when the quiz is navigated to, it will display a screen with a numpad to input the password. Once it is input, it does not need to be input again due to a database of unlocked quizzes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added code-based quiz access with a numeric keypad, backspace, and unlock control.
  * Persist unlock status locally so already-unlocked quizzes remain accessible on revisit.
  * Added backspace and open-lock icons for the unlock interface.
* **Bug Fixes**
  * Improved the locked quiz screen to correctly handle dependent quizzes vs access-code prompts.
  * Ensured configured access codes preserve leading zeros.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->