### PR TITLE
Change shared text to use copy-share-message from appdef.xml

### DIFF
--- a/config/index.d.ts
+++ b/config/index.d.ts
@@ -89,6 +89,7 @@ export type BookCollectionConfig = {
     languageCode: string;
     languageName?: string;
     footer?: HTML;
+    copyShareMessage?: string;
     meta?: {
         [key: string]: string;
     };

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -586,6 +586,15 @@ export function parseBookCollections(document: Document, dataDir: string, verbos
         if (verbose >= 2) {
             console.log(`Converting Collection: ${tag.id}`);
         }
+        const metaTags = tag.querySelector('metadata')?.getElementsByTagName('meta');
+        let copyShareMessage: string | undefined;
+        if (metaTags) {
+            for (const metaTag of metaTags) {
+                if (metaTag.attributes.getNamedItem('name')?.value === 'copy-share-message') {
+                    copyShareMessage = metaTag.attributes.getNamedItem('content')?.value;
+                }
+            }
+        }
         const featuresTags = tag.querySelector('features[type=bc]')?.getElementsByTagName('e');
         if (!featuresTags) {
             throw 'Book collection feature tags missing';
@@ -917,7 +926,8 @@ export function parseBookCollections(document: Document, dataDir: string, verbos
             languageName,
             footer,
             style: parseStylesInfo(stylesTag, verbose),
-            styles
+            styles,
+            copyShareMessage
         });
         if (verbose >= 3) {
             console.log(

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -142,9 +142,12 @@ TODO:
         const bookCol = $selectedVerses[0].collection;
         const fullBook = getBook({ collection: bookCol, book: book });
         const bookAbbrev = fullBook?.abbreviation ?? fullBook?.name;
+        const copyShareMessage = scriptureConfig.bookCollections?.find(
+            (x) => x.id === $refs.collection
+        )?.copyShareMessage;
         shareText(
             scriptureConfig.name ?? '',
-            scriptureConfig.name + '\n\n' + text + '\n' + reference,
+            text + '\n' + reference + (copyShareMessage ? '\n' + copyShareMessage : ''),
             book + '.txt'
         );
         logShareContent('Text', bookCol, bookAbbrev ?? '', reference);

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -143,7 +143,7 @@ TODO:
         const fullBook = getBook({ collection: bookCol, book: book });
         const bookAbbrev = fullBook?.abbreviation ?? fullBook?.name;
         const copyShareMessage = scriptureConfig.bookCollections?.find(
-            (x) => x.id === $refs.collection
+            (x) => x.id === bookCol
         )?.copyShareMessage;
         shareText(
             scriptureConfig.name ?? '',


### PR DESCRIPTION
Fixes #997. In convertConfig, it updates config with the copy-share-message (If any) configured from SAB, and it uses that to determine what text is shared.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for including a custom share message with selected text from a book collection.
  * Share actions can now include additional collection-specific text when available.

* **Bug Fixes**
  * Updated shared text formatting so the main passage text and reference are combined more consistently.
  * Improved fallback handling for the displayed collection name during sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->