### PR TITLE
Add DaisyUI debug theme for dev server

### DIFF
--- a/src/lib/styles/app.css
+++ b/src/lib/styles/app.css
@@ -5,6 +5,38 @@
     themes: light --default;
 }
 
+/*
+  Since we aren't (intentionally) using DaisyUI theme colors, this *loud* theme
+  should make missing App Builder styles easier to catch in development.
+*/
+@plugin "daisyui/theme" {
+    name: 'debug';
+    default: false;
+    prefersdark: false;
+    color-scheme: light;
+
+    --color-base-100: 'red';
+    --color-base-200: 'red';
+    --color-base-300: 'red';
+    --color-base-content: 'red';
+    --color-primary: 'red';
+    --color-primary-content: 'red';
+    --color-secondary: 'red';
+    --color-secondary-content: 'red';
+    --color-accent: 'red';
+    --color-accent-content: 'red';
+    --color-neutral: 'red';
+    --color-neutral-content: 'red';
+    --color-info: 'red';
+    --color-info-content: 'red';
+    --color-success: 'red';
+    --color-success-content: 'red';
+    --color-warning: 'red';
+    --color-warning-content: 'red';
+    --color-error: 'red';
+    --color-error-content: 'red';
+}
+
 @source inline("grid-cols-{{1..12..1},none,subgrid}");
 
 /* Allow post-(Tailwind v4) styling to use sensible class names for breakpoints */

--- a/src/lib/styles/app.css
+++ b/src/lib/styles/app.css
@@ -15,26 +15,26 @@
     prefersdark: false;
     color-scheme: light;
 
-    --color-base-100: 'red';
-    --color-base-200: 'red';
-    --color-base-300: 'red';
-    --color-base-content: 'red';
-    --color-primary: 'red';
-    --color-primary-content: 'red';
-    --color-secondary: 'red';
-    --color-secondary-content: 'red';
-    --color-accent: 'red';
-    --color-accent-content: 'red';
-    --color-neutral: 'red';
-    --color-neutral-content: 'red';
-    --color-info: 'red';
-    --color-info-content: 'red';
-    --color-success: 'red';
-    --color-success-content: 'red';
-    --color-warning: 'red';
-    --color-warning-content: 'red';
-    --color-error: 'red';
-    --color-error-content: 'red';
+    --color-base-100: red;
+    --color-base-200: red;
+    --color-base-300: red;
+    --color-base-content: red;
+    --color-primary: red;
+    --color-primary-content: red;
+    --color-secondary: red;
+    --color-secondary-content: red;
+    --color-accent: red;
+    --color-accent-content: red;
+    --color-neutral: red;
+    --color-neutral-content: red;
+    --color-info: red;
+    --color-info-content: red;
+    --color-success: red;
+    --color-success-content: red;
+    --color-warning: red;
+    --color-warning-content: red;
+    --color-error: red;
+    --color-error-content: red;
 }
 
 @source inline("grid-cols-{{1..12..1},none,subgrid}");

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -146,7 +146,7 @@
                       console.warn('DEBUG color theme enabled');
                       return 'debug';
                   })()
-                : 'default'}
+                : 'light'}
             data-color-theme={$theme}
             style="height:100vh;height:100dvh;margin:0;"
             style:direction={$direction}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
     import faviconHref from '$assets/icons/favicon.png';
     import manifestHref from '$assets/manifestUrl.json';
     import '$lib/styles/app.css';
+    import { dev } from '$app/environment';
     import config from '$assets/config';
     import AudioPlaybackSpeed from '$lib/components/AudioPlaybackSpeed.svelte';
     import CollectionModal from '$lib/components/CollectionModal.svelte';
@@ -137,8 +138,15 @@
 
 {#if showPage}
     <Sidebar>
+        <!-- Set DaisyUI theme colors to red during development for debug purposes -->
         <div
             id="container"
+            data-theme={dev
+                ? (() => {
+                      console.warn('DEBUG color theme enabled');
+                      return 'debug';
+                  })()
+                : 'default'}
             data-color-theme={$theme}
             style="height:100vh;height:100dvh;margin:0;"
             style:direction={$direction}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -50,6 +50,13 @@
         refs.init();
     }
 
+    const debugTheme = dev
+        ? (() => {
+              console.warn('DEBUG color theme enabled');
+              return 'debug';
+          })()
+        : undefined;
+
     if (!$analytics.initialized) {
         analytics.init();
     }
@@ -138,15 +145,10 @@
 
 {#if showPage}
     <Sidebar>
-        <!-- Set DaisyUI theme colors to red during development for debug purposes -->
+        <!-- `debugTheme` sets the *allegedly* unused DaisyUI theme to all-red when dev server is running -->
         <div
             id="container"
-            data-theme={dev
-                ? (() => {
-                      console.warn('DEBUG color theme enabled');
-                      return 'debug';
-                  })()
-                : 'light'}
+            data-theme={debugTheme}
             data-color-theme={$theme}
             style="height:100vh;height:100dvh;margin:0;"
             style:direction={$direction}


### PR DESCRIPTION
Related to #1037 and the corresponding PR at #1047. Missing SAB colors that fall through to DaisyUI defaults should now show as **red** during development to increase visibility. This occurs *only* when the `dev` server is running since that's when SvelteKit's `dev` var is `true`.

<img width="1592" height="222" alt="image" src="https://github.com/user-attachments/assets/968cc117-7139-4fbd-be8d-07ff3f6fdbc7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a development-only DaisyUI theme intended for visual diagnostics, with a distinctive red color scheme to make styling states immediately noticeable.
  * When running in development mode, the app now automatically activates this diagnostics theme.

* **Bug Fixes**
  * Improves detectability of missing, misconfigured, or incorrect theme-related styling during development by making theme activation and color tokens visibly stand out.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->