### PR TITLE
Give Modal Component Variable Styles

### DIFF
--- a/src/lib/components/CollectionModal.svelte
+++ b/src/lib/components/CollectionModal.svelte
@@ -96,7 +96,7 @@
     function handleOk() {}
 </script>
 
-<Modal bind:this={modal} {id}>
+<Modal bind:this={modal} {id} styling={'background-color:var(--BackgroundColor);'}>
     <div class="text-center">
         <div class="overflow-y-auto max-h-[80vh] p-1 text-left">
             <CollectionList

--- a/src/lib/components/CollectionModal.svelte
+++ b/src/lib/components/CollectionModal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { scriptureConfig } from '$assets/config';
-    import { selectedLayouts, t } from '$lib/data/stores';
+    import { selectedLayouts, t, themeColors } from '$lib/data/stores';
     import CollectionList from './CollectionList.svelte';
     import Modal from './Modal.svelte';
 
@@ -96,7 +96,7 @@
     function handleOk() {}
 </script>
 
-<Modal bind:this={modal} {id} styling="background-color:var(--BackgroundColor);">
+<Modal bind:this={modal} {id} styling="background-color:{$themeColors['BackgroundColor']};">
     <div class="text-center">
         <div class="overflow-y-auto max-h-[80vh] p-1 text-left">
             <CollectionList

--- a/src/lib/components/CollectionModal.svelte
+++ b/src/lib/components/CollectionModal.svelte
@@ -96,7 +96,7 @@
     function handleOk() {}
 </script>
 
-<Modal bind:this={modal} {id} styling={'background-color:var(--BackgroundColor);'}>
+<Modal bind:this={modal} {id} styling="background-color:var(--BackgroundColor);">
     <div class="text-center">
         <div class="overflow-y-auto max-h-[80vh] p-1 text-left">
             <CollectionList

--- a/src/lib/components/DownloadSelector.svelte
+++ b/src/lib/components/DownloadSelector.svelte
@@ -4,7 +4,7 @@ A component for verse-on-image providing a dropdown where you can choose to down
 -->
 
 <script lang="ts">
-    import { t } from '$lib/data/stores';
+    import { convertStyle, s, t } from '$lib/data/stores';
     import { ImageIcon, VideoIcon } from '$lib/icons';
     import Modal from './Modal.svelte';
 
@@ -23,7 +23,11 @@ A component for verse-on-image providing a dropdown where you can choose to down
 </script>
 
 <!-- svelte-ignore a11y_consider_explicit_label -->
-<Modal bind:this={modalThis} id={modalId} addCSS={positioningCSS}>
+<Modal
+    bind:this={modalThis}
+    id={modalId}
+    styling={'background-color:var(--PopupBackgroundColor);' + positioningCSS}
+>
     <div class="grid gap-2 m-2">
         <button
             class="dy-btn dy-btn-sm flex items-center justify-center gap-2"

--- a/src/lib/components/DownloadSelector.svelte
+++ b/src/lib/components/DownloadSelector.svelte
@@ -4,7 +4,7 @@ A component for verse-on-image providing a dropdown where you can choose to down
 -->
 
 <script lang="ts">
-    import { convertStyle, s, t } from '$lib/data/stores';
+    import { convertStyle, s, t, themeColors } from '$lib/data/stores';
     import { ImageIcon, VideoIcon } from '$lib/icons';
     import Modal from './Modal.svelte';
 
@@ -26,7 +26,7 @@ A component for verse-on-image providing a dropdown where you can choose to down
 <Modal
     bind:this={modalThis}
     id={modalId}
-    styling={'background-color:var(--PopupBackgroundColor);' + positioningCSS}
+    styling="background-color:{$themeColors['PopupBackgroundColor']}; {positioningCSS}"
 >
     <div class="grid gap-2 m-2">
         <button

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -15,13 +15,18 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
     interface Props {
         id: string;
         children?: Snippet;
-        addCSS?: string;
+        styling?: string;
         onclose?: () => void;
         dialog?: HTMLDialogElement;
     }
 
-    let { id, children, addCSS = '', onclose, dialog = $bindable() }: Props = $props();
-
+    let {
+        id,
+        children,
+        styling = convertStyle($s?.['ui.dialog']),
+        onclose,
+        dialog = $bindable()
+    }: Props = $props();
     /**
      * This exported function allows buttons/labels
      * in other divs to trigger the modal popup
@@ -38,11 +43,7 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
     class="dy-modal cursor-pointer"
     style:direction={$direction}
 >
-    <form
-        method="dialog"
-        style={convertStyle($s?.['ui.dialog']) + addCSS}
-        class="dy-modal-box overflow-y-visible relative"
-    >
+    <form method="dialog" style={styling} class="dy-modal-box overflow-y-visible relative">
         {@render children?.()}
         <!--This is the snippet for the popup's actual contents-->
     </form>

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -23,7 +23,7 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
     let {
         id,
         children,
-        styling = convertStyle($s?.['ui.dialog']),
+        styling = 'background-color:var(--DialogBackgroundColor);',
         onclose,
         dialog = $bindable()
     }: Props = $props();

--- a/src/lib/components/Modal.svelte
+++ b/src/lib/components/Modal.svelte
@@ -9,7 +9,7 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
 @prop { Function } onclose - Function to run when Modal closes.
 -->
 <script lang="ts">
-    import { convertStyle, direction, s } from '$lib/data/stores';
+    import { direction, themeColors } from '$lib/data/stores';
     import type { Snippet } from 'svelte';
 
     interface Props {
@@ -23,7 +23,7 @@ See https://daisyui.com/components/modal/#modal-that-closes-when-clicked-outside
     let {
         id,
         children,
-        styling = 'background-color:var(--DialogBackgroundColor);',
+        styling = `background-color:${$themeColors['DialogBackgroundColor']};`,
         onclose,
         dialog = $bindable()
     }: Props = $props();

--- a/src/lib/components/NoteDialog.svelte
+++ b/src/lib/components/NoteDialog.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
-    import { bodyFontSize, currentFont } from '$lib/data/stores';
+    import { bodyFontSize, currentFont, themeColors } from '$lib/data/stores';
     import { EditIcon } from '$lib/icons';
     import { resolve } from '$lib/utils/paths';
     import Modal from './Modal.svelte';
@@ -32,7 +32,7 @@
     bind:this={modal}
     {id}
     onclose={reset}
-    styling="background-color:var(--PopupBackgroundColor);"
+    styling="background-color:{$themeColors['PopupBackgroundColor']};"
 >
     <div class="flex flex-col justify-evenly">
         <div class="w-full flex justify-between items-center">

--- a/src/lib/components/NoteDialog.svelte
+++ b/src/lib/components/NoteDialog.svelte
@@ -32,7 +32,7 @@
     bind:this={modal}
     {id}
     onclose={reset}
-    styling={'background-color:var(--PopupBackgroundColor);'}
+    styling="background-color:var(--PopupBackgroundColor);"
 >
     <div class="flex flex-col justify-evenly">
         <div class="w-full flex justify-between items-center">

--- a/src/lib/components/NoteDialog.svelte
+++ b/src/lib/components/NoteDialog.svelte
@@ -28,7 +28,12 @@
     }
 </script>
 
-<Modal bind:this={modal} {id} onclose={reset}>
+<Modal
+    bind:this={modal}
+    {id}
+    onclose={reset}
+    styling={'background-color:var(--PopupBackgroundColor);'}
+>
     <div class="flex flex-col justify-evenly">
         <div class="w-full flex justify-between items-center">
             <div class="w-full pb-3" style:font-weight="bold">

--- a/src/lib/components/TextAppearanceSelector.svelte
+++ b/src/lib/components/TextAppearanceSelector.svelte
@@ -142,7 +142,7 @@ The navbar component. We have sliders that update reactively to both font size a
     <Modal
         bind:dialog={modalThis}
         id={modalId}
-        styling={'background-color:var(--PopupBackgroundColor);' + positioningCSS}
+        styling="background-color:{$themeColors['PopupBackgroundColor']}; {positioningCSS}"
     >
         <div class="grid gap-4">
             <!-- Sliders for when text appearence text size is implemented place holder no functionality-->

--- a/src/lib/components/TextAppearanceSelector.svelte
+++ b/src/lib/components/TextAppearanceSelector.svelte
@@ -139,7 +139,11 @@ The navbar component. We have sliders that update reactively to both font size a
 <!-- TextAppearanceSelector -->
 {#if _showTextAppearance}
     <!-- svelte-ignore a11y_consider_explicit_label -->
-    <Modal bind:dialog={modalThis} id={modalId} addCSS={positioningCSS}>
+    <Modal
+        bind:dialog={modalThis}
+        id={modalId}
+        styling={'background-color:var(--PopupBackgroundColor);' + positioningCSS}
+    >
         <div class="grid gap-4">
             <!-- Sliders for when text appearence text size is implemented place holder no functionality-->
             {#if _showFontSize}
@@ -162,7 +166,7 @@ The navbar component. We have sliders that update reactively to both font size a
                             max={config.mainFeatures['text-size-max'] as number}
                         />
                     {/if}
-                    <div class="text-md text-{$monoIconColor} place-self-end">
+                    <div class="text-base text-{$monoIconColor} place-self-end">
                         {contentsMode ? $contentsFontSize : $bodyFontSize}
                     </div>
                 </div>
@@ -177,7 +181,7 @@ The navbar component. We have sliders that update reactively to both font size a
                         min={100}
                         max={250}
                     />
-                    <div class="text-md text-{$monoIconColor} place-self-end">
+                    <div class="text-base text-{$monoIconColor} place-self-end">
                         {formatLineHeight($bodyLineHeight)}
                     </div>
                 </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -136,25 +136,6 @@
 </svelte:head>
 
 {#if showPage}
-    <div>
-        <!--Div containing the popup modals triggered by the navBar buttons and SideBar entries -->
-
-        {#if isSAB}
-            <!-- Add Note Menu -->
-            <NoteDialog bind:this={noteDialog} />
-        {/if}
-
-        <FontSelector bind:this={fontSelector} />
-
-        <PlanStopDialog
-            bind:this={planStopDialog}
-            bind:planId={planStopId}
-            vertOffset={NAVBAR_HEIGHT}
-        />
-
-        <AudioPlaybackSpeed bind:this={audioPlaybackSpeed} />
-    </div>
-
     <Sidebar>
         <div
             id="container"
@@ -162,9 +143,27 @@
             style="height:100vh;height:100dvh;margin:0;"
             style:direction={$direction}
         >
-            <!-- Text Appearance Options Menu -->
-            <TextAppearanceSelector bind:this={textAppearanceSelector} vertOffset={NAVBAR_HEIGHT} />
-            <CollectionModal bind:this={collectionModal} />
+            <div>
+                <!--Div containing the popup modals triggered by the navBar buttons and SideBar entries -->
+
+                {#if isSAB}
+                    <!-- Add Note Menu -->
+                    <NoteDialog bind:this={noteDialog} />
+                {/if}
+                <!-- Text Appearance Options Menu -->
+                <TextAppearanceSelector
+                    bind:this={textAppearanceSelector}
+                    vertOffset={NAVBAR_HEIGHT}
+                />
+                <CollectionModal bind:this={collectionModal} />
+                <PlanStopDialog
+                    bind:this={planStopDialog}
+                    bind:planId={planStopId}
+                    vertOffset={NAVBAR_HEIGHT}
+                />
+                <AudioPlaybackSpeed bind:this={audioPlaybackSpeed} />
+                <FontSelector bind:this={fontSelector} />
+            </div>
             {@render children()}
         </div>
     </Sidebar>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -143,8 +143,6 @@
             <!-- Add Note Menu -->
             <NoteDialog bind:this={noteDialog} />
         {/if}
-        <!-- Text Appearance Options Menu -->
-        <TextAppearanceSelector bind:this={textAppearanceSelector} vertOffset={NAVBAR_HEIGHT} />
 
         <FontSelector bind:this={fontSelector} />
 
@@ -164,6 +162,8 @@
             style="height:100vh;height:100dvh;margin:0;"
             style:direction={$direction}
         >
+            <!-- Text Appearance Options Menu -->
+            <TextAppearanceSelector bind:this={textAppearanceSelector} vertOffset={NAVBAR_HEIGHT} />
             <CollectionModal bind:this={collectionModal} />
             {@render children()}
         </div>


### PR DESCRIPTION
Closes #1018. The Modal component now has a property that allows its styling to be specified instead of being hardcoded, and each component that used the Modal now has its styling matching that of the native app. They were also moved inside the container div in +layout.svelte so they could use the CSS styling variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dialogs and modals to use consistent, theme-based background styling for improved visual uniformity.
  * Refined text appearance controls so numeric font-size and line-height labels display more clearly.
* **Refactor**
  * Reorganized where popup dialogs render within the sidebar for a cleaner, more reliable layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->