### PR TITLE
Fix collections without scripture books

### DIFF
--- a/convert/convertBooks.ts
+++ b/convert/convertBooks.ts
@@ -566,6 +566,7 @@ export async function convertBooks(
             console.timeEnd('convert ' + collection.id);
         }
         //start freezing process and map promise to docSet name
+        
         const frozen = freeze(pk);
         freezer.set(context.docSet, frozen[context.docSet]);
         //start catalog generation process

--- a/convert/convertBooks.ts
+++ b/convert/convertBooks.ts
@@ -566,7 +566,6 @@ export async function convertBooks(
             console.timeEnd('convert ' + collection.id);
         }
         //start freezing process and map promise to docSet name
-        
         const frozen = freeze(pk);
         freezer.set(context.docSet, frozen[context.docSet]);
         //start catalog generation process

--- a/convert/convertBooks.ts
+++ b/convert/convertBooks.ts
@@ -566,11 +566,47 @@ export async function convertBooks(
             console.timeEnd('convert ' + collection.id);
         }
         //start freezing process and map promise to docSet name
-
         const frozen = freeze(pk);
         freezer.set(context.docSet, frozen[context.docSet]);
         //start catalog generation process
-        catalogEntries.push(pk.gqlQuery(queries.catalogQuery({ cv: true })));
+        //catalogEntries.push(pk.gqlQuery(queries.catalogQuery({ cv: true })));
+        catalogEntries.push(
+            pk.gqlQuery(queries.catalogQuery({ cv: true })).then((j) => {
+                if (j.data.nDocSets > 0) {
+                    return j;
+                } else {
+                    if (verbose) {
+                        console.log(` -- Empty DocSet: ${context.docSet}`);
+                    }
+                    // return empty version of appropriate docSet,
+                    // as the query failed due to lack of documents.
+                    return {
+                        data: {
+                            nDocSets: 1,
+                            nDocuments: 0,
+                            docSets: [
+                                {
+                                    id: context.docSet,
+                                    tagsKv: [],
+                                    selectors: [
+                                        {
+                                            key: 'lang',
+                                            value: context.lang
+                                        },
+                                        {
+                                            key: 'abbr',
+                                            value: context.bcId
+                                        }
+                                    ],
+                                    hasMapping: false,
+                                    documents: []
+                                }
+                            ]
+                        }
+                    };
+                }
+            })
+        );
         //check if folder exists for collection
         const collPath = path.join('src/gen-assets', 'collections', context.bcId);
         createOutputDir(collPath);
@@ -586,7 +622,7 @@ export async function convertBooks(
     createOutputDir(catalogPath);
     entries.forEach((entry) => {
         fs.writeFileSync(
-            path.join(catalogPath, entry.data.docSets[0].id + '.json'),
+            path.join(catalogPath, entry.data.docSets[0]?.id + '.json'),
             JSON.stringify(transformCatalogEntry(entry, quizzes, htmlBooks))
         );
     });
@@ -598,12 +634,12 @@ export async function convertBooks(
     //write frozen archives
 
     //push files to be written to files array
-    freezer.forEach((value, key) =>
+    freezer.forEach((value, key) => {
         files.push({
             path: path.join('src/gen-assets', 'collections', key + '.pkf'),
-            content: value
-        })
-    );
+            content: value || ''
+        });
+    });
 
     //write index file
     fs.writeFileSync(

--- a/convert/convertBooks.ts
+++ b/convert/convertBooks.ts
@@ -569,7 +569,6 @@ export async function convertBooks(
         const frozen = freeze(pk);
         freezer.set(context.docSet, frozen[context.docSet]);
         //start catalog generation process
-        //catalogEntries.push(pk.gqlQuery(queries.catalogQuery({ cv: true })));
         catalogEntries.push(
             pk.gqlQuery(queries.catalogQuery({ cv: true })).then((j) => {
                 if (j.data.nDocSets > 0) {
@@ -622,7 +621,7 @@ export async function convertBooks(
     createOutputDir(catalogPath);
     entries.forEach((entry) => {
         fs.writeFileSync(
-            path.join(catalogPath, entry.data.docSets[0]?.id + '.json'),
+            path.join(catalogPath, entry.data.docSets[0].id + '.json'),
             JSON.stringify(transformCatalogEntry(entry, quizzes, htmlBooks))
         );
     });

--- a/src/lib/data/navigation.ts
+++ b/src/lib/data/navigation.ts
@@ -174,7 +174,7 @@ export class NavigationContext {
 
     private async updateLocation(docSet: string, book: string, chapter: string, verse: string) {
         let newBook = await this.updateCatalog(docSet);
-        if (book !== this.book && this.allBookIds.includes(book)) {
+        if (book !== this.book && (this.allBookIds.includes(book) || !this.book)) {
             this.book = book;
             newBook = true;
         }

--- a/src/lib/data/navigation.ts
+++ b/src/lib/data/navigation.ts
@@ -162,9 +162,15 @@ export class NavigationContext {
             this.collection = docSet.split('_')[1];
             this.catalog = await this.fetchCatalog(this.docSet);
             this.books = this.catalog.documents.map((b) => b.bookCode);
+            const collection = this.config.bookCollections?.find(
+                (c) => docSet === c.id || docSet === this.docSetFromCollection(c)
+            );
+            const quizzes =
+                collection?.books.filter((x) => x.type === 'quiz').map((x) => x.id) || [];
             this.allBookIds = [
                 ...this.books,
-                ...(this.catalog.htmlBooks ? this.catalog.htmlBooks.map((b) => b.id) : [])
+                ...(this.catalog.htmlBooks ? this.catalog.htmlBooks.map((b) => b.id) : []),
+                ...quizzes
             ];
             return true;
         } else {
@@ -174,8 +180,7 @@ export class NavigationContext {
 
     private async updateLocation(docSet: string, book: string, chapter: string, verse: string) {
         let newBook = await this.updateCatalog(docSet);
-
-        if (book !== this.book) {
+        if (book !== this.book && this.allBookIds.includes(book)) {
             this.book = book;
             newBook = true;
         }

--- a/src/lib/data/navigation.ts
+++ b/src/lib/data/navigation.ts
@@ -174,7 +174,8 @@ export class NavigationContext {
 
     private async updateLocation(docSet: string, book: string, chapter: string, verse: string) {
         let newBook = await this.updateCatalog(docSet);
-        if (book !== this.book && (this.allBookIds.includes(book) || !this.book)) {
+
+        if (book !== this.book) {
             this.book = book;
             newBook = true;
         }

--- a/src/lib/data/stores/collection.ts
+++ b/src/lib/data/stores/collection.ts
@@ -80,3 +80,10 @@ function createSelectedLayouts() {
     };
 }
 export const selectedLayouts = createSelectedLayouts();
+
+export const moreThanOneCollection = (scriptureConfig.bookCollections?.length ?? 0) > 1;
+export const showCollection = {
+    navbar: !!scriptureConfig.mainFeatures['layout-config-change-toolbar-button'],
+    viewer: !!scriptureConfig.mainFeatures['layout-config-change-viewer-button'],
+    onFirstLaunch: !!scriptureConfig.mainFeatures['layout-config-first-launch']
+} as const;

--- a/src/routes/quiz/[collection]/[id]/+page.svelte
+++ b/src/routes/quiz/[collection]/[id]/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { beforeNavigate, goto, invalidateAll } from '$app/navigation';
-    import config, { scriptureConfig } from '$assets/config';
+    import { scriptureConfig } from '$assets/config';
     import contents from '$assets/contents';
     import type { QuizAnswer, QuizQuestion } from '$config';
     import BookSelector from '$lib/components/BookSelector.svelte';
@@ -15,9 +15,11 @@
         convertStyle,
         modal,
         ModalType,
+        moreThanOneCollection,
         NAVBAR_HEIGHT,
         quizAudioActive,
         s,
+        showCollection,
         t
     } from '$lib/data/stores';
     import { refs } from '$lib/data/stores/scripture';
@@ -80,9 +82,7 @@
             ?.find((x) => x.id === $refs.collection)
             ?.books.find((x) => x.id === quizId)
     );
-    const showCollectionViewer = !!config.mainFeatures['layout-config-change-viewer-button'];
 
-    const enoughCollections = (scriptureConfig.bookCollections?.length ?? 0) > 1;
     const navBarHeight = NAVBAR_HEIGHT;
     const questions: QuizQuestion[] = $derived(
         book?.quizFeatures?.['shuffle-questions']
@@ -304,19 +304,16 @@
             {/snippet}
         </Navbar>
     </div>
-    {#if showCollectionViewer && enoughCollections}
-        <!-- svelte-ignore a11y_click_events_have_key_events -->
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <div
-            class="absolute dy-badge dy-badge-outline dy-badge-md rounded-xs p-1 inset-e-3 m-1 cursor-pointer"
+    {#if showCollection.viewer && moreThanOneCollection}
+        <button
+            class="absolute dy-badge dy-badge-outline dy-badge-md rounded-xs p-1 inset-e-3 m-1"
             style:top={navBarHeight}
-            style:background-color={convertStyle($s?.['ui.pane1'])}
             style={convertStyle($s?.['ui.pane1.name'])}
             onclick={() => goto(resolve(`/layout`))}
         >
             {scriptureConfig.bookCollections?.find((x) => x.id === $refs.collection)
                 ?.collectionAbbreviation}
-        </div>
+        </button>
     {/if}
 
     {#if locked}
@@ -336,7 +333,7 @@
                 </div>
                 <input
                     id="input-box"
-                    class="text-black w-[90%] text-[30px] text-center p-[10px] border bg-white mx-auto block"
+                    class="text-black w-[90%] text-[30px] text-center p-2.5 border bg-white mx-auto block"
                     bind:value={passwordInput}
                     readonly
                     onkeydown={handleKeyInput}

--- a/src/routes/quiz/[collection]/[id]/+page.svelte
+++ b/src/routes/quiz/[collection]/[id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-    import { beforeNavigate, invalidateAll } from '$app/navigation';
-    import { scriptureConfig } from '$assets/config';
+    import { beforeNavigate, goto, invalidateAll } from '$app/navigation';
+    import config, { scriptureConfig } from '$assets/config';
+    import contents from '$assets/contents';
     import type { QuizAnswer, QuizQuestion } from '$config';
     import BookSelector from '$lib/components/BookSelector.svelte';
     import Navbar from '$lib/components/Navbar.svelte';
@@ -10,9 +11,13 @@
         actionBarColor,
         bodyFontSize,
         bodyLineHeight,
+        contentsStack,
+        convertStyle,
         modal,
         ModalType,
+        NAVBAR_HEIGHT,
         quizAudioActive,
+        s,
         t
     } from '$lib/data/stores';
     import { refs } from '$lib/data/stores/scripture';
@@ -25,6 +30,7 @@
     } from '$lib/icons';
     import { getRandomItem, shuffleArray } from '$lib/scripts/arrayUtils.js';
     import { compareVersions } from '$lib/scripts/stringUtils';
+    import { resolve } from '$lib/utils/paths';
     import { onDestroy } from 'svelte';
     import type { ClassValue } from 'svelte/elements';
     import type { PageData } from './$types.js';
@@ -74,6 +80,10 @@
             ?.find((x) => x.id === $refs.collection)
             ?.books.find((x) => x.id === quizId)
     );
+    const showCollectionViewer = !!config.mainFeatures['layout-config-change-viewer-button'];
+
+    const enoughCollections = (scriptureConfig.bookCollections?.length ?? 0) > 1;
+    const navBarHeight = NAVBAR_HEIGHT;
     const questions: QuizQuestion[] = $derived(
         book?.quizFeatures?.['shuffle-questions']
             ? shuffleArray([...(quiz?.questions ?? [])])
@@ -85,6 +95,9 @@
     );
 
     const staticAssets = compareVersions(scriptureConfig.programVersion, '12.0') < 0;
+    const showBackButton = $derived(
+        contents?.features?.['navigation-type'] === 'up' && $contentsStack.length > 0
+    );
     function getQuizAssetAudio(file: string) {
         return staticAssets ? 'assets/' + file : quizAssets[`./${file}`].replace(/^\//, '');
     }
@@ -258,7 +271,7 @@
 
 <div class="grid grid-rows-[auto_1fr] h-screen overflow-y-auto" style:font-size="{$bodyFontSize}px">
     <div class="navbar">
-        <Navbar>
+        <Navbar {showBackButton}>
             {#snippet start()}
                 <BookSelector {displayLabel} />
             {/snippet}
@@ -291,6 +304,20 @@
             {/snippet}
         </Navbar>
     </div>
+    {#if showCollectionViewer && enoughCollections}
+        <!-- svelte-ignore a11y_click_events_have_key_events -->
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div
+            class="absolute dy-badge dy-badge-outline dy-badge-md rounded-xs p-1 inset-e-3 m-1 cursor-pointer"
+            style:top={navBarHeight}
+            style:background-color={convertStyle($s?.['ui.pane1'])}
+            style={convertStyle($s?.['ui.pane1.name'])}
+            onclick={() => goto(resolve(`/layout`))}
+        >
+            {scriptureConfig.bookCollections?.find((x) => x.id === $refs.collection)
+                ?.collectionAbbreviation}
+        </div>
+    {/if}
 
     {#if locked}
         {#if data.dependentQuizName || data.dependentQuizId}

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -207,46 +207,43 @@
             ($userSettings['show-border'] ?? showBorderSetting)
         )
     );
-    const format = $derived(getFormat($refs.collection, $refs.book));
     const viewSettings = $derived(
-        format === 'html'
+        book?.format === 'html'
             ? ({
                   references: $refs,
                   bodyFontSize: $bodyFontSize,
                   bodyLineHeight: $bodyLineHeight,
                   fetch: data.fetch
               } satisfies HtmlBookViewProps)
-            : ({
-                  audioPhraseEndChars: audioPhraseEndChars,
-                  bodyFontSize: $bodyFontSize,
-                  bodyLineHeight: $bodyLineHeight,
-                  bookmarks: $bookmarks,
-                  notes: $notes,
-                  highlights: $highlights,
-                  maxSelections: config.mainFeatures['annotation-max-select'],
-                  redLetters: $userSettingsOrDefault['red-letters'] as boolean,
-                  references: $refs,
-                  glossary: $glossary,
-                  selectedVerses: selectedVerses,
-                  themeColors: $themeColors,
-                  verseLayout: $userSettingsOrDefault['verse-layout'],
-                  viewShowBibleImages: $userSettingsOrDefault[
-                      'display-images-in-bible-text'
-                  ] as string,
-                  viewShowBibleVideos: $userSettingsOrDefault[
-                      'display-videos-in-bible-text'
-                  ] as string,
-                  viewShowIllustrations: config.mainFeatures['show-illustrations'] as boolean,
-                  viewShowVerses,
-                  viewShowGlossaryWords: $userSettingsOrDefault['glossary-words'] as boolean,
-                  font: $currentFont!,
-                  proskomma: data?.proskomma
-              } satisfies ScriptureViewSofriaProps)
+            : book?.testament !== 'quiz'
+              ? ({
+                    audioPhraseEndChars: audioPhraseEndChars,
+                    bodyFontSize: $bodyFontSize,
+                    bodyLineHeight: $bodyLineHeight,
+                    bookmarks: $bookmarks,
+                    notes: $notes,
+                    highlights: $highlights,
+                    maxSelections: config.mainFeatures['annotation-max-select'],
+                    redLetters: $userSettingsOrDefault['red-letters'] as boolean,
+                    references: $refs,
+                    glossary: $glossary,
+                    selectedVerses: selectedVerses,
+                    themeColors: $themeColors,
+                    verseLayout: $userSettingsOrDefault['verse-layout'],
+                    viewShowBibleImages: $userSettingsOrDefault[
+                        'display-images-in-bible-text'
+                    ] as string,
+                    viewShowBibleVideos: $userSettingsOrDefault[
+                        'display-videos-in-bible-text'
+                    ] as string,
+                    viewShowIllustrations: config.mainFeatures['show-illustrations'] as boolean,
+                    viewShowVerses,
+                    viewShowGlossaryWords: $userSettingsOrDefault['glossary-words'] as boolean,
+                    font: $currentFont!,
+                    proskomma: data?.proskomma
+                } satisfies ScriptureViewSofriaProps)
+              : {}
     );
-
-    function getFormat(bcId: string, bookId: string) {
-        return book?.format;
-    }
 
     const stackSettings = $derived({
         bodyFontSize: $bodyFontSize,
@@ -601,9 +598,9 @@
                                 }}
                                 onswipe={doSwipe}
                             >
-                                {#if format === 'html'}
+                                {#if book?.format === 'html'}
                                     <HtmlBookView {...viewSettings as HtmlBookViewProps} />
-                                {:else}
+                                {:else if book?.testament !== 'quiz'}
                                     <ScriptureViewSofria
                                         {...viewSettings as ScriptureViewSofriaProps}
                                     />

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -137,7 +137,7 @@
     const bookType = $derived(book?.type);
     $effect(() => {
         if (bookType === 'quiz') {
-            goto(resolve(`/quiz/${$refs.collection}/${book?.id}`));
+            goto(resolve(`/quiz/${$refs.collection}/${book?.id}`), { replaceState: true });
         }
     });
 

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -128,17 +128,18 @@
             await navigateToTextChapterInDirection(swipeDirection === 'right' ? -1 : 1);
         }
     }
-
-    const bookTabs = $derived(
+    const book = $derived(
         scriptureConfig?.bookCollections
             ?.find((x) => x.id === $refs.collection)
-            ?.books.find((x) => x.id === $refs.book)?.bookTabs
-    ); //This should hopefully be reactive and find the book tabs if the current book has them.
-    const bookType = $derived(
-        scriptureConfig?.bookCollections
-            ?.find((x) => x.id === $refs.collection)
-            ?.books.find((x) => x.id === $refs.book)?.type
+            ?.books.find((x) => x.id === $refs.book)
     );
+    const bookTabs = $derived(book?.bookTabs); //This should hopefully be reactive and find the book tabs if the current book has them.
+    const bookType = $derived(book?.type);
+    $effect(() => {
+        if (bookType === 'quiz') {
+            goto(resolve(`/quiz/${$refs.collection}/${book?.id}`));
+        }
+    });
 
     const bottomNavBarEnabled = config?.bottomNavBarItems && config?.bottomNavBarItems.length > 0;
     const barType = 'book';
@@ -244,9 +245,7 @@
     );
 
     function getFormat(bcId: string, bookId: string) {
-        return scriptureConfig.bookCollections
-            ?.find((x) => x.id === bcId)
-            ?.books.find((x) => x.id === bookId)?.format;
+        return book?.format;
     }
 
     const stackSettings = $derived({
@@ -437,9 +436,7 @@
         playStop();
     });
     function getCurrentIllustrationFile() {
-        let illustrations = scriptureConfig?.bookCollections
-            ?.find((x) => x.id === $refs.collection)
-            ?.books.find((x) => x.id === $refs.book)?.pageIllustrations;
+        let illustrations = book?.pageIllustrations;
         if (illustrations) {
             for (let i = 0; i < illustrations.length; i++) {
                 if (illustrations[i].num === Number($refs.chapter)) {

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -37,11 +37,13 @@
         isFirstLaunch,
         modal,
         ModalType,
+        moreThanOneCollection,
         NAVBAR_HEIGHT,
         notes,
         refs,
         s,
         selectedVerses,
+        showCollection,
         showDesktopSidebar,
         t,
         themeColors,
@@ -192,10 +194,7 @@
     );
 
     const showSearch = !!config.mainFeatures['search'];
-    const enoughCollections = (scriptureConfig.bookCollections?.length ?? 0) > 1;
-    const showCollectionNavbar = !!config.mainFeatures['layout-config-change-toolbar-button'];
-    const showCollectionsOnFirstLaunch = !!config.mainFeatures['layout-config-first-launch'];
-    const showCollectionViewer = !!config.mainFeatures['layout-config-change-viewer-button'];
+    
     const showAudio = !!config.mainFeatures['audio-allow-turn-on-off'];
 
     const showBorderSetting = $derived(
@@ -251,7 +250,7 @@
         font: $currentFont
     });
 
-    const extraIconsExist = $derived(showSearch || showCollectionNavbar); //Note: was trying document.getElementById('extraButtons').childElementCount; but that caused it to hang forever.
+    const extraIconsExist = $derived(showSearch || showCollection.navbar); //Note: was trying document.getElementById('extraButtons').childElementCount; but that caused it to hang forever.
     let scrollingDiv: HTMLDivElement | undefined = $state();
 
     let showOverlowMenu = $state(false); //Controls the visibility of the extraButtons div on mobile
@@ -404,7 +403,7 @@
     onMount(() => {
         if ($isFirstLaunch) {
             analytics.log('ab_first_run');
-            if (showCollectionsOnFirstLaunch && enoughCollections) {
+            if (showCollection.onFirstLaunch && moreThanOneCollection) {
                 goto(resolve(`/layout`));
             }
         }
@@ -503,7 +502,7 @@
                         {/if}
 
                         <!-- Collection Selector Button -->
-                        {#if showCollectionNavbar && enoughCollections}
+                        {#if showCollection.navbar && moreThanOneCollection}
                             <button
                                 class="dy-btn dy-btn-ghost dy-btn-circle"
                                 onclick={() => goto(resolve(`/layout`))}
@@ -537,19 +536,16 @@
         {/if}
     </div>
 
-    {#if showCollectionViewer && enoughCollections}
-        <!-- svelte-ignore a11y_click_events_have_key_events -->
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <div
-            class="absolute dy-badge dy-badge-outline dy-badge-md rounded-xs p-1 inset-e-3 m-1 cursor-pointer"
+    {#if showCollection.viewer && moreThanOneCollection}
+        <button
+            class="absolute dy-badge dy-badge-outline dy-badge-md rounded-xs p-1 inset-e-3 m-1"
             style:top={navBarHeight}
-            style:background-color={convertStyle($s?.['ui.pane1'])}
             style={convertStyle($s?.['ui.pane1.name'])}
             onclick={() => goto(resolve(`/layout`))}
         >
             {scriptureConfig.bookCollections?.find((x) => x.id === $refs.collection)
                 ?.collectionAbbreviation}
-        </div>
+        </button>
     {/if}
     <div class="flex flex-col overflow-y-auto">
         {#if bookType === 'story'}

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -194,7 +194,7 @@
     );
 
     const showSearch = !!config.mainFeatures['search'];
-    
+
     const showAudio = !!config.mainFeatures['audio-allow-turn-on-off'];
 
     const showBorderSetting = $derived(


### PR DESCRIPTION
Fixes #581. This PR generates dummy Proskomma data for collections without Scripture books so that the convert process does not fail, as well as tweaking some runtime behavior to account for collections without Scripture books. It also makes the text route redirect to the appropriate quiz route if it detects that the current book is a quiz.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quiz-based books now automatically open the corresponding quiz experience from the text page.
* **Bug Fixes**
  * Improved active-book switching when navigating between books and collections.
  * Improved catalog generation for empty results to ensure consistent, valid output.
  * Prevent writing frozen archives with missing content by defaulting to an empty value.
* **Improvements**
  * More consistent book format selection and illustration loading based on the active collection/book.
  * Enhanced quiz page header/navigation, including a conditional collection badge and back button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->