### PR TITLE
Implement verse by verse layout

### DIFF
--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -1606,10 +1606,10 @@ function filterFeaturesNotReady(data: ScriptureConfig | DictionaryConfig) {
 
     // Two pane and Verse-By-Verse are not done
     if (isScriptureConfig(data)) {
-        // Two pane and Verse-By-Verse are not done
+        // Two pane is not done
         if (data.layouts) {
             for (const layout of data.layouts) {
-                if (layout.mode === 'two' || layout.mode === 'verse-by-verse') {
+                if (layout.mode === 'two') {
                     layout.enabled = false;
                 }
             }

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -61,7 +61,6 @@ LOGGING:
         monoIconColor,
         plan,
         refs,
-        selectedLayouts,
         t,
         userSettings
     } from '$lib/data/stores';
@@ -1924,10 +1923,12 @@ LOGGING:
                                 }
 
                                 if (verseByVerseMode) {
-                                    workspace.paragraphDiv.appendChild(
-                                        workspace.verseByVerseDivRoot.cloneNode(true)
-                                    );
-                                    workspace.verseByVerseDivRoot = null;
+                                    if (workspace.verseByVerseDivRoot) {
+                                        workspace.paragraphDiv.appendChild(
+                                            workspace.verseByVerseDivRoot.cloneNode(true)
+                                        );
+                                        workspace.verseByVerseDivRoot = null;
+                                    }
                                 }
 
                                 workspace.phraseDiv = null;

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -321,7 +321,10 @@ LOGGING:
                     break;
             }
             const phraseIndex = createLetterIndex(workspace.currentPhraseIndex);
-            div.id = workspace.currentVerse + phraseIndex;
+
+            if (!verseByVerseMode || timesRendered === 1) {
+                div.id = workspace.currentVerse + phraseIndex;
+            }
             div.setAttribute('data-verse', workspace.currentVerse);
             div.setAttribute('data-phrase', phraseIndex);
             div.classList.add('txs', 'seltxt', 'scroll-item');

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -2246,7 +2246,9 @@ LOGGING:
                                         if (scriptureLogs?.sequence) {
                                             console.log('TITLE DIV %o', div);
                                         }
-                                        workspace.root.append(div);
+                                        if (timesRendered === 1) {
+                                            workspace.root.append(div);
+                                        }
                                         break;
                                     }
                                     case 'heading': {

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -165,6 +165,7 @@ LOGGING:
     }
     const layoutMode = $derived($layout.mode);
     const verseByVerseMode = $derived(layoutMode === 'verse-by-verse');
+    let currentCollection: string;
     let planDivObserver = $state(null); // To store the observer instance
     let planObservationCompleted = $state(false);
     // Function to observe the visibility of the plan div
@@ -1834,6 +1835,10 @@ LOGGING:
                                     workspace.verseDiv.classList.add('verse-block');
                                 }
                                 if (verseByVerseMode) {
+                                    const collectionDirection =
+                                        scriptureConfig.bookCollections?.find(
+                                            (x) => x.languageCode + '_' + x.id === currentCollection
+                                        )?.style?.textDirection;
                                     if (timesRendered > 1) {
                                         workspace.verseByVerseDivRoot = document.getElementById(
                                             'verseblock-' + element.atts['number']
@@ -1849,6 +1854,10 @@ LOGGING:
                                         workspace.currentVerseByVerseDiv.classList.add(
                                             'verse-by-verse-' + (timesRendered - 1)
                                         );
+                                        if (collectionDirection) {
+                                            workspace.currentVerseByVerseDiv.style.direction =
+                                                collectionDirection.toLowerCase();
+                                        }
                                         workspace.verseByVerseDivRoot?.appendChild(
                                             workspace.currentVerseByVerseDiv
                                         );
@@ -2713,6 +2722,7 @@ LOGGING:
         performance.mark('cl-render-start');
         // Parse whole book if no chapters
         if (chapterCount(currentBook) === 0) {
+            currentCollection = docSet;
             cl.renderDocument({ docId, config: {}, output });
             if (verseByVerseMode) {
                 if ($layout.auxDocSets?.length && $layout.auxDocSets.length > 0) {
@@ -2725,12 +2735,14 @@ LOGGING:
                         }
                         const docId = bookLookup[bookCode];
                         if (docId) {
+                            currentCollection = $layout.auxDocSets[i];
                             cl.renderDocument({ docId, config: {}, output });
                         }
                     }
                 }
             }
         } else {
+            currentCollection = docSet;
             cl.renderDocument({ docId, config: { chapters: [chapter] }, output });
             if (verseByVerseMode) {
                 if ($layout.auxDocSets?.length && $layout.auxDocSets.length > 0) {
@@ -2743,6 +2755,7 @@ LOGGING:
                         }
                         const docId = bookLookup[bookCode];
                         if (docId) {
+                            currentCollection = $layout.auxDocSets[i];
                             cl.renderDocument({ docId, config: { chapters: [chapter] }, output });
                         }
                     }

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -54,12 +54,14 @@ LOGGING:
         currentPlanState,
         footnotes,
         language,
+        layout,
         logs,
         modal,
         ModalType,
         monoIconColor,
         plan,
         refs,
+        selectedLayouts,
         t,
         userSettings
     } from '$lib/data/stores';
@@ -143,6 +145,12 @@ LOGGING:
 
     let container: HTMLElement = $state();
     let displayingIntroduction = $state(false);
+    let timesRendered = $state(0);
+    $effect(() => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+        $refs;
+        timesRendered = 0;
+    });
 
     const fnc = 'abcdefghijklmnopqrstuvwxyz';
     /** calculate letter index from number
@@ -155,6 +163,8 @@ LOGGING:
             fnc.charAt(index % fnc.length)
         );
     }
+    const layoutMode = $derived($layout.mode);
+    const verseByVerseMode = $derived(layoutMode === 'verse-by-verse');
     let planDivObserver = $state(null); // To store the observer instance
     let planObservationCompleted = $state(false);
     // Function to observe the visibility of the plan div
@@ -567,7 +577,9 @@ LOGGING:
     };
     function appendPhrase(workspace) {
         workspace.lastPhrase = workspace.phraseDiv.getAttribute('data-phrase');
-        if (versePerLine) {
+        if (verseByVerseMode) {
+            workspace.currentVerseByVerseDiv.appendChild(workspace.phraseDiv.cloneNode(true));
+        } else if (versePerLine) {
             workspace.verseDiv.appendChild(workspace.phraseDiv.cloneNode(true));
         } else {
             workspace.paragraphDiv.appendChild(workspace.phraseDiv.cloneNode(true));
@@ -614,11 +626,15 @@ LOGGING:
                 // chapter at top of page
                 div.classList.add('c');
                 div.innerText = workspace.chapterNumText;
-                workspace.root.appendChild(div);
-                addVerseNumber(workspace, element, showVerseNumbers);
+                if (timesRendered === 1) {
+                    workspace.root.appendChild(div);
+                    addVerseNumber(workspace, element, showVerseNumbers);
+                }
             }
         } else {
-            addVerseNumber(workspace, element, showVerseNumbers);
+            if (timesRendered === 1) {
+                addVerseNumber(workspace, element, showVerseNumbers);
+            }
         }
         workspace.firstVerse = false;
     }
@@ -1515,6 +1531,13 @@ LOGGING:
             return;
         }
         await loadDocSetIfNotLoaded(proskomma, docSet, fetch);
+        if (verseByVerseMode) {
+            if ($layout.auxDocSets?.length && $layout.auxDocSets.length > 0) {
+                for (const i in $layout.auxDocSets) {
+                    await loadDocSetIfNotLoaded(proskomma, $layout?.auxDocSets?.[i], fetch);
+                }
+            }
+        }
         const cl = new SofriaRenderFromProskomma({
             proskomma,
             actions: {
@@ -1530,8 +1553,11 @@ LOGGING:
                                     context.document.metadata.document
                                 );
                             }
+                            timesRendered = timesRendered + 1;
                             preprocessAction('startDocument', workspace);
-                            bookRoot.replaceChildren();
+                            if (timesRendered <= 1) {
+                                bookRoot.replaceChildren();
+                            }
                             workspace.root = bookRoot;
                             workspace.footnoteIndex = 0;
                             workspace.footnoteIdIndex = 0;
@@ -1717,37 +1743,6 @@ LOGGING:
                                     workspace.titleGraft
                                 )
                             ) {
-                                switch (sequenceType) {
-                                    case 'main': {
-                                        if (scriptureLogs?.paragraph) {
-                                            console.log('End main paragraph');
-                                        }
-                                        if (
-                                            workspace.phraseDiv != null &&
-                                            workspace.phraseDiv.innerText !== ''
-                                        ) {
-                                            appendPhrase(workspace);
-                                            workspace.phraseDiv = null;
-                                        }
-                                        if (versePerLine) {
-                                            if (workspace.verseDiv !== null) {
-                                                workspace.paragraphDiv.appendChild(
-                                                    workspace.verseDiv.cloneNode(true)
-                                                );
-                                                workspace.verseDiv = document.createElement('div');
-                                            }
-                                        }
-                                        // Build div
-                                        if (workspace.paragraphDiv.innerHTML !== '') {
-                                            workspace.root.appendChild(workspace.paragraphDiv);
-                                        }
-                                        if (workspace.videoDiv) {
-                                            workspace.root.appendChild(workspace.videoDiv);
-                                            workspace.videoDiv = null;
-                                        }
-                                        break;
-                                    }
-                                }
                                 if (sequenceType == 'main') {
                                     if (scriptureLogs?.paragraph) {
                                         console.log('End main paragraph');
@@ -1769,10 +1764,14 @@ LOGGING:
                                     }
                                     // Build div
                                     if (workspace.paragraphDiv.innerHTML !== '') {
-                                        workspace.root.appendChild(workspace.paragraphDiv);
+                                        if (timesRendered === 1) {
+                                            workspace.root.appendChild(workspace.paragraphDiv);
+                                        }
                                     }
                                     if (workspace.videoDiv) {
-                                        workspace.root.appendChild(workspace.videoDiv);
+                                        if (timesRendered === 1) {
+                                            workspace.root.appendChild(workspace.videoDiv);
+                                        }
                                         workspace.videoDiv = null;
                                     }
                                 } else if (sequenceType == 'title') {
@@ -1786,7 +1785,9 @@ LOGGING:
                                     workspace.titleSpan = null;
                                 } else if (sequenceType == 'heading') {
                                     workspace.headerDiv.appendChild(workspace.headerInnerDiv);
-                                    workspace.root.appendChild(workspace.headerDiv);
+                                    if (timesRendered === 1) {
+                                        workspace.root.appendChild(workspace.headerDiv);
+                                    }
                                     workspace.headerInnerDiv = null;
                                     workspace.headerDiv = null;
                                 } else if (sequenceType == 'introduction') {
@@ -1797,7 +1798,9 @@ LOGGING:
                                         appendPhrase(workspace);
                                         workspace.phraseDiv = null;
                                     }
-                                    workspace.root.appendChild(workspace.paragraphDiv);
+                                    if (timesRendered === 1) {
+                                        workspace.root.appendChild(workspace.paragraphDiv);
+                                    }
                                 }
                             }
                         }
@@ -1824,6 +1827,34 @@ LOGGING:
                                 if (versePerLine) {
                                     workspace.verseDiv = document.createElement('div');
                                     workspace.verseDiv.classList.add('verse-block');
+                                }
+                                if (verseByVerseMode) {
+                                    if (timesRendered > 1) {
+                                        workspace.verseByVerseDivRoot = document.getElementById(
+                                            'verseblock-' + element.atts['number']
+                                        );
+                                        workspace.currentVerseByVerseDiv =
+                                            document.createElement('div');
+                                        workspace.currentVerseByVerseDiv.classList.add(
+                                            'verse-by-verse-verse'
+                                        );
+                                        workspace.currentVerseByVerseDiv.classList.add(
+                                            'verse-by-verse-block'
+                                        );
+                                        workspace.currentVerseByVerseDiv.classList.add(
+                                            'verse-by-verse-' + (timesRendered - 1)
+                                        );
+                                        workspace.verseByVerseDivRoot.appendChild(
+                                            workspace.currentVerseByVerseDiv
+                                        );
+                                    } else {
+                                        workspace.verseByVerseDivRoot =
+                                            document.createElement('div');
+                                        workspace.verseByVerseDivRoot.id =
+                                            'verseblock-' + element.atts['number'];
+                                        workspace.currentVerseByVerseDiv =
+                                            workspace.verseByVerseDivRoot;
+                                    }
                                 }
                                 if (scriptureLogs?.verses) {
                                     console.log('IN: %o', workspace.phraseDiv);
@@ -1860,6 +1891,14 @@ LOGGING:
                                     );
                                     workspace.verseDiv = null;
                                 }
+
+                                if (verseByVerseMode) {
+                                    workspace.paragraphDiv.appendChild(
+                                        workspace.verseByVerseDivRoot.cloneNode(true)
+                                    );
+                                    workspace.verseByVerseDivRoot = null;
+                                }
+
                                 workspace.phraseDiv = null;
                                 addBookmarksDiv(workspace);
                                 addNotesDiv(workspace);
@@ -2069,7 +2108,9 @@ LOGGING:
                                                 // chapter at top of page
                                                 div.classList.add('c');
                                                 div.innerText = workspace.chapterNumText;
-                                                workspace.root.appendChild(div);
+                                                if (timesRendered === 1) {
+                                                    workspace.root.appendChild(div);
+                                                }
                                             }
                                             workspace.chapterNumText = '';
                                         }
@@ -2670,6 +2711,20 @@ LOGGING:
             cl.renderDocument({ docId, config: {}, output });
         } else {
             cl.renderDocument({ docId, config: { chapters: [chapter] }, output });
+            if (verseByVerseMode) {
+                if ($layout.auxDocSets?.length && $layout.auxDocSets.length > 0) {
+                    for (const i in $layout.auxDocSets) {
+                        const bookLookup = {};
+                        for (const docRecord of docsResult.data.documents) {
+                            if (docRecord.docSetId === $layout.auxDocSets[i]) {
+                                bookLookup[docRecord.bookCode] = docRecord.id;
+                            }
+                        }
+                        const docId = bookLookup[bookCode];
+                        cl.renderDocument({ docId, config: { chapters: [chapter] }, output });
+                    }
+                }
+            }
         }
         performance.mark('cl-render-end');
         performance.measure('cl-render-duration', 'cl-render-start', 'cl-render-end');

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -577,7 +577,7 @@ LOGGING:
     };
     function appendPhrase(workspace) {
         workspace.lastPhrase = workspace.phraseDiv.getAttribute('data-phrase');
-        if (verseByVerseMode) {
+        if (verseByVerseMode && workspace.currentVerseByVerseDiv) {
             workspace.currentVerseByVerseDiv.appendChild(workspace.phraseDiv.cloneNode(true));
         } else if (versePerLine) {
             workspace.verseDiv.appendChild(workspace.phraseDiv.cloneNode(true));
@@ -618,9 +618,11 @@ LOGGING:
                 // So override that style based on the current directin of the text
                 div.style.float = direction.toLowerCase() === 'ltr' ? 'left' : 'right';
                 div.innerText = workspace.chapterNumText;
-                workspace.paragraphDiv.appendChild(div);
-                if (!scriptureConfig.mainFeatures['hide-verse-number-1']) {
-                    addVerseNumber(workspace, element, showVerseNumbers);
+                if (timesRendered === 1) {
+                    workspace.paragraphDiv.appendChild(div);
+                    if (!scriptureConfig.mainFeatures['hide-verse-number-1']) {
+                        addVerseNumber(workspace, element, showVerseNumbers);
+                    }
                 }
             } else {
                 // chapter at top of page
@@ -1530,6 +1532,7 @@ LOGGING:
         if (!proskomma) {
             return;
         }
+        timesRendered = 0;
         await loadDocSetIfNotLoaded(proskomma, docSet, fetch);
         if (verseByVerseMode) {
             if ($layout.auxDocSets?.length && $layout.auxDocSets.length > 0) {
@@ -1617,22 +1620,24 @@ LOGGING:
                                 console.log('End Document');
                             }
                             preprocessAction('endDocument', workspace);
-                            addOnClickDivs();
-                            if (!displayingIntroduction) {
-                                addNotedVerses(notes);
-                                addBookmarkedVerses(bookmarks);
-                                addHighlightedVerses(highlights);
-                                if (showVideo()) {
-                                    addVideos(videos);
+                            if (timesRendered === 1) {
+                                addOnClickDivs();
+                                if (!displayingIntroduction) {
+                                    addNotedVerses(notes);
+                                    addBookmarkedVerses(bookmarks);
+                                    addHighlightedVerses(highlights);
+                                    if (showVideo()) {
+                                        addVideos(videos);
+                                    }
+                                    if (showImage()) {
+                                        addIllustrations(illustrations);
+                                    }
+                                    addPlanDiv(workspace, '-1');
                                 }
-                                if (showImage()) {
-                                    addIllustrations(illustrations);
+                                addFooter(document, workspace.root, docSet);
+                                if (references) {
+                                    observeVisibility();
                                 }
-                                addPlanDiv(workspace, '-1');
-                            }
-                            addFooter(document, workspace.root, docSet);
-                            if (references) {
-                                observeVisibility();
                             }
                         }
                     }
@@ -1844,7 +1849,7 @@ LOGGING:
                                         workspace.currentVerseByVerseDiv.classList.add(
                                             'verse-by-verse-' + (timesRendered - 1)
                                         );
-                                        workspace.verseByVerseDivRoot.appendChild(
+                                        workspace.verseByVerseDivRoot?.appendChild(
                                             workspace.currentVerseByVerseDiv
                                         );
                                     } else {
@@ -2709,6 +2714,22 @@ LOGGING:
         // Parse whole book if no chapters
         if (chapterCount(currentBook) === 0) {
             cl.renderDocument({ docId, config: {}, output });
+            if (verseByVerseMode) {
+                if ($layout.auxDocSets?.length && $layout.auxDocSets.length > 0) {
+                    for (const i in $layout.auxDocSets) {
+                        const bookLookup = {};
+                        for (const docRecord of docsResult.data.documents) {
+                            if (docRecord.docSetId === $layout.auxDocSets[i]) {
+                                bookLookup[docRecord.bookCode] = docRecord.id;
+                            }
+                        }
+                        const docId = bookLookup[bookCode];
+                        if (docId) {
+                            cl.renderDocument({ docId, config: {}, output });
+                        }
+                    }
+                }
+            }
         } else {
             cl.renderDocument({ docId, config: { chapters: [chapter] }, output });
             if (verseByVerseMode) {
@@ -2721,7 +2742,9 @@ LOGGING:
                             }
                         }
                         const docId = bookLookup[bookCode];
-                        cl.renderDocument({ docId, config: { chapters: [chapter] }, output });
+                        if (docId) {
+                            cl.renderDocument({ docId, config: { chapters: [chapter] }, output });
+                        }
                     }
                 }
             }

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -1835,10 +1835,15 @@ LOGGING:
                                     workspace.verseDiv.classList.add('verse-block');
                                 }
                                 if (verseByVerseMode) {
-                                    const collectionDirection =
+                                    const collectionBeingUsed =
                                         scriptureConfig.bookCollections?.find(
                                             (x) => x.languageCode + '_' + x.id === currentCollection
-                                        )?.style?.textDirection;
+                                        );
+                                    const collectionDirection =
+                                        collectionBeingUsed?.style?.textDirection;
+                                    const font = collectionBeingUsed?.style?.font;
+                                    const fontSize = collectionBeingUsed?.style?.textSize;
+                                    const lineHeight = collectionBeingUsed?.style?.lineHeight;
                                     if (timesRendered > 1) {
                                         workspace.verseByVerseDivRoot = document.getElementById(
                                             'verseblock-' + element.atts['number']
@@ -1857,6 +1862,18 @@ LOGGING:
                                         if (collectionDirection) {
                                             workspace.currentVerseByVerseDiv.style.direction =
                                                 collectionDirection.toLowerCase();
+                                        }
+                                        if (font) {
+                                            workspace.currentVerseByVerseDiv.style.fontFamily =
+                                                font;
+                                        }
+                                        if (fontSize) {
+                                            workspace.currentVerseByVerseDiv.style.fontSize =
+                                                fontSize + 'px';
+                                        }
+                                        if (lineHeight) {
+                                            workspace.currentVerseByVerseDiv.style.lineHeight =
+                                                lineHeight + '%';
                                         }
                                         workspace.verseByVerseDivRoot?.appendChild(
                                             workspace.currentVerseByVerseDiv

--- a/src/lib/data/stores/collection.ts
+++ b/src/lib/data/stores/collection.ts
@@ -58,10 +58,18 @@ function createInitCollections(): App.CollectionGroup {
 
 const initCollections: App.CollectionGroup = createInitCollections();
 
+function loadPersistedSelectedLayouts(): App.CollectionGroup {
+    if (typeof localStorage === 'undefined') return initCollections;
+    try {
+        return localStorage.selectedLayouts
+            ? JSON.parse(localStorage.selectedLayouts)
+            : initCollections;
+    } catch {
+        return initCollections;
+    }
+}
 function createSelectedLayouts() {
-    const external = writable<App.CollectionGroup>(
-        localStorage.selectedLayouts ? JSON.parse(localStorage.selectedLayouts) : initCollections
-    );
+    const external = writable<App.CollectionGroup>(loadPersistedSelectedLayouts());
     external.subscribe((value) => (localStorage.selectedLayouts = JSON.stringify(value)));
 
     return {

--- a/src/lib/data/stores/collection.ts
+++ b/src/lib/data/stores/collection.ts
@@ -59,7 +59,9 @@ function createInitCollections(): App.CollectionGroup {
 const initCollections: App.CollectionGroup = createInitCollections();
 
 function loadPersistedSelectedLayouts(): App.CollectionGroup {
-    if (typeof localStorage === 'undefined') return initCollections;
+    if (typeof localStorage === 'undefined') {
+        return initCollections;
+    }
     try {
         return localStorage.selectedLayouts
             ? JSON.parse(localStorage.selectedLayouts)

--- a/src/lib/data/stores/collection.ts
+++ b/src/lib/data/stores/collection.ts
@@ -59,7 +59,10 @@ function createInitCollections(): App.CollectionGroup {
 const initCollections: App.CollectionGroup = createInitCollections();
 
 function createSelectedLayouts() {
-    const external = writable<App.CollectionGroup>(initCollections);
+    const external = writable<App.CollectionGroup>(
+        localStorage.selectedLayouts ? JSON.parse(localStorage.selectedLayouts) : initCollections
+    );
+    external.subscribe((value) => (localStorage.selectedLayouts = JSON.stringify(value)));
 
     return {
         subscribe: external.subscribe,

--- a/src/lib/data/stores/view.ts
+++ b/src/lib/data/stores/view.ts
@@ -23,7 +23,9 @@ export const Layout = {
 export type Layout = (typeof Layout)[keyof typeof Layout];
 
 function loadPersistedLayout(): { mode: Layout; auxDocSets?: string[] } {
-    if (typeof localStorage === 'undefined') return singleLayout;
+    if (typeof localStorage === 'undefined') {
+        return singleLayout;
+    }
     try {
         return localStorage.layout ? JSON.parse(localStorage.layout) : singleLayout;
     } catch {

--- a/src/lib/data/stores/view.ts
+++ b/src/lib/data/stores/view.ts
@@ -22,10 +22,16 @@ export const Layout = {
 } as const;
 export type Layout = (typeof Layout)[keyof typeof Layout];
 
+function loadPersistedLayout(): { mode: Layout; auxDocSets?: string[] } {
+    if (typeof localStorage === 'undefined') return singleLayout;
+    try {
+        return localStorage.layout ? JSON.parse(localStorage.layout) : singleLayout;
+    } catch {
+        return singleLayout;
+    }
+}
 const singleLayout = { mode: Layout.Single, auxDocSets: [] };
-export const layout = writable<{ mode: Layout; auxDocSets?: string[] }>(
-    localStorage.layout ? JSON.parse(localStorage.layout) : singleLayout
-);
+export const layout = writable<{ mode: Layout; auxDocSets?: string[] }>(loadPersistedLayout());
 layout.subscribe((value) => (localStorage.layout = JSON.stringify(value)));
 
 export const ModalType = {

--- a/src/lib/data/stores/view.ts
+++ b/src/lib/data/stores/view.ts
@@ -1,4 +1,4 @@
-import { derived, get, readable, writable } from 'svelte/store';
+import { derived, get, readable, writable, type Writable } from 'svelte/store';
 import { defaultSettings, userSettings } from './setting';
 import { setDefaultStorage } from './storage';
 
@@ -23,7 +23,10 @@ export const Layout = {
 export type Layout = (typeof Layout)[keyof typeof Layout];
 
 const singleLayout = { mode: Layout.Single, auxDocSets: [] };
-export const layout = writable<{ mode: Layout; auxDocSets?: string[] }>(singleLayout);
+export const layout = writable<{ mode: Layout; auxDocSets?: string[] }>(
+    localStorage.layout ? JSON.parse(localStorage.layout) : singleLayout
+);
+layout.subscribe((value) => (localStorage.layout = JSON.stringify(value)));
 
 export const ModalType = {
     Note: 'note',

--- a/src/routes/layout/+page.svelte
+++ b/src/routes/layout/+page.svelte
@@ -17,21 +17,6 @@
     } from '$lib/data/stores';
     import { CheckIcon, SideBySideIcon, SinglePaneIcon, VerseByVerseIcon } from '$lib/icons';
 
-    const matchingDocSets =
-        scriptureConfig.bookCollections
-            ?.map((ds) => ({
-                id: ds.languageCode + '_' + ds.id,
-                name: ds.collectionName,
-                singlePane: (ds?.features['bc-allow-single-pane'] ??
-                    ds?.features['bc-layout-allow-single-pane']) as boolean,
-                description: ds?.collectionDescription,
-                image: ds?.collectionImage
-            }))
-            .filter((x) => x.id === $refs.docSet) ?? [];
-
-    if (matchingDocSets[0]) {
-        $selectedLayouts.singlePane = matchingDocSets[0];
-    }
     let tabMenuActive = $state($layout.mode);
 
     // values of selectedLayouts before user makes changes

--- a/src/routes/layout/+page.svelte
+++ b/src/routes/layout/+page.svelte
@@ -32,8 +32,7 @@
     if (matchingDocSets[0]) {
         $selectedLayouts.singlePane = matchingDocSets[0];
     }
-
-    let tabMenuActive = $state(Layout.Single);
+    let tabMenuActive = $state($layout.mode);
 
     // values of selectedLayouts before user makes changes
     const restoreDocSets = JSON.stringify($selectedLayouts);


### PR DESCRIPTION
Resolves #593. This PR implements the verse-by-verse display. This was done by making the Proskomma renderer run once for each collection, but for all but the first, it adds components to the HTML that has already been rendered instead of rendering it again from scratch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Remember layout selection and the active layout mode across sessions.
  * In verse-by-verse mode, the view can load additional document sets for the selected layouts.

* **Bug Fixes**
  * Improved verse-by-verse rendering consistency across multi-pass rendering.
  * Prevented duplicated top-level content and repeated UI setup during subsequent render passes.
  * Corrected layout availability so verse-by-verse layouts are no longer incorrectly disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->