### PR TITLE
feat: verify if audio is reachable during conversion

### DIFF
--- a/config/index.d.ts
+++ b/config/index.d.ts
@@ -105,18 +105,18 @@ export type BookCollectionConfig = {
     collectionDescription?: string;
 };
 
+export type AudioSource = {
+    type: string;
+    name: string;
+    accessMethods?: string[];
+    folder?: string;
+    key?: string;
+    damId?: string;
+    address?: string;
+};
+
 export type AudioConfig = {
-    sources: {
-        [key: string]: {
-            type: string;
-            name: string;
-            accessMethods?: string[];
-            folder?: string;
-            key?: string;
-            damId?: string;
-            address?: string;
-        };
-    };
+    sources: Record<string, AudioSource>;
     files?: {
         name: string;
         src: string;

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -1409,7 +1409,12 @@ export async function verifyMediaAvailability(config: AppConfig, verbose: number
                 }
 
                 if (path) {
-                    return testRemoteAccess(path, (status) => `${key} - ${status} ${path}`, () => (pass = false), verbose);
+                    return testRemoteAccess(
+                        path,
+                        (status) => `${key} - ${status} ${path}`,
+                        () => (pass = false),
+                        verbose
+                    );
                 }
             })
         );
@@ -1427,7 +1432,12 @@ export async function verifyMediaAvailability(config: AppConfig, verbose: number
         }
         await Promise.all(
             remoteVideos.map((v) =>
-                testRemoteAccess(v.onlineUrl, (status) => `${status} "${v.title ?? v.id}" (${v.onlineUrl})`, () => {}, verbose)
+                testRemoteAccess(
+                    v.onlineUrl,
+                    (status) => `${status} "${v.title ?? v.id}" (${v.onlineUrl})`,
+                    () => {},
+                    verbose
+                )
             )
         );
     }

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -218,19 +218,35 @@ function isDictionaryConfig(data: ScriptureConfig | DictionaryConfig): data is D
     return data.programType === 'DAB';
 }
 
-function convertConfig(dataDir: string, verbose: number) {
-    const genAssets = path.join('src/gen-assets');
-    if (!existsSync(genAssets)) {
-        mkdirSync(genAssets, { recursive: true });
-    }
+export function getProgramType(dataDir: string) {
+    return extractProgramType(openConfigAsXMLDocument(dataDir)).programType;
+}
+
+function openConfigAsXMLDocument(dataDir: string) {
     const dom = new jsdom.JSDOM(readFileSync(path.join(dataDir, 'appdef.xml')).toString(), {
         contentType: 'text/xml'
     });
     const { document } = dom.window;
 
-    // Program info
+    return document;
+}
+
+function extractProgramType(document: Document) {
     const appDefinition = document.getElementsByTagName('app-definition')[0];
     const programType = appDefinition.attributes.getNamedItem('type')!.value;
+
+    return { appDefinition, programType };
+}
+
+function convertConfig(dataDir: string, verbose: number) {
+    const genAssets = path.join('src/gen-assets');
+    if (!existsSync(genAssets)) {
+        mkdirSync(genAssets, { recursive: true });
+    }
+    const document = openConfigAsXMLDocument(dataDir);
+
+    // Program info
+    const { appDefinition, programType } = extractProgramType(document);
 
     // Program type determines data object type
     const data = setConfigType(programType);

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, type PathLike } from 
 import path, { basename, extname, join } from 'path';
 import type {
     AppConfig,
+    AudioConfig,
     BookCollectionAudioConfig,
     BookCollectionConfig,
     BookTabConfig,
@@ -14,6 +15,8 @@ import type {
 } from '$config';
 import jsdom from 'jsdom';
 import { isDAB, isSAB } from '../src/lib/scripts/configUtils';
+import { getBibleBrainUrl } from '../src/lib/scripts/mediaUtils';
+import { pathJoin } from '../src/lib/scripts/stringUtils';
 import { convertMarkdownsToHTML } from './convertMarkdown';
 import { getHashedName } from './fileUtils';
 import { splitVersion } from './stringUtils';
@@ -231,7 +234,7 @@ function extractProgramType(document: Document) {
     return { appDefinition, programType };
 }
 
-function convertConfig(dataDir: string, verbose: number) {
+async function convertConfig(dataDir: string, verbose: number) {
     const genAssets = path.join('src/gen-assets');
     if (!existsSync(genAssets)) {
         mkdirSync(genAssets, { recursive: true });
@@ -373,6 +376,12 @@ function convertConfig(dataDir: string, verbose: number) {
             data.watermarkImages = watermarkImages;
         }
     }
+
+    /**
+     * DAB, SAB: depends on audioSources
+     * SAB only: depends on audioSources, videos, bookCollections
+     */
+    await verifyMediaAvailability(data, verbose);
 
     const menuItems = parseMenuItems(document, 'drawer', verbose);
     if (menuItems.length > 0) {
@@ -1309,6 +1318,168 @@ export function parseVideos(document: Document, verbose: number) {
     return videos;
 }
 
+export async function verifyMediaAvailability(config: AppConfig, verbose: number) {
+    type MediaType =
+        | ({ type: 'file' } & NonNullable<AudioConfig['files']>[number])
+        | ({ type: 'video' } & NonNullable<ScriptureConfig['videos']>[number])
+        | ({
+              type: 'book';
+              collection: string;
+              book: string;
+              chapter: string;
+          } & BookCollectionAudioConfig);
+    // check all downloadable files
+    const sources = new Map(
+        Object.entries(config.audio?.sources ?? {})
+            .filter((s) => s[1].accessMethods?.includes('download'))
+            .map(([key, value]) => [
+                key,
+                {
+                    ...value,
+                    errored: false,
+                    media: [
+                        ...(config.audio?.files
+                            ?.filter((f) => f.src === key)
+                            .map((f) => ({ type: 'file', ...f })) ?? []),
+                        ...(isSAB(config)
+                            ? [
+                                  ...(config.videos
+                                      ?.filter((v) => v.src === key)
+                                      .map((v) => ({ type: 'video', ...v })) ?? []),
+                                  ...(config.bookCollections?.flatMap((bc) =>
+                                      bc.books.flatMap((b) =>
+                                          b.audio
+                                              .filter((a) => a.src === key)
+                                              .map((a) => ({
+                                                  type: 'book',
+                                                  ...a,
+                                                  collection: bc.id,
+                                                  book: b.id,
+                                                  chapter: String(a.num)
+                                              }))
+                                      )
+                                  ) ?? [])
+                              ]
+                            : [])
+                    ] as MediaType[]
+                }
+            ])
+    );
+
+    if (verbose && sources.size) {
+        console.log(`Verifying access to ${sources.size} media sources...`);
+    }
+
+    for (const [key, source] of sources.entries()) {
+        if (verbose) {
+            if (source.media.length) {
+                console.log(
+                    ` Verifying access to ${source.media.length} files for media source ${key} (${source.type}) - ${source.name}...`
+                );
+            } else {
+                console.log(
+                    ` ⚠️ No media included for source ${key} (${source.type}) - ${source.name}`
+                );
+            }
+        }
+
+        let pass = true;
+
+        await Promise.all(
+            source.media.map(async (v) => {
+                let path = '';
+                if (source.type === 'fcbh' && v.type === 'book') {
+                    const res = await getBibleBrainUrl(source, v, (source) => source.damId);
+                    if (res.error) {
+                        pass = false;
+                        console.log(
+                            ` ⚠️ ${key} - (${v.collection} ${v.book} ${v.chapter}) API Error: ${res.error}`
+                        );
+                    } else {
+                        path = res.path ?? '';
+                    }
+                } else if (source.type === 'download') {
+                    path = pathJoin([source.address, v.type === 'file' ? v.name : v.filename]);
+                }
+
+                if (path) {
+                    return fetch(path, { method: 'HEAD' }).then(
+                        (response) => {
+                            if (!response.ok) {
+                                pass = false;
+                                console.log(` ⚠️ ${key} - ${response.statusText} ${path}`);
+                            } else if (verbose) {
+                                console.log(` ✅ ${key} - ${response.statusText}  ${path}`);
+                            }
+                        },
+                        (rejection) => {
+                            pass = false;
+                            console.log(` ⚠️ ${key} - ${rejection} ${path}`);
+                        }
+                    );
+                }
+            })
+        );
+
+        if (!pass) {
+            source.errored = true;
+        }
+    }
+
+    if (isSAB(config)) {
+        // check all remote videos
+        const remoteVideos = config.videos?.filter((v) => v.onlineUrl) ?? [];
+        if (verbose && remoteVideos.length) {
+            console.log(`Verifying access to ${remoteVideos.length} remote videos...`);
+        }
+        await Promise.all(
+            remoteVideos.map((v) =>
+                fetch(v.onlineUrl, { method: 'HEAD' }).then(
+                    (response) => {
+                        if (!response.ok) {
+                            console.log(
+                                ` ⚠️ ${response.statusText} "${v.title ?? v.id}" (${v.onlineUrl})`
+                            );
+                        } else if (verbose) {
+                            console.log(
+                                ` ✅ ${response.statusText} "${v.title ?? v.id}" (${v.onlineUrl})`
+                            );
+                        }
+                    },
+                    (rejection) =>
+                        console.log(` ⚠️ ${rejection} "${v.title ?? v.id}" (${v.onlineUrl})`)
+                )
+            )
+        );
+    }
+
+    for (const [key, source] of sources.entries()) {
+        if (source.errored) {
+            config.audio!.sources[key].accessMethods = config.audio!.sources[
+                key
+            ].accessMethods?.filter((m) => m !== 'download');
+            console.log(
+                ` ⚠️ An error was encountered when verifying download access to media source ${key} (${source.type}) - ${source.name}. Download access to this source has been removed for this build.`
+            );
+        }
+    }
+
+    const noAccessMethods = Object.entries(config.audio?.sources ?? {})
+        .filter(
+            (s) => (s[1].type === 'download' || s[1].type === 'fcbh') && !s[1].accessMethods?.length
+        )
+        .map(([k, v]) => `${k} (${v.type}) - ${v.name}`)
+        .join(', ');
+
+    if (noAccessMethods) {
+        const missinMethodError = new Error(
+            `No access methods found for media sources ${noAccessMethods}.`
+        );
+        missinMethodError.stack = `Error in ${__filename}:verifyMediaAvailability(): ${missinMethodError.message}`;
+        throw missinMethodError;
+    }
+}
+
 export function parseIllustrations(document: Document, verbose: number) {
     const imagesTags = document.getElementsByTagName('images');
     const illustrations: any[] = [];
@@ -1701,8 +1872,8 @@ export interface ConfigTaskOutput extends TaskOutput {
  */
 export class ConvertConfig extends Task {
     public triggerFiles: string[] = ['appdef.xml'];
-    public run(verbose: number): ConfigTaskOutput {
-        const data = convertConfig(this.dataDir, verbose);
+    public async run(verbose: number): Promise<ConfigTaskOutput> {
+        const data = await convertConfig(this.dataDir, verbose);
         return {
             taskName: 'ConvertConfig',
             data,

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -13,6 +13,7 @@ import type {
     WritingSystemConfig
 } from '$config';
 import jsdom from 'jsdom';
+import { isDAB, isSAB } from '../src/lib/scripts/configUtils';
 import { convertMarkdownsToHTML } from './convertMarkdown';
 import { getHashedName } from './fileUtils';
 import { splitVersion } from './stringUtils';
@@ -210,14 +211,6 @@ function setConfigType(programType: string) {
     }
 }
 
-function isScriptureConfig(data: ScriptureConfig | DictionaryConfig): data is ScriptureConfig {
-    return data.programType === 'SAB';
-}
-
-function isDictionaryConfig(data: ScriptureConfig | DictionaryConfig): data is DictionaryConfig {
-    return data.programType === 'DAB';
-}
-
 export function getProgramType(dataDir: string) {
     return extractProgramType(openConfigAsXMLDocument(dataDir)).programType;
 }
@@ -287,7 +280,7 @@ function convertConfig(dataDir: string, verbose: number) {
     const mainStyles = document.querySelector('styles')!;
     data.styles = parseStyles(mainStyles, verbose);
 
-    if (isDictionaryConfig(data)) {
+    if (isDAB(data)) {
         const singleEntryStyles = document.querySelector('styles[type=single-entry]');
         if (singleEntryStyles) {
             data.singleEntryStyles = parseStyles(singleEntryStyles, verbose);
@@ -296,7 +289,7 @@ function convertConfig(dataDir: string, verbose: number) {
         }
     }
 
-    if (isScriptureConfig(data)) {
+    if (isSAB(data)) {
         data.traits = parseTraits(document, dataDir, verbose);
         data.bookCollections = parseBookCollections(document, dataDir, verbose);
 
@@ -306,7 +299,7 @@ function convertConfig(dataDir: string, verbose: number) {
                 (bc) => bc.books.filter((b) => b.type === 'glossary').length > 0
             ).length > 0;
     }
-    if (isDictionaryConfig(data)) {
+    if (isDAB(data)) {
         const writingSystems: { [key: string]: DictionaryWritingSystemConfig } = {};
         const writingSystemsTag = document.getElementsByTagName('writing-systems')[0];
         const writingSystemTags = writingSystemsTag.getElementsByTagName('writing-system');
@@ -348,7 +341,7 @@ function convertConfig(dataDir: string, verbose: number) {
         }
     }
 
-    if (isScriptureConfig(data)) {
+    if (isSAB(data)) {
         const videos = parseVideos(document, verbose);
         if (videos.length > 0) {
             data.videos = videos;
@@ -386,7 +379,7 @@ function convertConfig(dataDir: string, verbose: number) {
         data.menuItems = menuItems;
     }
 
-    if (isScriptureConfig(data)) {
+    if (isSAB(data)) {
         const bottomNavigationItems = parseMenuItems(document, 'bottom', verbose);
         if (bottomNavigationItems.length > 0) {
             data.bottomNavBarItems = bottomNavigationItems;
@@ -1644,7 +1637,7 @@ function filterFeaturesNotReady(data: ScriptureConfig | DictionaryConfig) {
     data.mainFeatures['user-accounts'] = false;
 
     // Two pane and Verse-By-Verse are not done
-    if (isScriptureConfig(data)) {
+    if (isSAB(data)) {
         // Two pane and Verse-By-Verse are not done
         if (data.layouts) {
             for (const layout of data.layouts) {

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -1461,11 +1461,11 @@ export async function verifyMediaAvailability(config: AppConfig, verbose: number
         .join(', ');
 
     if (noAccessMethods) {
-        const missinMethodError = new Error(
+        const missingMethodError = new Error(
             `No access methods found for media sources ${noAccessMethods}.`
         );
-        missinMethodError.stack = `Error in ${__filename}:verifyMediaAvailability(): ${missinMethodError.message}`;
-        throw missinMethodError;
+        missingMethodError.stack = `Error in ${__filename}:verifyMediaAvailability(): ${missingMethodError.message}`;
+        throw missingMethodError;
     }
 }
 

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -1403,20 +1403,7 @@ export async function verifyMediaAvailability(config: AppConfig, verbose: number
                 }
 
                 if (path) {
-                    return fetch(path, { method: 'HEAD' }).then(
-                        (response) => {
-                            if (!response.ok) {
-                                pass = false;
-                                console.log(` ⚠️ ${key} - ${response.statusText} ${path}`);
-                            } else if (verbose) {
-                                console.log(` ✅ ${key} - ${response.statusText}  ${path}`);
-                            }
-                        },
-                        (rejection) => {
-                            pass = false;
-                            console.log(` ⚠️ ${key} - ${rejection} ${path}`);
-                        }
-                    );
+                    return testRemoteAccess(path, (status) => `${key} - ${status} ${path}`, () => (pass = false), verbose);
                 }
             })
         );
@@ -1434,21 +1421,7 @@ export async function verifyMediaAvailability(config: AppConfig, verbose: number
         }
         await Promise.all(
             remoteVideos.map((v) =>
-                fetch(v.onlineUrl, { method: 'HEAD' }).then(
-                    (response) => {
-                        if (!response.ok) {
-                            console.log(
-                                ` ⚠️ ${response.statusText} "${v.title ?? v.id}" (${v.onlineUrl})`
-                            );
-                        } else if (verbose) {
-                            console.log(
-                                ` ✅ ${response.statusText} "${v.title ?? v.id}" (${v.onlineUrl})`
-                            );
-                        }
-                    },
-                    (rejection) =>
-                        console.log(` ⚠️ ${rejection} "${v.title ?? v.id}" (${v.onlineUrl})`)
-                )
+                testRemoteAccess(v.onlineUrl, (status) => `${status} "${v.title ?? v.id}" (${v.onlineUrl})`, () => {}, verbose)
             )
         );
     }
@@ -1477,6 +1450,41 @@ export async function verifyMediaAvailability(config: AppConfig, verbose: number
         );
         missinMethodError.stack = `Error in ${__filename}:verifyMediaAvailability(): ${missinMethodError.message}`;
         throw missinMethodError;
+    }
+}
+
+async function testRemoteAccess(
+    path: string,
+    display: (status: string) => string,
+    fail: () => void,
+    verbose: number
+) {
+    try {
+        await fetch(path, {
+            method: 'OPTIONS',
+            headers: { 'Access-Control-Request-Method': 'GET', Origin: '*' }
+        }).then(
+            (response) => {
+                const origin = response.headers.get('Access-Control-Allow-Origin');
+                const methods =
+                    response.headers.get('Access-Control-Allow-Methods')?.split(/,\s*/) ?? [];
+                if (!(response.ok && origin === '*' && methods.includes('GET'))) {
+                    fail();
+                    console.log(
+                        ` ⚠️ ${display(response.statusText)}${verbose && origin !== '*' ? `\n Origin: '${origin}'` : ''}${verbose && !methods.includes('GET') ? `\n Methods: '${methods.join(', ')}'` : ''}`
+                    );
+                } else if (verbose) {
+                    console.log(` ✅ ${display(response.statusText)}`);
+                }
+            },
+            (rejection) => {
+                fail();
+                console.log(` ⚠️ ${display(rejection)}`);
+            }
+        );
+    } catch (e) {
+        fail();
+        console.log(` ⚠️ ${display(e instanceof Error ? e.message : (e as string))}`);
     }
 }
 

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -14,6 +14,7 @@ import type {
     WritingSystemConfig
 } from '$config';
 import jsdom from 'jsdom';
+import { shuffleArray } from '../src/lib/scripts/arrayUtils';
 import { isDAB, isSAB } from '../src/lib/scripts/configUtils';
 import { getBibleBrainUrl } from '../src/lib/scripts/mediaUtils';
 import { pathJoin } from '../src/lib/scripts/stringUtils';
@@ -1371,10 +1372,15 @@ export async function verifyMediaAvailability(config: AppConfig, verbose: number
     }
 
     for (const [key, source] of sources.entries()) {
+        const sampleSize = Math.min(
+            source.media.length,
+            Math.max(10, Math.floor(Math.sqrt(source.media.length)))
+        );
+        const sample = shuffleArray(source.media).slice(0, sampleSize);
         if (verbose) {
             if (source.media.length) {
                 console.log(
-                    ` Verifying access to ${source.media.length} files for media source ${key} (${source.type}) - ${source.name}...`
+                    ` Testing access to ${sampleSize}/${source.media.length} files for media source ${key} (${source.type}) - ${source.name}...`
                 );
             } else {
                 console.log(
@@ -1386,7 +1392,7 @@ export async function verifyMediaAvailability(config: AppConfig, verbose: number
         let pass = true;
 
         await Promise.all(
-            source.media.map(async (v) => {
+            sample.map(async (v) => {
                 let path = '';
                 if (source.type === 'fcbh' && v.type === 'book') {
                     const res = await getBibleBrainUrl(source, v, (source) => source.damId);

--- a/convert/index.ts
+++ b/convert/index.ts
@@ -4,7 +4,7 @@ import { watch } from 'chokidar';
 import { ConvertAbout } from './convertAbout';
 import { ConvertBadges } from './convertBadges';
 import { ConvertBooks } from './convertBooks';
-import { ConvertConfig } from './convertConfig';
+import { ConvertConfig, getProgramType } from './convertConfig';
 import { ConvertContents } from './convertContents';
 import { ConvertFirebase } from './convertFirebase';
 import { ConvertManifest } from './convertManifest';
@@ -34,8 +34,7 @@ const verbose: number = verboseLevel
         : 1
     : 0;
 
-const config = new ConvertConfig(dataDir).run(verbose);
-const programType = config.data.programType;
+const programType = getProgramType(dataDir);
 
 //Classes common to both SAB and DAB
 const commonStepClasses = [

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -351,16 +351,19 @@ LOGGING:
         switch (textType) {
             case 'xref':
                 callerType = getFeatureValueString(
+                    scriptureConfig,
                     'crossref-caller-type',
                     references.collection,
                     references.book
                 );
                 callerCustomSymbol = getFeatureValueString(
+                    scriptureConfig,
                     'crossref-caller-symbol',
                     references.collection,
                     references.book
                 );
                 callerNoCallerToAuto = getFeatureValueBoolean(
+                    scriptureConfig,
                     'crossref-caller-no-caller-to-auto',
                     references.collection,
                     references.book
@@ -369,16 +372,19 @@ LOGGING:
 
             default:
                 callerType = getFeatureValueString(
+                    scriptureConfig,
                     'footnote-caller-type',
                     references.collection,
                     references.book
                 );
                 callerCustomSymbol = getFeatureValueString(
+                    scriptureConfig,
                     'footnote-caller-symbol',
                     references.collection,
                     references.book
                 );
                 callerNoCallerToAuto = getFeatureValueBoolean(
+                    scriptureConfig,
                     'footnote-caller-no-caller-to-auto',
                     references.collection,
                     references.book
@@ -595,6 +601,7 @@ LOGGING:
         if (workspace.firstVerse === true && workspace.chapterNumText !== '') {
             const div = document.createElement('div');
             const chapterNumberFormatSetting = getFeatureValueString(
+                scriptureConfig,
                 'chapter-number-format',
                 references.collection,
                 references.book
@@ -2030,6 +2037,7 @@ LOGGING:
                                 if (element.subType === 'chapter_label') {
                                     if (
                                         getFeatureValueBoolean(
+                                            scriptureConfig,
                                             'show-chapter-numbers',
                                             references.collection,
                                             references.book
@@ -2050,6 +2058,7 @@ LOGGING:
                                             const div = document.createElement('div');
                                             const chapterNumberFormatSetting =
                                                 getFeatureValueString(
+                                                    scriptureConfig,
                                                     'chapter-number-format',
                                                     references.collection,
                                                     references.book

--- a/src/lib/components/SearchForm.svelte
+++ b/src/lib/components/SearchForm.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
     import config, { dictionaryConfig } from '$assets/config';
-    import { convertStyle, isDAB, isSAB, s, t, themeColors } from '$lib/data/stores';
+    import { convertStyle, s, t, themeColors } from '$lib/data/stores';
     import { SearchIcon } from '$lib/icons';
+    import { isDAB, isSAB } from '$lib/scripts/configUtils';
     import type { SearchFormSubmitEvent } from '$lib/types';
 
     interface SearchFormProps {

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -12,8 +12,6 @@ The sidebar/drawer.
     import {
         direction,
         fontChoices,
-        isDAB,
-        isSAB,
         language,
         languageDefault,
         modal,
@@ -41,6 +39,7 @@ The sidebar/drawer.
         ShareIcon,
         TextAppearanceIcon
     } from '$lib/icons';
+    import { isDAB, isSAB } from '$lib/scripts/configUtils';
     import { resolve } from '$lib/utils/paths';
     import { showTextAppearance } from './TextAppearanceSelector.svelte';
 

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -1,4 +1,5 @@
 import { scriptureConfig } from '$assets/config';
+import type { AudioSource } from '$config';
 import { MRUCache } from '$lib/data/mrucache';
 import {
     audioHighlightElements,
@@ -13,6 +14,7 @@ import {
     type PlayModeSettings,
     type Timing
 } from '$lib/data/stores';
+import { getBibleBrainUrl } from '$lib/scripts/mediaUtils';
 import { pathJoin } from '$lib/scripts/stringUtils';
 import { logAudioDuration, logAudioPlay } from './analytics';
 
@@ -662,9 +664,10 @@ export function updatePlaybackSpeed(playbackSpeed: string) {
         currentAudioPlayer.audio.playbackRate = parseFloat(playbackSpeed);
     }
 }
-function getDamId(audioSource: any) {
+
+function getDamId(audioSource: AudioSource) {
     let damId = audioSource.damId;
-    if (damId.endsWith('-opus16')) {
+    if (damId?.endsWith('-opus16')) {
         // Check to see if the browser can handle webm files.
         const audio = new Audio();
         if (!audio.canPlayType('audio/webm')) {
@@ -673,6 +676,7 @@ function getDamId(audioSource: any) {
     }
     return damId;
 }
+
 export async function getAudioSourceInfo(
     item: Partial<{
         collection: string;
@@ -693,24 +697,12 @@ export async function getAudioSourceInfo(
     let audioPath = null;
 
     if (audioSource?.type === 'fcbh') {
-        const dbp4 = audioSource.address ? audioSource.address : 'https://4.dbt.io';
-        // if (source.accessMethods.includes('download')) {
-        //    // TODO: Figure out how to use Cache API to download audio to PWA
-        // }
-        const damId = getDamId(audioSource);
-        const request = `${dbp4}/api/bibles/filesets/${damId}/${item.book}/${item.chapter}?v=4&key=${audioSource.key}`;
-        const response = await fetch(request, {
-            method: 'GET',
-            headers: {
-                accept: 'application/json'
-            }
-        });
-        const result = await response.json();
+        const result = await getBibleBrainUrl(audioSource, item, getDamId);
         if (result.error) {
-            throw `Failed to connect to BibleBrain: ${result.error}`;
+            throw new Error(`Failed to connect to BibleBrain: ${result.error}`);
         }
 
-        audioPath = result.data[0].path;
+        audioPath = result.path;
     } else if (audioSource?.type === 'assets') {
         const audioKey = `./${audio.filename}`;
         if (!audioSources[audioKey]) {

--- a/src/lib/data/stores/setting.ts
+++ b/src/lib/data/stores/setting.ts
@@ -1,7 +1,8 @@
 import config, { scriptureConfig } from '$assets/config';
-import type { AppConfig, DictionaryConfig, FeatureConfig, ScriptureConfig } from '$config';
+import type { FeatureConfig } from '$config';
 import { getDefaultLanguage } from '$lib/data/language';
 import { mergeDefaultStorage, setDefaultStorage } from '$lib/data/stores/storage';
+import { isSAB } from '$lib/scripts/configUtils';
 import { derived, readable, writable } from 'svelte/store';
 
 export const SettingsCategory = {
@@ -47,14 +48,6 @@ const sabDefaultSettings = {
     'desktop-sidebar': false,
     'scripture-logs': false
 };
-
-export function isSAB(data: AppConfig): data is ScriptureConfig {
-    return data.programType === 'SAB';
-}
-
-export function isDAB(data: AppConfig): data is DictionaryConfig {
-    return data.programType === 'DAB';
-}
 
 export const defaultSettings: FeatureConfig = isSAB(config)
     ? { ...commonDefaultSettings, ...sabDefaultSettings }

--- a/src/lib/scripts/arrayUtils.ts
+++ b/src/lib/scripts/arrayUtils.ts
@@ -1,0 +1,17 @@
+export function getRandomItem<T>(array: T[]) {
+    return array[Math.floor(Math.random() * array.length)];
+}
+
+export function shuffleArray<T>(array: T[]) {
+    let currentIndex = array.length;
+    let randomIndex = 0;
+
+    while (currentIndex !== 0) {
+        randomIndex = Math.floor(Math.random() * currentIndex);
+        currentIndex--;
+
+        [array[currentIndex], array[randomIndex]] = [array[randomIndex], array[currentIndex]];
+    }
+
+    return array;
+}

--- a/src/lib/scripts/configUtils.ts
+++ b/src/lib/scripts/configUtils.ts
@@ -1,22 +1,31 @@
-import config, { scriptureConfig } from '$assets/config';
-import type { BookCollectionConfig, BookConfig, ScriptureConfig, StyleConfig } from '$config';
+import type {
+    AppConfig,
+    BookCollectionConfig,
+    BookConfig,
+    DictionaryConfig,
+    ScriptureConfig,
+    StyleConfig
+} from '$config';
 
-export function getFeatureValueBoolean(feature: string, bc: string, book: string): boolean {
+export function getFeatureValueBoolean(
+    config: ScriptureConfig,
+    feature: string,
+    bc: string,
+    book: string
+): boolean {
     let returnValue = false;
     let value: any = '';
     if (config.mainFeatures[feature] != null) {
         value = config.mainFeatures[feature];
     }
-    const bookCollectionFeatures = scriptureConfig.bookCollections?.find(
-        (x) => x.id === bc
-    )?.features;
+    const bookCollectionFeatures = config.bookCollections?.find((x) => x.id === bc)?.features;
     if (bookCollectionFeatures != null) {
         const bookCollectionFeature = bookCollectionFeatures[feature];
         if (bookCollectionFeature != null && bookCollectionFeature != 'inherit') {
             value = bookCollectionFeatures[feature];
         }
     }
-    const bookFeatures = scriptureConfig.bookCollections
+    const bookFeatures = config.bookCollections
         ?.find((x) => x.id === bc)
         ?.books.find((x) => x.id === book)?.features;
     if (bookFeatures != null) {
@@ -33,21 +42,24 @@ export function getFeatureValueBoolean(feature: string, bc: string, book: string
 
     return returnValue;
 }
-export function getFeatureValueString(feature: string, bc: string, book: string): string {
+export function getFeatureValueString(
+    config: ScriptureConfig,
+    feature: string,
+    bc: string,
+    book: string
+): string {
     let value = '';
     if (config.mainFeatures[feature] != null) {
         value = config.mainFeatures[feature] as string;
     }
-    const bookCollectionFeatures = scriptureConfig.bookCollections?.find(
-        (x) => x.id === bc
-    )?.features;
+    const bookCollectionFeatures = config.bookCollections?.find((x) => x.id === bc)?.features;
     if (bookCollectionFeatures != null) {
         const bookCollectionFeature = bookCollectionFeatures[feature];
         if (bookCollectionFeature != null && bookCollectionFeature != 'inherit') {
             value = bookCollectionFeatures[feature] as string;
         }
     }
-    const bookFeatures = scriptureConfig.bookCollections
+    const bookFeatures = config.bookCollections
         ?.find((x) => x.id === bc)
         ?.books.find((x) => x.id === book)?.features;
     if (bookFeatures != null) {
@@ -59,7 +71,7 @@ export function getFeatureValueString(feature: string, bc: string, book: string)
     // console.log('getFeatureValueString %o %o', feature, value);
     return value;
 }
-export function hasFeature(feature: string) {
+export function hasFeature(config: AppConfig, feature: string) {
     return config.mainFeatures[feature] != null;
 }
 
@@ -87,4 +99,12 @@ export function getStyle(
     }
     // No style was found.
     return '';
+}
+
+export function isSAB(data: Pick<AppConfig, 'programType'>): data is ScriptureConfig {
+    return data.programType === 'SAB';
+}
+
+export function isDAB(data: Pick<AppConfig, 'programType'>): data is DictionaryConfig {
+    return data.programType === 'DAB';
 }

--- a/src/lib/scripts/mediaUtils.ts
+++ b/src/lib/scripts/mediaUtils.ts
@@ -1,0 +1,32 @@
+import type { AudioSource } from '$config';
+
+export async function getBibleBrainUrl(
+    audioSource: AudioSource,
+    item: Partial<{
+        collection: string;
+        book: string;
+        chapter: string;
+    }>,
+    getDamId: (src: AudioSource) => string | undefined
+): Promise<{ error: unknown; path?: never } | { error?: never; path: string }> {
+    const dbp4 = audioSource.address ? audioSource.address : 'https://4.dbt.io';
+    // if (source.accessMethods.includes('download')) {
+    //    // TODO: Figure out how to use Cache API to download audio to PWA
+    // }
+    const damId = getDamId(audioSource);
+    const request = `${dbp4}/api/bibles/filesets/${damId}/${item.book}/${item.chapter}?v=4&key=${audioSource.key}`;
+    const response = await fetch(request, {
+        method: 'GET',
+        headers: {
+            accept: 'application/json'
+        }
+    });
+
+    const json = await response.json();
+
+    if (!json.error) {
+        return { path: json.data[0].path };
+    }
+
+    return json;
+}

--- a/src/lib/scripts/mediaUtils.ts
+++ b/src/lib/scripts/mediaUtils.ts
@@ -9,24 +9,28 @@ export async function getBibleBrainUrl(
     }>,
     getDamId: (src: AudioSource) => string | undefined
 ): Promise<{ error: unknown; path?: never } | { error?: never; path: string }> {
-    const dbp4 = audioSource.address ? audioSource.address : 'https://4.dbt.io';
-    // if (source.accessMethods.includes('download')) {
-    //    // TODO: Figure out how to use Cache API to download audio to PWA
-    // }
-    const damId = getDamId(audioSource);
-    const request = `${dbp4}/api/bibles/filesets/${damId}/${item.book}/${item.chapter}?v=4&key=${audioSource.key}`;
-    const response = await fetch(request, {
-        method: 'GET',
-        headers: {
-            accept: 'application/json'
+    try {
+        const dbp4 = audioSource.address ? audioSource.address : 'https://4.dbt.io';
+        // if (source.accessMethods.includes('download')) {
+        //    // TODO: Figure out how to use Cache API to download audio to PWA
+        // }
+        const damId = getDamId(audioSource);
+        const request = `${dbp4}/api/bibles/filesets/${damId}/${item.book}/${item.chapter}?v=4&key=${audioSource.key}`;
+        const response = await fetch(request, {
+            method: 'GET',
+            headers: {
+                accept: 'application/json'
+            }
+        });
+
+        const json = await response.json();
+
+        if (!json.error) {
+            return { path: json.data[0].path };
         }
-    });
 
-    const json = await response.json();
-
-    if (!json.error) {
-        return { path: json.data[0].path };
+        return json;
+    } catch (error) {
+        return { error };
     }
-
-    return json;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,8 +2,9 @@
     import { goto } from '$app/navigation';
     import config from '$assets/config';
     import contents from '$assets/contents';
-    import { audioActive, isDAB, isFirstLaunch } from '$lib/data/stores';
+    import { audioActive, isFirstLaunch } from '$lib/data/stores';
     import { navigateToTextReference } from '$lib/navigate';
+    import { isDAB } from '$lib/scripts/configUtils';
     import { resolve } from '$lib/utils/paths';
     import { onMount } from 'svelte';
     import type { PageData } from './$types';

--- a/src/routes/quiz/[collection]/[id]/+page.svelte
+++ b/src/routes/quiz/[collection]/[id]/+page.svelte
@@ -1,23 +1,3 @@
-<script lang="ts" module>
-    function getRandomItem<T>(array: T[]) {
-        return array[Math.floor(Math.random() * array.length)];
-    }
-
-    function shuffle<T>(array: T[]) {
-        let currentIndex = array.length;
-        let randomIndex = 0;
-
-        while (currentIndex !== 0) {
-            randomIndex = Math.floor(Math.random() * currentIndex);
-            currentIndex--;
-
-            [array[currentIndex], array[randomIndex]] = [array[randomIndex], array[currentIndex]];
-        }
-
-        return array;
-    }
-</script>
-
 <script lang="ts">
     import { beforeNavigate, invalidateAll } from '$app/navigation';
     import { scriptureConfig } from '$assets/config';
@@ -43,6 +23,7 @@
         LockOpenIcon,
         TextAppearanceIcon
     } from '$lib/icons';
+    import { getRandomItem, shuffleArray } from '$lib/scripts/arrayUtils.js';
     import { compareVersions } from '$lib/scripts/stringUtils';
     import { onDestroy } from 'svelte';
     import type { ClassValue } from 'svelte/elements';
@@ -95,12 +76,12 @@
     );
     const questions: QuizQuestion[] = $derived(
         book?.quizFeatures?.['shuffle-questions']
-            ? shuffle([...(quiz?.questions ?? [])])
+            ? shuffleArray([...(quiz?.questions ?? [])])
             : [...(quiz?.questions ?? [])]
     );
     const currentQuestion: QuizQuestion | undefined = $derived(questions[currentQuestionIdx]);
     const shuffledAnswers: QuizAnswer[] = $derived(
-        shuffle(currentQuestion?.answers.map((a) => ({ ...a, clicked: false })) ?? [])
+        shuffleArray(currentQuestion?.answers.map((a) => ({ ...a, clicked: false })) ?? [])
     );
 
     const staticAssets = compareVersions(scriptureConfig.programVersion, '12.0') < 0;

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -156,7 +156,12 @@
     const hasNext = $derived($refs.next.chapter !== null);
     const viewShowVerses = $derived(
         ($userSettings['verse-numbers'] as boolean) ??
-            getFeatureValueBoolean('show-verse-numbers', $refs.collection, $refs.book)
+            getFeatureValueBoolean(
+                scriptureConfig,
+                'show-verse-numbers',
+                $refs.collection,
+                $refs.book
+            )
     );
 
     const minFontSize = config.mainFeatures['text-size-min'] as number;
@@ -177,7 +182,12 @@
     }
 
     const audioPhraseEndChars = $derived(
-        getFeatureValueString('audio-phrase-end-chars', $refs.collection, $refs.book)
+        getFeatureValueString(
+            scriptureConfig,
+            'audio-phrase-end-chars',
+            $refs.collection,
+            $refs.book
+        )
     );
 
     const showSearch = !!config.mainFeatures['search'];
@@ -188,7 +198,7 @@
     const showAudio = !!config.mainFeatures['audio-allow-turn-on-off'];
 
     const showBorderSetting = $derived(
-        getFeatureValueBoolean('show-border', $refs.collection, $refs.book)
+        getFeatureValueBoolean(scriptureConfig, 'show-border', $refs.collection, $refs.book)
     );
     const showBorder = $derived(
         !!(


### PR DESCRIPTION
Supports #1036, #992

When parsing the config, check all specified audio sources for if their associated files are reachable via the fetch API.
If one of the files fails to be fetched, the audio source has `download` removed as an access method and a warning is printed.
If after these checks have run, an audio source has no remaining access methods an error is thrown and conversion fails.

Notes:
- files are fetched using the OPTIONS method to mimic the browser's preflight check (and to save bandwidth and memory).
- I have implemented a sampling method to limit the number of requests made for each audio source.
  - The starting sample size is the square root of the total number of files associated with a given source.
  - If the sample size is less than 10, it is set to 10.
  - If the sample size is larger than the total number of files, the sample size will instead consist of all files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added preflight verification for downloadable media availability, so unavailable audio/video sources are automatically disabled during config generation.

* **Bug Fixes**
  * Improved chapter number, footnote/xref, and cross-reference rendering by aligning feature-flag evaluation across the app.
  * More reliable BibleBrain-based audio link resolution and safer handling of audio source identifiers.
  * Search and sidebar now consistently apply the same configuration checks as the rest of the UI.

* **Chores**
  * Reused shared array/audio/media utilities to keep behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->