### PR TITLE
Cause conversion to fail on missing color

### DIFF
--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -15,7 +15,7 @@ import type {
 import jsdom from 'jsdom';
 import { convertMarkdownsToHTML } from './convertMarkdown';
 import { getHashedName } from './fileUtils';
-import { compareVersions, splitVersion } from './stringUtils';
+import { splitVersion } from './stringUtils';
 import { Task, type TaskOutput } from './Task';
 
 const fontFamilies: string[] = [];
@@ -262,7 +262,7 @@ function convertConfig(dataDir: string, verbose: number) {
 
     data.fonts = parseFonts(document, verbose);
 
-    const { themes, defaultTheme } = parseColorThemes(document, data.programVersion, verbose);
+    const { themes, defaultTheme } = parseColorThemes(document, verbose);
     data.themes = themes;
     if (defaultTheme !== '') {
         data.defaultTheme = defaultTheme;
@@ -453,7 +453,7 @@ export function parseFonts(document: Document, verbose: number) {
     return fonts;
 }
 
-export function parseColorThemes(document: Document, programVersion: string, verbose: number) {
+export function parseColorThemes(document: Document, verbose: number) {
     const colorThemeTags = document
         .getElementsByTagName('color-themes')[0]
         .getElementsByTagName('color-theme');

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -480,19 +480,14 @@ export function parseColorThemes(document: Document, programVersion: string, ver
                     const value = cm?.getAttribute('value');
                     if (name && value) {
                         colors[name] = value;
-                    } else if (
-                        name &&
-                        !value &&
-                        defaultColors[name] &&
-                        compareVersions(programVersion, '14.3') < 0
-                    ) {
-                        if (verbose >= 2) {
-                            console.log(
-                                `.. colors[${name}] had no specified value; ` +
-                                    `falling back to color ${defaultColors[name]} from default theme`
-                            );
-                        }
-                        colors[name] = defaultColors[name];
+                    } else if (name && !value) {
+                        const colorMissingError = new Error(
+                            `No color value found for "${name}" in the "${theme}" theme.` +
+                                `\nIt is possible that the project was last saved with a version of the App Builder that didn't correctly save the color values.` +
+                                `\nPlease select a different color theme in the App Builder and save the project, then change it back to the desired theme and save the project again.`
+                        );
+                        colorMissingError.stack = `Error in ${__filename}:parseColorThemes(): ${colorMissingError.message}`;
+                        throw colorMissingError;
                     }
                     if (verbose >= 3) {
                         console.log(`.. colors[${name}]=${colors[name]}`);

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -453,6 +453,20 @@ export function parseFonts(document: Document, verbose: number) {
     return fonts;
 }
 
+// HACK: Work-around undefined color in DAB 14.2
+// For the PWA for 14.3, we are adding a check for missing colors.
+// However, in DAB 14.2, the TextHighlightColor was not defined for Sepia
+function hackColorValue(
+    theme: string,
+    name: string,
+    value: string | null | undefined
+): string | null | undefined {
+    if (theme === 'Sepia' && name === 'TextHighlightColor' && !value) {
+        return '#D9D9D9'; // Default TextHighlightColor from Normal theme in DAB 14.2
+    }
+    return value;
+}
+
 export function parseColorThemes(document: Document, verbose: number) {
     const colorThemeTags = document
         .getElementsByTagName('color-themes')[0]
@@ -477,7 +491,7 @@ export function parseColorThemes(document: Document, verbose: number) {
                 for (const color of colorTags) {
                     const cm = color.querySelector(`cm[theme="${theme}"]`);
                     const name = color.getAttribute('name') || '';
-                    const value = cm?.getAttribute('value');
+                    const value = hackColorValue(theme, name, cm?.getAttribute('value'));
                     if (name && value) {
                         colors[name] = value;
                     } else if (name && !value) {

--- a/convert/tests/sab/convertConfigSAB.test.ts
+++ b/convert/tests/sab/convertConfigSAB.test.ts
@@ -47,8 +47,7 @@ test('convertConfig: parse fonts', () => {
 });
 
 test('convertConfig: parse color themes', () => {
-    // Use arbitrary "development" version; see `convertConfig()` in convertConfig.ts
-    const result = parseColorThemes(document, '100.0', 1);
+    const result = parseColorThemes(document, 1);
     expect(result.defaultTheme).not.toSatisfy((r) => r === '' || r === undefined);
     for (const theme of result.themes) {
         expect(theme.name).not.toSatisfy((r) => r === '' || r === undefined);


### PR DESCRIPTION
To help users identify unintended theme color issues: fail the build on encountering a missing color, give a minimal stack trace, and suggest resetting the theme in SAB to refresh the `.appDef`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color theme parsing to fail fast when a color is missing its value.
  * Added a clearer error message to help identify corrupted theme data and guide users to re-save the theme in the App Builder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->