### PR TITLE
Fix remaining DaisyUI 4 tab styles

### DIFF
--- a/src/routes/plans/+page.svelte
+++ b/src/routes/plans/+page.svelte
@@ -83,7 +83,7 @@
                     type="radio"
                     name="my_tabs_1"
                     role="tab"
-                    class="dy-tab dy-tab-bordered {selectedTab === 'in-use' ? 'dy-tab-active' : ''}"
+                    class="dy-tab {selectedTab === 'in-use' ? 'dy-tab-active' : ''}"
                     onclick={() => (selectedTab = 'in-use')}
                     aria-label={$t['Plans_Tab_My_Plans']}
                     style={convertStyle($s?.['ui.plans.tabs.text'])}
@@ -103,9 +103,7 @@
                     type="radio"
                     name="my_tabs_1"
                     role="tab"
-                    class="dy-tab dy-tab-bordered {selectedTab === 'completed'
-                        ? 'dy-tab-active'
-                        : ''}"
+                    class="dy-tab {selectedTab === 'completed' ? 'dy-tab-active' : ''}"
                     onclick={() => (selectedTab = 'completed')}
                     aria-label={$t['Plans_Tab_Completed_Plans']}
                     style={convertStyle($s?.['ui.plans.tabs.text'])}

--- a/src/routes/plans/[id]/+page.svelte
+++ b/src/routes/plans/[id]/+page.svelte
@@ -234,7 +234,7 @@
             <!-- svelte-ignore a11y_no_static_element_interactions -->
 
             <div
-                class="dy-tab dy-tab-bordered {selectedTab === 'info' ? 'dy-tab-active' : ''}"
+                class="dy-tab {selectedTab === 'info' ? 'dy-tab-active' : ''}"
                 onclick={() => (selectedTab = 'info')}
                 aria-label="info icon"
                 style={convertStyle($s?.['ui.plans.tabs.text'])}

--- a/src/routes/songs/[collection]/[id]/+page.svelte
+++ b/src/routes/songs/[collection]/[id]/+page.svelte
@@ -61,7 +61,7 @@
     </div>
     <div class="min-h-0">
         <div
-            class="border-t border-base-content/10 dy-tabs dy-tabs-bordered w-full justify-start"
+            class="border-t border-base-content/10 dy-tabs dy-tabs-border w-full justify-start"
             style:background-color={actionBarColor}
         >
             {#each tabs as songTab, i}


### PR DESCRIPTION
These styles changed in the DaisyUI v5 upgrade, but there are a few I forgot to migrate.

- replace last `tabs-bordered` with `tabs-border`
- remove uses of class `tab-bordered` that no longer has effect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tab styling on plans and song pages so the active tab is highlighted more consistently.
  * Adjusted tab border appearance in the songs view for a cleaner, more polished layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->