### PR TITLE
fix: remove keyboard documentation from sidebar

### DIFF
--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -1627,6 +1627,19 @@ function filterFeaturesNotReady(data: ScriptureConfig | DictionaryConfig) {
     data.mainFeatures['settings-audio-access-method'] = false;
     data.mainFeatures['settings-video-access-method'] = false;
     data.mainFeatures['settings-audio-download-mode'] = false;
+
+    /**
+     * Keyboards are not supported (documentation links were added in 14.2)
+     * 
+     * See [Issue #1041](https://github.com/sillsdev/appbuilder-pwa/issues/1041)
+     */ 
+    if (data.menuItems?.length) {
+        data.menuItems = data.menuItems.filter(
+            (it) =>
+                it.type !== 'website' ||
+                !Object.values(it.link ?? {}).some((l) => /android_asset\/keyboard/.test(l))
+        );
+    }
     return data;
 }
 

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -1630,9 +1630,9 @@ function filterFeaturesNotReady(data: ScriptureConfig | DictionaryConfig) {
 
     /**
      * Keyboards are not supported (documentation links were added in 14.2)
-     * 
+     *
      * See [Issue #1041](https://github.com/sillsdev/appbuilder-pwa/issues/1041)
-     */ 
+     */
     if (data.menuItems?.length) {
         data.menuItems = data.menuItems.filter(
             (it) =>


### PR DESCRIPTION
See #1041 for adding back in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Menu links related to keyboard content are now filtered out when unavailable, preventing broken or inaccessible website entries from appearing.
  * Improved consistency in menu display by hiding unsupported items before they reach users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->