### PR TITLE
Save selectedVerses to localStorage

### DIFF
--- a/src/lib/data/stores/scripture.ts
+++ b/src/lib/data/stores/scripture.ts
@@ -207,10 +207,12 @@ export type Selection = {
     reference: string;
     verse: string;
 };
-
+setDefaultStorage('selectedVerses', JSON.stringify([]));
 function createSelectedVerses() {
-    const external: Writable<Selection[]> = writable([]);
-
+    const external: Writable<Selection[]> = writable(JSON.parse(localStorage.selectedVerses));
+    external.subscribe(
+        (selectedVerses) => (localStorage.selectedVerses = JSON.stringify(selectedVerses))
+    );
     return {
         subscribe: external.subscribe,
         addVerse: (id: string | number) => {


### PR DESCRIPTION
Fixes #1033. Back up $selectedVerses to localStorage so the note editor doesn't lose its reference on page reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selected verses are now saved in the browser, so your current selection is preserved after refreshing or reopening the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->