### PR TITLE
Fix upper-right navigate to reference button on pop-ups not working

### DIFF
--- a/src/lib/components/StackView.svelte
+++ b/src/lib/components/StackView.svelte
@@ -118,7 +118,7 @@
                 class="footnote rounded-sm h-40 shadow-lg overflow-y-auto"
                 onclick={(e) => {
                     e.stopPropagation();
-                    insideClick(e.currentTarget);
+                    insideClick((e.target || e.currentTarget) as HTMLElement);
                 }}
             >
                 <div


### PR DESCRIPTION
The event wasn't being handled properly because it was being handled based on the *current* element after it propagated to the parent div. This is a one-line fix. The indicated button should now work and navigate to the referenced passage (example from Mateo 3, CUK in the SAB PWA test app).

<img width="1008" height="790" alt="image" src="https://github.com/user-attachments/assets/01f68dbd-0634-4527-b623-0e6c85392e1a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved click handling in footnote areas so the app now checks the actual clicked element first, with a fallback to the container.
  * This makes reference and icon interactions more reliable when clicking inside footnotes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->