### PR TITLE
#1061 Fix footnote being shifted to the right

### DIFF
--- a/src/lib/components/StackView.svelte
+++ b/src/lib/components/StackView.svelte
@@ -109,29 +109,31 @@
   - make width of scripture view
 -->
 {#if $footnotes.length > 0}
-    <div bind:this={stack} class="absolute max-w-breakpoint-md w-5/6 h-40 bottom-8 dy-stack">
-        {#each $footnotes as item}
-            <!-- svelte-ignore a11y_click_events_have_key_events -->
-            <!-- svelte-ignore a11y_no_static_element_interactions -->
-            <div
-                id="container"
-                class="footnote place-self-center rounded-sm h-40 shadow-lg overflow-y-auto"
-                onclick={(e) => {
-                    e.stopPropagation();
-                    insideClick((e.target || e.currentTarget) as HTMLElement);
-                }}
-            >
+    <div class="flex justify-center">
+        <div bind:this={stack} class="absolute max-w-breakpoint-md w-5/6 h-40 bottom-8 dy-stack">
+            {#each $footnotes as item}
+                <!-- svelte-ignore a11y_click_events_have_key_events -->
+                <!-- svelte-ignore a11y_no_static_element_interactions -->
                 <div
                     id="container"
-                    class="footnote"
-                    style:font-family={font}
-                    style:font-size={fontSize}
-                    style:line-height={lineHeight}
+                    class="footnote place-self-center rounded-sm h-40 shadow-lg overflow-y-auto"
+                    onclick={(e) => {
+                        e.stopPropagation();
+                        insideClick((e.target || e.currentTarget) as HTMLElement);
+                    }}
                 >
-                    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-                    {@html item}
+                    <div
+                        id="container"
+                        class="footnote"
+                        style:font-family={font}
+                        style:font-size={fontSize}
+                        style:line-height={lineHeight}
+                    >
+                        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                        {@html item}
+                    </div>
                 </div>
-            </div>
-        {/each}
+            {/each}
+        </div>
     </div>
 {/if}

--- a/src/lib/components/StackView.svelte
+++ b/src/lib/components/StackView.svelte
@@ -115,7 +115,7 @@
             <!-- svelte-ignore a11y_no_static_element_interactions -->
             <div
                 id="container"
-                class="footnote rounded-sm h-40 shadow-lg overflow-y-auto"
+                class="footnote place-self-center rounded-sm h-40 shadow-lg overflow-y-auto"
                 onclick={(e) => {
                     e.stopPropagation();
                     insideClick((e.target || e.currentTarget) as HTMLElement);

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -629,9 +629,10 @@
             </div>
         </div>
     </div>
-    <div class="flex justify-center">
-        <StackView {...stackSettings} />
-    </div>
+
+    <!-- Display pop-ups for cross-references, footnotes, etc. -->
+    <StackView {...stackSettings} />
+
     {#if textCopied}
         <div
             class="flex h-12 p-2 bg-black text-white items-center justify-center text-center text-sm"


### PR DESCRIPTION
Closes #1061.

DaisyUI stacks after v5 don't have these styles by default, so I re-added them in the `app.css`.

Before:
<img width="466" height="504" alt="image" src="https://github.com/user-attachments/assets/b0913f33-336a-48f3-8fbd-30acb2e500f8" />

After:
<img width="462" height="502" alt="image" src="https://github.com/user-attachments/assets/f1a0443e-3875-4bf0-85f4-fb6de7c44258" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Centered footnote content within its container for improved layout consistency by refining the footnote layout wrapper and centering each footnote card.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->