### PR TITLE
fix: properly handle introductions in chapter fallback

### DIFF
--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -467,6 +467,8 @@ function hackColorValue(
     return value;
 }
 
+const deprecatedColors = ['StatusBarColor'];
+
 export function parseColorThemes(document: Document, verbose: number) {
     const colorThemeTags = document
         .getElementsByTagName('color-themes')[0]
@@ -494,6 +496,13 @@ export function parseColorThemes(document: Document, verbose: number) {
                     const value = hackColorValue(theme, name, cm?.getAttribute('value'));
                     if (name && value) {
                         colors[name] = value;
+                    } else if (deprecatedColors.includes(name)) {
+                        if (verbose >= 3) {
+                            console.log(
+                                `.. skipping deprecated color "${name}" in "${theme}" theme.`
+                            );
+                        }
+                        continue;
                     } else if (name && !value) {
                         const colorMissingError = new Error(
                             `No color value found for "${name}" in the "${theme}" theme.` +

--- a/convert/tests/sab/convertConfigSAB.test.ts
+++ b/convert/tests/sab/convertConfigSAB.test.ts
@@ -251,7 +251,7 @@ if (programType === 'DAB') {
         const result = parseFeatures(document, 1);
         // If this number is different from expected, AppBuilders likely has new features.
         // Care should be taken to look at what's new and open issues accordingly.
-        expect(Object.keys(result)).toHaveLength(143);
+        expect(Object.keys(result)).toHaveLength(144);
     });
 
     test('convertConfig: parse background images', () => {

--- a/src/lib/data/navigation.test.ts
+++ b/src/lib/data/navigation.test.ts
@@ -126,7 +126,7 @@ const catalog1: CatalogData = {
             toc2: 'Matthew',
             toc3: 'Mat',
             sequences: [],
-            hasIntroduction: false,
+            hasIntroduction: true,
             versesByChapters: {
                 1: {
                     1: '1',
@@ -153,7 +153,7 @@ const catalog1: CatalogData = {
             toc2: 'Mark',
             toc3: 'Mrk',
             sequences: [],
-            hasIntroduction: false,
+            hasIntroduction: true,
             versesByChapters: {
                 1: {
                     1: '1',

--- a/src/lib/data/navigation.ts
+++ b/src/lib/data/navigation.ts
@@ -90,7 +90,8 @@ export class NavigationContext {
             .map((range) => range.split('-').map((n) => parseInt(n, 10)));
         const fallbackChapter = String(chapterRange?.[0][0] || 1);
         if (
-            (isNaN(chapterNum) && chapter !== 'i') ||
+            isNaN(chapterNum) &&
+            chapter !== 'i' &&
             !chapterRange?.some(
                 (range) => chapterNum >= range[0] && chapterNum <= (range[1] || range[0])
             )

--- a/src/lib/data/navigation.ts
+++ b/src/lib/data/navigation.ts
@@ -181,8 +181,6 @@ export class NavigationContext {
 
     private updateChapterVerse(chapter: string, verse: string, newBook: boolean) {
         if (newBook) {
-            const catalogBook = this.catalog.documents.find((b) => this.book === b.bookCode);
-            console.log(catalogBook);
             this.versesByChapters =
                 this.catalog.documents.find((b) => this.book === b.bookCode)?.versesByChapters ??
                 {};

--- a/src/lib/data/navigation.ts
+++ b/src/lib/data/navigation.ts
@@ -85,7 +85,9 @@ export class NavigationContext {
 
         await this.updateCatalog(useFallbackDocSet ? fallbackDocSet : docSet);
 
-        const catalogBook = this.catalog.documents.find((d) => d.bookCode === bookId);
+        const catalogBook = this.catalog.documents.find(
+            (d) => d.bookCode === (useFallbackBookId ? fallbackBookId : bookId)
+        );
         if (!catalogBook) {
             console.warn(
                 `catalog entry not found for book '${bookId}', following results may be inaccurate`

--- a/src/lib/data/navigation.ts
+++ b/src/lib/data/navigation.ts
@@ -1,6 +1,6 @@
 import { scriptureConfig } from '$assets/config';
 import type { BookCollectionAudioConfig, BookCollectionConfig } from '$config';
-import { isBlank, isNotBlank, isPositiveInteger } from '$lib/scripts/stringUtils';
+import { isPositiveInteger } from '$lib/scripts/stringUtils';
 import { loadCatalog, type CatalogData } from './catalogData';
 
 /**
@@ -58,7 +58,7 @@ export class NavigationContext {
         };
     }
 
-    private handleFallbacks(docSet: string, bookId: string, chapter: string) {
+    private async handleFallbacks(docSet: string, bookId: string, chapter: string) {
         let useFallbackDocSet = false;
         const fallbackDocSet = this.docSets[0];
         const collection =
@@ -83,23 +83,34 @@ export class NavigationContext {
             useFallbackBookId = true;
         }
 
+        await this.updateCatalog(useFallbackDocSet ? fallbackDocSet : docSet);
+
+        const catalogBook = this.catalog.documents.find((d) => d.bookCode === bookId);
+        if (!catalogBook) {
+            console.warn(
+                `catalog entry not found for book '${bookId}', following results may be inaccurate`
+            );
+        }
+
         let useFallbackChapter = false;
         const chapterNum = parseInt(chapter, 10);
         const chapterRange = book?.chaptersN
             ?.split(' ')
             .map((range) => range.split('-').map((n) => parseInt(n, 10)));
         const fallbackChapter = String(chapterRange?.[0][0] || 1);
-        if (
-            isNaN(chapterNum) &&
-            chapter !== 'i' &&
-            !chapterRange?.some(
-                (range) => chapterNum >= range[0] && chapterNum <= (range[1] || range[0])
-            )
-        ) {
-            console.error(
-                `chapter '${chapter}' falls outside of chapter range '${book?.chaptersN}'. Defaulting to '${fallbackChapter}'.`
-            );
-            useFallbackChapter = true;
+        if (!(chapter === 'i' && catalogBook?.hasIntroduction)) {
+            if (
+                !chapter ||
+                isNaN(chapterNum) ||
+                !chapterRange?.some(
+                    (range) => chapterNum >= range[0] && chapterNum <= (range[1] || range[0])
+                )
+            ) {
+                console.error(
+                    `chapter '${chapter}' falls outside of chapter range '${book?.chaptersN}'. Defaulting to '${fallbackChapter}'.`
+                );
+                useFallbackChapter = true;
+            }
         }
 
         return {
@@ -127,7 +138,7 @@ export class NavigationContext {
         if (!this.initialized) {
             throw new Error('NavigationContext is not initialized; please call gotoInitial()');
         }
-        const withFallbacks = this.handleFallbacks(docSet, book, chapter);
+        const withFallbacks = await this.handleFallbacks(docSet, book, chapter);
         await this.updateLocation(
             withFallbacks.docSet,
             withFallbacks.book,
@@ -143,8 +154,7 @@ export class NavigationContext {
         this.bookTab = bookTab;
     }
 
-    private async updateLocation(docSet: string, book: string, chapter: string, verse: string) {
-        let newBook = false;
+    private async updateCatalog(docSet: string) {
         if (this.docSets.includes(docSet) && this.docSet !== docSet) {
             this.docSet = docSet;
             this.collection = docSet.split('_')[1];
@@ -154,8 +164,14 @@ export class NavigationContext {
                 ...this.books,
                 ...(this.catalog.htmlBooks ? this.catalog.htmlBooks.map((b) => b.id) : [])
             ];
-            newBook = true;
+            return true;
+        } else {
+            return false;
         }
+    }
+
+    private async updateLocation(docSet: string, book: string, chapter: string, verse: string) {
+        let newBook = await this.updateCatalog(docSet);
         if (book !== this.book && this.allBookIds.includes(book)) {
             this.book = book;
             newBook = true;
@@ -165,6 +181,8 @@ export class NavigationContext {
 
     private updateChapterVerse(chapter: string, verse: string, newBook: boolean) {
         if (newBook) {
+            const catalogBook = this.catalog.documents.find((b) => this.book === b.bookCode);
+            console.log(catalogBook);
             this.versesByChapters =
                 this.catalog.documents.find((b) => this.book === b.bookCode)?.versesByChapters ??
                 {};

--- a/test_data/data/config.js
+++ b/test_data/data/config.js
@@ -167,7 +167,6 @@ export default {
             "PrimaryDarkColor": "#000044",
             "AccentColor": "#000000",
             "ActionBarColor": "#000B63",
-            "StatusBarColor": "#000044",
             "TextColor": "#000000",
             "TitlesColor": "#000B63",
             "VerseNumberColor": "#1976D2",
@@ -296,7 +295,6 @@ export default {
             "PrimaryDarkColor": "#3E2723",
             "AccentColor": "#3E2723",
             "ActionBarColor": "#4E342E",
-            "StatusBarColor": "#3E2723",
             "TextColor": "#5A4129",
             "TitlesColor": "#513A24",
             "VerseNumberColor": "#8D6E63",
@@ -425,7 +423,6 @@ export default {
             "PrimaryDarkColor": "#121212",
             "AccentColor": "#121212",
             "ActionBarColor": "#181818",
-            "StatusBarColor": "#121212",
             "TextColor": "#E0E0E0",
             "TitlesColor": "#E0E0E0",
             "VerseNumberColor": "#BBDEFB",
@@ -642,13 +639,6 @@ export default {
       "category": "ui",
       "properties": {
         "color": "TextSelectionBarIconColor"
-      }
-    },
-    {
-      "name": "ui.bar.status",
-      "category": "ui",
-      "properties": {
-        "background-color": "StatusBarColor"
       }
     },
     {


### PR DESCRIPTION
Fix regressions introduced by https://github.com/sillsdev/appbuilder-pwa/commit/b7810b0fb98a84bc7ecca15066b38bb63ca17d49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation fallback handling to wait for any catalog refresh before resolving fallbacks and updating location.
  * Corrected chapter parsing/validation so introductions and valid chapter inputs no longer trigger incorrect fallback redirects.
  * Updated theme color parsing to skip deprecated `StatusBarColor` entries instead of erroring, and removed related `StatusBarColor` mappings from shipped theme/style config.
* **Tests**
  * Updated navigation fixture expectations for introduction availability.
  * Adjusted SAB conversion feature test to expect one additional feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->