### PR TITLE
#459 Render rich text in cross-ref pop-up

### DIFF
--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -1428,6 +1428,8 @@ LOGGING:
     }
     // handles on click when interacting with the scripture view
     function onClick(e: any) {
+        const t = e.target as HTMLElement;
+        console.log(`clicked <${t.nodeName.toLowerCase()} ${t.className}>`);
         switch (e.target.getAttribute('class')) {
             case 'v':
                 audioClickHandler(e);

--- a/src/lib/components/StackView.svelte
+++ b/src/lib/components/StackView.svelte
@@ -43,6 +43,7 @@
     };
     // handles clicks on in text markdown reference links
     function referenceLinkClickHandler(target: HTMLElement) {
+        console.warn(`Reference link clicked -> ${target}`);
         const linkRef = target.getAttribute('ref') ?? '';
         const splitRef = splitString(linkRef, '.');
         const splitSet = splitRef[0];
@@ -63,6 +64,8 @@
         return;
     }
     async function insideClick(target: HTMLElement) {
+        console.log(`inside click registered on ${target}`);
+        console.log(`target has classes ${target.classList.toString()}`);
         if (target.hasAttribute('data-start-ref')) {
             let start = JSON.parse(target.getAttribute('data-start-ref') || '{}');
             let end =
@@ -72,6 +75,7 @@
             if (config.mainFeatures['scripture-refs-display-from-popup'] === 'viewer') {
                 navigate(start);
             } else {
+                console.log('Creating inner footer?');
                 const footnoteHTML = await handleHeaderLinkPressed(start, end, themeColors);
                 footnotes.push(footnoteHTML);
             }
@@ -118,7 +122,7 @@
                 class="footnote rounded-sm h-40 shadow-lg overflow-y-auto"
                 onclick={(e) => {
                     e.stopPropagation();
-                    insideClick(e.currentTarget);
+                    insideClick((e.target || e.currentTarget) as HTMLElement);
                 }}
             >
                 <div


### PR DESCRIPTION
In progress, closes #459.

- Fix parent div capturing all clicks on footnotes (separated as #1058).
- ...