### PR TITLE
fix: add missing filled-circle style for PlayButton

### DIFF
--- a/src/lib/components/PlayButton.svelte
+++ b/src/lib/components/PlayButton.svelte
@@ -11,6 +11,11 @@
         'outline-circle': {
             play: AudioIcon.PlayOutlineCircle,
             pause: AudioIcon.PauseOutlineCircle
+        },
+
+        'filled-circle': {
+            play: AudioIcon.PlayFillCircle,
+            pause: AudioIcon.PauseFillCircle
         }
     };
 

--- a/src/lib/icons/audio/PauseFillCircleIcon.svelte
+++ b/src/lib/icons/audio/PauseFillCircleIcon.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+    // Pause Circle from https://fonts.google.com/icons
+    // Filled = 1
+    // Weight = 400
+    // Grade = 0
+    // Optical size = 24px
+    let { color = 'black', size = 24 } = $props();
+</script>
+
+<svg
+    fill={color}
+    xmlns="http://www.w3.org/2000/svg"
+    height={size}
+    viewBox="0 -960 960 960"
+    width={size}
+    ><path
+        d="M360-320h80v-320h-80v320Zm160 0h80v-320h-80v320ZM480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Z"
+    /></svg
+>

--- a/src/lib/icons/audio/index.ts
+++ b/src/lib/icons/audio/index.ts
@@ -1,6 +1,7 @@
 import FastForwardIcon from './FastForwardIcon.svelte';
 import Forward10Icon from './Forward10Icon.svelte';
 import MuteIcon from './MuteIcon.svelte';
+import PauseFillCircleIcon from './PauseFillCircleIcon.svelte';
 import PauseIcon from './PauseIcon.svelte';
 import PauseOutlineCircleIcon from './PauseOutlineCircleIcon.svelte';
 import PlayFillCircleIcon from './PlayFillCircleIcon.svelte';
@@ -24,6 +25,7 @@ const AudioIcon = {
     Mute: MuteIcon,
     Pause: PauseIcon,
     PlayFillCircle: PlayFillCircleIcon,
+    PauseFillCircle: PauseFillCircleIcon,
     Play: PlayIcon,
     PlayOutlineCircle: PlayOutlineCircleIcon,
     PauseOutlineCircle: PauseOutlineCircleIcon,


### PR DESCRIPTION
How did we miss this, since it preexists the outline-circle style in SAB???

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new audio control icon for a filled pause-in-circle state.
  * Expanded audio button icon support so play and pause states now map correctly across circle styles.

* **Bug Fixes**
  * Fixed an icon mapping issue in the audio play button, improving the correct display of button states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->