### PR TITLE
Display border for intro when show-border-intro is set

### DIFF
--- a/src/lib/scripts/configUtils.ts
+++ b/src/lib/scripts/configUtils.ts
@@ -33,7 +33,7 @@ export function getFeatureValueBoolean(
         if (
             feature === 'show-border-intro' &&
             bookFeature === 'inherit' &&
-            config.mainFeatures['show-border']
+            config.mainFeatures['show-border'] != null
         ) {
             value = config.mainFeatures['show-border'];
         } else if (bookFeature != null && bookFeature !== 'inherit') {

--- a/src/lib/scripts/configUtils.ts
+++ b/src/lib/scripts/configUtils.ts
@@ -30,7 +30,13 @@ export function getFeatureValueBoolean(
         ?.books.find((x) => x.id === book)?.features;
     if (bookFeatures != null) {
         const bookFeature = bookFeatures[feature];
-        if (bookFeature != null && bookFeature !== 'inherit') {
+        if (
+            feature === 'show-border-intro' &&
+            bookFeature === 'inherit' &&
+            config.mainFeatures['show-border']
+        ) {
+            value = config.mainFeatures['show-border'];
+        } else if (bookFeature != null && bookFeature !== 'inherit') {
             value = bookFeatures[feature];
         }
     }

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -197,8 +197,17 @@
 
     const showAudio = !!config.mainFeatures['audio-allow-turn-on-off'];
 
+    const isIntro = $derived($refs.chapter === 'i');
+
     const showBorderSetting = $derived(
-        getFeatureValueBoolean(scriptureConfig, 'show-border', $refs.collection, $refs.book)
+        isIntro
+            ? getFeatureValueBoolean(
+                  scriptureConfig,
+                  'show-border-intro',
+                  $refs.collection,
+                  $refs.book
+              )
+            : getFeatureValueBoolean(scriptureConfig, 'show-border', $refs.collection, $refs.book)
     );
     const showBorder = $derived(
         !!(


### PR DESCRIPTION
Fixes #1080. This PR checks the show-border-intro setting when determining whether to show the border on an intro so that it will display the border when it's supposed to do so.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate border display settings for introductory chapters.
  * Introductory chapter borders can now inherit the main border setting when no specific preference is configured.

* **Bug Fixes**
  * Improved border visibility handling so regular chapters continue using the standard border setting while introductions use their dedicated setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->