### PR TITLE
#1003 Support new color themes

### DIFF
--- a/src/lib/components/AudioBar.svelte
+++ b/src/lib/components/AudioBar.svelte
@@ -116,7 +116,7 @@ TODO:
     {#if showRepeatMode}
         <div class="audio-control-buttons">
             <RepeatButton
-                color="{iconColor},"
+                color={iconColor}
                 onclick={() => playMode.next(!!$refs.hasAudio?.timingFile)}
                 state={$playMode.mode}
             />

--- a/src/lib/components/BookTabs.svelte
+++ b/src/lib/components/BookTabs.svelte
@@ -4,7 +4,15 @@ A component that displays the book tabs and allows the user to switch between th
 -->
 <script lang="ts">
     import { scriptureConfig } from '$assets/config';
-    import { convertStyle, language, monoIconColor, refs, s, theme } from '$lib/data/stores';
+    import {
+        convertStyle,
+        language,
+        monoIconColor,
+        refs,
+        s,
+        theme,
+        themeIsDark
+    } from '$lib/data/stores';
 
     const tabIcons = import.meta.glob('./*', {
         import: 'default',
@@ -36,7 +44,7 @@ A component that displays the book tabs and allows the user to switch between th
         onclick={() => changeTab(0)}
         style={convertStyle($s?.['ui.book.tabs'])}
     >
-        <picture class:invert={$theme === 'Dark'}>
+        <picture class:invert={themeIsDark($theme)}>
             <img
                 src={tabIcons[`./${getImageName(bookTabs?.mainType)}`]}
                 color={$monoIconColor}
@@ -52,7 +60,7 @@ A component that displays the book tabs and allows the user to switch between th
             onclick={() => changeTab(i + 1)}
             style={convertStyle($s?.['ui.book.tabs'])}
         >
-            <picture class:invert={$theme === 'Dark'}>
+            <picture class:invert={themeIsDark($theme)}>
                 <img
                     src={tabIcons[`./${getImageName(bookTab.type)}`]}
                     color={$monoIconColor}

--- a/src/lib/components/BottomNavigationBar.svelte
+++ b/src/lib/components/BottomNavigationBar.svelte
@@ -5,7 +5,7 @@
     import { goto } from '$app/navigation';
     import config, { scriptureConfig } from '$assets/config';
     import contents from '$assets/contents';
-    import { language, languageDefault, refs, s, theme } from '$lib/data/stores';
+    import { language, languageDefault, refs, s, theme, themeIsDark } from '$lib/data/stores';
     import { resolve } from '$lib/utils/paths';
 
     const menuIcons = import.meta.glob('./*', {
@@ -135,7 +135,7 @@
                             class="dy-btn dy-btn-ghost flex-col gap-1 my-2"
                             onclick={() => handleClick(item.type, item.link?.['default'])}
                         >
-                            <picture class:invert={$theme === 'Dark'}>
+                            <picture class:invert={themeIsDark($theme)}>
                                 <!-- Image Icon -->
                                 <img
                                     src={menuIcons[`./${item.images?.[0]?.file}`]}

--- a/src/lib/components/SelectList.svelte
+++ b/src/lib/components/SelectList.svelte
@@ -3,7 +3,7 @@
 A component to display menu options in a list.
 -->
 <script lang="ts">
-    import { convertStyle, s, theme, themeColors } from '$lib/data/stores';
+    import { convertStyle, s, theme, themeColors, themeIsDark } from '$lib/data/stores';
 
     let { options = [], menuaction }: { options: App.GridGroup[]; menuaction } = $props();
 
@@ -18,7 +18,7 @@ A component to display menu options in a list.
 
     let hovered = $state(null);
     const hoverColor = $derived(
-        $theme === 'Dark' ? '#444444' : $themeColors['ButtonSelectedColor']
+        themeIsDark($theme) ? '#444444' : $themeColors['ButtonSelectedColor']
     );
     const backgroundColor = $derived($s['ui.button.book-list']['background-color']);
 

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -24,6 +24,7 @@ The sidebar/drawer.
         t,
         theme,
         themeColors,
+        themeIsDark,
         userPreferenceSettings
     } from '$lib/data/stores';
     import {
@@ -261,7 +262,7 @@ The sidebar/drawer.
                             target="_blank"
                             rel="noreferrer"
                         >
-                            <picture class:invert={$theme === 'Dark'}>
+                            <picture class:invert={themeIsDark($theme)}>
                                 {#if (item.images?.length ?? 0) > 1}
                                     <source srcset={imageSrcSet(item.images)} />
                                 {/if}

--- a/src/lib/components/TextAppearanceSelector.svelte
+++ b/src/lib/components/TextAppearanceSelector.svelte
@@ -204,35 +204,15 @@ The navbar component. We have sliders that update reactively to both font size a
             {/if}
             <!-- Theme Selction buttons-->
             {#if _showThemes}
-                <div
-                    class="grid gap-2 m-2"
-                    class:grid-cols-2={themes.length === 2}
-                    class:grid-cols-3={themes.length === 3}
-                >
-                    {#if themes.includes('Normal')}
+                <div class="grid grid-cols-{themes.length} gap-2 m-2">
+                    {#each themes as t}
                         <button
                             class="dy-btn-sm"
-                            style:background-color={buttonBackground('Normal')}
-                            style:border={buttonBorder('Normal', $theme)}
-                            onclick={() => ($theme = 'Normal')}
+                            style:background-color={buttonBackground(t)}
+                            style:border={buttonBorder(t, $theme)}
+                            onclick={() => ($theme = t)}
                         ></button>
-                    {/if}
-                    {#if themes.includes('Sepia')}
-                        <button
-                            class="dy-btn-sm"
-                            style:background-color={buttonBackground('Sepia')}
-                            style:border={buttonBorder('Sepia', $theme)}
-                            onclick={() => ($theme = 'Sepia')}
-                        ></button>
-                    {/if}
-                    {#if themes.includes('Dark')}
-                        <button
-                            class="dy-btn-sm"
-                            style:background-color={buttonBackground('Dark')}
-                            style:border={buttonBorder('Dark', $theme)}
-                            onclick={() => ($theme = 'Dark')}
-                        ></button>
-                    {/if}
+                    {/each}
                 </div>
             {/if}
         </div>

--- a/src/lib/components/TextAppearanceSelector.svelte
+++ b/src/lib/components/TextAppearanceSelector.svelte
@@ -42,6 +42,7 @@ The navbar component. We have sliders that update reactively to both font size a
         monoIconColor,
         theme,
         themeColors,
+        themeIsDark,
         themes
     } from '$lib/data/stores';
     import { ImageIcon, TextAppearanceIcon } from '$lib/icons';
@@ -124,7 +125,7 @@ The navbar component. We have sliders that update reactively to both font size a
         return (
             (theme === currentTheme ? '3px' : '1px') +
             ' solid ' +
-            (theme === 'Dark' ? '#FFFFFF' : '#888888')
+            (themeIsDark(theme) ? '#FFFFFF' : '#888888')
         );
     };
 

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -166,7 +166,7 @@ TODO:
         <!-- Controls -->
         <div class="place-self-center">
             {#if showHighlightPens}
-                <div class="pen-grid grid grid-rows-1 gap-2 my-2">
+                <div class="pen-grid grid grid-rows-1 gap-2 my-1">
                     {#each highlight_colors as { color, number }}
                         <button
                             class="dy-btn dy-btn-sm"

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -26,6 +26,7 @@ TODO:
         selectedVerses,
         theme,
         themeColors,
+        themeIsDark,
         voiCustomImage
     } from '$lib/data/stores';
     import { AudioIcon, CopyContentIcon, HighlightIcon, NoteIcon, ShareIcon } from '$lib/icons';
@@ -55,7 +56,7 @@ TODO:
         ]
     );
 
-    const buttonBorder = $derived('1px solid ' + ($theme === 'Dark' ? '#FFFFFF' : '#888888'));
+    const buttonBorder = $derived('1px solid ' + (themeIsDark($theme) ? '#FFFFFF' : '#888888'));
 
     let selectedVerseBookmarks = $state(-1);
     async function updateSelectedVerseBookmarks() {

--- a/src/lib/data/stores/theme.ts
+++ b/src/lib/data/stores/theme.ts
@@ -22,8 +22,15 @@ export const themeBookColors = derived(theme, ($theme) => {
 });
 
 export const monoIconColor = derived(theme, ($theme) => {
-    return $theme === 'Dark' ? 'white' : 'black';
+    return themeIsDark($theme) ? 'white' : 'black';
 });
+
+/**
+ * treat Dark and Charcoal as dark themes
+ */
+export function themeIsDark(theme: string) {
+    return theme === 'Dark' || theme === 'Charcoal';
+}
 
 const resolveColor = (colorValue: string, colors: Record<string, string>) => {
     if (colorValue.startsWith('#')) {

--- a/src/lib/data/stores/theme.ts
+++ b/src/lib/data/stores/theme.ts
@@ -3,7 +3,18 @@ import { derived, writable } from 'svelte/store';
 import { setDefaultStorage } from './storage';
 
 //** themes */
-export const themes = config.themes?.filter((x) => x.enabled)?.map((theme) => theme.name) ?? [];
+// rough port of AppConfig.java:getColorThemeDisplayOrder
+const themeOrder: string[] = ['Normal', 'Sage', 'Rose', 'Sepia', 'Charcoal', 'Dark'] as const;
+function orderThemes(theme: string) {
+    const i = themeOrder.indexOf(theme);
+    return i < 0 ? 100 : i;
+}
+
+export const themes =
+    config.themes
+        ?.filter((x) => x.enabled)
+        ?.map((theme) => theme.name)
+        .sort((a, b) => orderThemes(a) - orderThemes(b)) ?? [];
 export const themeDefault = config.defaultTheme ?? '';
 setDefaultStorage('theme', themeDefault);
 export const theme = writable(localStorage.theme);

--- a/src/routes/contents/[id]/+page.svelte
+++ b/src/routes/contents/[id]/+page.svelte
@@ -18,6 +18,7 @@
         language,
         modal,
         ModalType,
+        monoIconColor,
         refs,
         s,
         themeColors
@@ -336,7 +337,7 @@
                                     class="contents-item-audio-image"
                                     onclick={(event) => playAudio(event, item)}
                                 >
-                                    <AudioIcon.Volume></AudioIcon.Volume>
+                                    <AudioIcon.Volume color={$monoIconColor} />
                                 </div>
                             {/if}
 


### PR DESCRIPTION
Closes #1003

I know this probably could have been left, but there was a bug in main for any project that had additional color themes specified and the easiest way to fix it was to go ahead and support the other colors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dark-mode icon contrast across the app, including correct handling for additional dark themes.
  * Fixed an audio repeat button color prop issue and updated the volume icon to use the theme-aware icon color.

* **UI Improvements**
  * Theme options now display in a consistent, predictable order.
  * Theme-related hover/border and toolbar styling updated for more consistent dark-mode appearance.
  * Theme selection layout now adapts automatically to the number of available themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->