### PR TITLE
Change manifest to prevent icon cropping on Android

### DIFF
--- a/convert/convertManifest.ts
+++ b/convert/convertManifest.ts
@@ -54,8 +54,10 @@ export function convertManifest(dataDir: string, verbose: number) {
                     } else {
                         throw new Error(`Required icon file ${iconPath} does not exist!`);
                     }
-
                     line = line.replace(srcMatch[0], `"src": "${joinUrlPath('.', finalName)}"`);
+                }
+                if (line.includes('purpose')) {
+                    line = line.replace(/\bmaskable\b/g, 'any'); //Without this, the app icon on Android could be badly cropped
                 }
                 return line;
             })

--- a/convert/convertManifest.ts
+++ b/convert/convertManifest.ts
@@ -57,7 +57,7 @@ export function convertManifest(dataDir: string, verbose: number) {
                     line = line.replace(srcMatch[0], `"src": "${joinUrlPath('.', finalName)}"`);
                 }
                 if (line.includes('purpose')) {
-                    line = line.replace(/\bmaskable\b/g, 'any'); //Without this, the app icon on Android could be badly cropped
+                    line = line.replace(/"maskable"/g, '"any"'); //Without this, the app icon on Android could be badly cropped
                 }
                 return line;
             })


### PR DESCRIPTION
Fixes #1013. The manifest is now changed to give icons the "purpose": "any" attribute, which fixes the icon cropping issue on Android.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manifest output normalization for icon metadata, updating `purpose` values so supported icons are handled more consistently.
  * Adjusted icon path rewriting so generated manifest entries continue to point to the correct final icon files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->