### PR TITLE
Fix for missing bar under ui.bottom-navigation

### DIFF
--- a/src/lib/components/BottomNavigationBar.svelte
+++ b/src/lib/components/BottomNavigationBar.svelte
@@ -19,7 +19,7 @@
 
     const bottomNavBarItems = config?.bottomNavBarItems;
 
-    const barBackgroundColor = $derived($s?.['ui.bottom-navigation.']['background-color']);
+    const barBackgroundColor = $derived($s?.['ui.bottom-navigation.bar']['background-color']);
     const barTextColor = $derived($s?.['ui.bottom-navigation.item.text']['color']);
     const barTextSelectedColor = $derived($s?.['ui.bottom-navigation.item.text.selected']['color']);
 

--- a/src/lib/components/BottomNavigationBar.svelte
+++ b/src/lib/components/BottomNavigationBar.svelte
@@ -19,7 +19,9 @@
 
     const bottomNavBarItems = config?.bottomNavBarItems;
 
-    const barBackgroundColor = $derived($s?.['ui.bottom-navigation.bar']['background-color']);
+    const barBackgroundColor = $derived(
+        ($s?.['ui.bottom-navigation.bar'] ?? $s?.['ui.bottom-navigation.'])?.['background-color']
+    );
     const barTextColor = $derived($s?.['ui.bottom-navigation.item.text']['color']);
     const barTextSelectedColor = $derived($s?.['ui.bottom-navigation.item.text.selected']['color']);
 


### PR DESCRIPTION
Missing "bar" from ui.bottom-navigation caused the PWA to crash on launch with error about not being able to find 'background-color' from undefined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the bottom navigation bar background color to correctly read the intended UI style setting, restoring the intended appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->