### PR TITLE
Fix verse on image crop box and text box moving on window resize

### DIFF
--- a/src/lib/components/VerseOnImage.svelte
+++ b/src/lib/components/VerseOnImage.svelte
@@ -706,12 +706,13 @@ The verse on image component.
     let previousParentLeft = 0;
     onMount(() => {
         previousParentLeft = parentDiv.getBoundingClientRect().left;
+        window.addEventListener('resize', onResize);
+        return () => window.removeEventListener('resize', onResize);
     });
-
-    window.addEventListener('resize', () => {
+    function onResize() {
         textX = parentDiv.getBoundingClientRect().left - previousParentLeft + textX; //It looks like this doesn't need to be done with y because the canvas doesn't move when the window height is changed.
         previousParentLeft = parentDiv.getBoundingClientRect().left;
-    });
+    }
 
     function drag(event: PointerEvent) {
         if (dragging) {

--- a/src/lib/components/VerseOnImage.svelte
+++ b/src/lib/components/VerseOnImage.svelte
@@ -703,6 +703,15 @@ The verse on image component.
     let textY = $state(0);
     let dragging = false;
     let offsetX: number, offsetY: number;
+    let previousParentLeft = 0;
+    onMount(() => {
+        previousParentLeft = parentDiv.getBoundingClientRect().left;
+    });
+
+    window.addEventListener('resize', () => {
+        textX = parentDiv.getBoundingClientRect().left - previousParentLeft + textX; //It looks like this doesn't need to be done with y because the canvas doesn't move when the window height is changed.
+        previousParentLeft = parentDiv.getBoundingClientRect().left;
+    });
 
     function drag(event: PointerEvent) {
         if (dragging) {

--- a/src/routes/image/upload/+page.svelte
+++ b/src/routes/image/upload/+page.svelte
@@ -9,10 +9,6 @@
     let image: HTMLImageElement;
     let container: HTMLDivElement;
 
-    let cropTop = $state(0);
-    let cropLeft = $state(0);
-    let cropSize = $state(100);
-
     let dragging = false;
     let dragStartX = 0;
     let dragStartY = 0;
@@ -25,6 +21,14 @@
         width: 0,
         height: 0
     });
+
+    let unscaledCropLeft = $state(0);
+    let unscaledCropTop = $state(0);
+    let cropScale = $state(0.5);
+
+    const cropLeft = $derived(imageRect.left + unscaledCropLeft * imageRect.width);
+    const cropTop = $derived(imageRect.top + unscaledCropTop * imageRect.height);
+    const cropSize = $derived(cropScale * Math.min(imageRect.width, imageRect.height));
 
     let resizeStartSize = $state(0);
     let resizeStartDistance = $state(0); //These are variables for the 2-finger resize
@@ -41,12 +45,30 @@
             return () => image.removeEventListener('load', initCropBox);
         }
     });
+    function updateCropValues(
+        scaledCropLeft: number | null,
+        scaledCropTop: number | null,
+        scaledCropSize: number | null
+    ) {
+        if (scaledCropSize) {
+            cropScale = scaledCropSize / Math.min(imageRect.width, imageRect.height);
+        }
+        if (scaledCropLeft) {
+            unscaledCropLeft = (scaledCropLeft - imageRect.left) / imageRect.width;
+        }
+        if (scaledCropTop) {
+            unscaledCropTop = (scaledCropTop - imageRect.top) / imageRect.height;
+        }
+    }
     function initCropBox() {
         imageRect = getImageRect(image);
-        cropSize = Math.max(20, Math.min(100, imageRect.width, imageRect.height));
-        cropLeft = imageRect.left;
-        cropTop = imageRect.top;
+        const scaledCropSize = Math.max(20, Math.min(100, imageRect.width, imageRect.height));
+        updateCropValues(cropLeft, cropTop, scaledCropSize);
     }
+    window.addEventListener('resize', () => {
+        imageRect = getImageRect(image);
+        updateCropValues(cropLeft, cropTop, cropSize);
+    });
     function getImageRect(img: HTMLImageElement) {
         const containerRect = container.getBoundingClientRect();
         const naturalRatio = img.naturalWidth / img.naturalHeight;
@@ -104,15 +126,17 @@
             newSize = Math.max(20, Math.min(newSize, maxSizeX, maxSizeY));
 
             const sizeDifference = -(newSize - cropSize);
-            cropLeft = Math.min(
+            const scaledCropLeft = Math.min(
                 Math.max(cropLeft + sizeDifference / 2, rect.left),
                 rect.right - newSize
             );
-            cropTop = Math.min(
+            const scaledCropTop = Math.min(
                 Math.max(cropTop + sizeDifference / 2, rect.top),
                 rect.bottom - newSize
             );
-            cropSize = newSize;
+            const scaledCropSize = newSize;
+
+            updateCropValues(scaledCropLeft, scaledCropTop, scaledCropSize);
         }
     } //2-finger resize
 
@@ -135,9 +159,16 @@
 
         const rect = getImageRect(image);
 
-        cropLeft = Math.min(Math.max(e.clientX - dragStartX, rect.left), rect.right - cropSize);
+        const scaledCropLeft = Math.min(
+            Math.max(e.clientX - dragStartX, rect.left),
+            rect.right - cropSize
+        );
+        const scaledCropTop = Math.min(
+            Math.max(e.clientY - dragStartY, rect.top),
+            rect.bottom - cropSize
+        );
 
-        cropTop = Math.min(Math.max(e.clientY - dragStartY, rect.top), rect.bottom - cropSize);
+        updateCropValues(scaledCropLeft, scaledCropTop, cropSize);
     }
 
     function stopDrag() {
@@ -172,7 +203,7 @@
         const maxSizeY = rect.bottom - cropTop;
         newSize = Math.min(newSize, maxSizeX, maxSizeY);
 
-        cropSize = Math.max(20, newSize);
+        updateCropValues(null, null, Math.max(20, newSize));
     }
 
     function stopResize() {

--- a/src/routes/image/upload/+page.svelte
+++ b/src/routes/image/upload/+page.svelte
@@ -50,13 +50,13 @@
         scaledCropTop: number | null,
         scaledCropSize: number | null
     ) {
-        if (scaledCropSize) {
+        if (scaledCropSize !== null) {
             cropScale = scaledCropSize / Math.min(imageRect.width, imageRect.height);
         }
-        if (scaledCropLeft) {
+        if (scaledCropLeft !== null) {
             unscaledCropLeft = (scaledCropLeft - imageRect.left) / imageRect.width;
         }
-        if (scaledCropTop) {
+        if (scaledCropTop !== null) {
             unscaledCropTop = (scaledCropTop - imageRect.top) / imageRect.height;
         }
     }
@@ -65,9 +65,14 @@
         const scaledCropSize = Math.max(20, Math.min(100, imageRect.width, imageRect.height));
         updateCropValues(cropLeft, cropTop, scaledCropSize);
     }
-    window.addEventListener('resize', () => {
+
+    function onResize() {
         imageRect = getImageRect(image);
         updateCropValues(cropLeft, cropTop, cropSize);
+    }
+    onMount(() => {
+        window.addEventListener('resize', onResize);
+        return () => window.removeEventListener('resize', onResize);
     });
     function getImageRect(img: HTMLImageElement) {
         const containerRect = container.getBoundingClientRect();


### PR DESCRIPTION
Resolves #1044. This pull request fixes the issue where the crop box in verse on image can move outside the image bounds when the window is resized, and fixes a similar issue with the verse on image textbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image cropping behavior when resizing the browser window, preserving the crop area’s position and scale.
  * Enhanced crop interactions for touch gestures, dragging, and resizing with more consistent boundaries.
  * Kept verse text overlays horizontally aligned with their parent containers after window resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->