### PR TITLE
Move language code box below book tabs if present

### DIFF
--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -404,7 +404,7 @@
     $effect(() => {
         newRefScroll($refs);
     });
-    const navBarHeight = NAVBAR_HEIGHT;
+    const navBarHeight = $derived(bookTabs ? 'calc(' + NAVBAR_HEIGHT + ' + 2rem)' : NAVBAR_HEIGHT);
     onMount(() => {
         if ($isFirstLaunch) {
             analytics.log('ab_first_run');


### PR DESCRIPTION
Fixes #1063. If book tabs are present, the language code box is moved a little bit lower so that it will be below the tabs.