### PR TITLE
Allow navigating to intros using swipes or arrows

### DIFF
--- a/src/lib/data/navigation.test.ts
+++ b/src/lib/data/navigation.test.ts
@@ -507,7 +507,7 @@ describe('goTo', () => {
             const navContext = new TestNavigationContext(getTestCatalog, config);
             await navContext.gotoInitial();
             await navContext.goto('eng_C01', 'MAT', '3', '1');
-            const next = { book: 'MRK', chapter: '1' };
+            const next = { book: 'MRK', chapter: 'i' };
             expect(navContext.next).toStrictEqual(next);
         });
 
@@ -525,7 +525,7 @@ describe('goTo', () => {
             const navContext = new TestNavigationContext(getTestCatalog, config);
             await navContext.gotoInitial();
             await navContext.goto('eng_C01', 'MAT', '3', '1');
-            await navContext.goto('eng_C01', 'MAT', '1', '1');
+            await navContext.goto('eng_C01', 'MAT', 'i', '1');
             const prev = { book: null, chapter: null };
             expect(navContext.prev).toStrictEqual(prev);
         });
@@ -541,7 +541,7 @@ describe('goTo', () => {
         test('last chapter of previous book', async () => {
             const navContext = new TestNavigationContext(getTestCatalog, config);
             await navContext.gotoInitial();
-            await navContext.goto('eng_C01', 'MRK', '1', '1');
+            await navContext.goto('eng_C01', 'MRK', 'i', '1');
             const prev = { book: 'MAT', chapter: '3' };
             expect(navContext.prev).toStrictEqual(prev);
         });
@@ -564,10 +564,10 @@ describe('goTo', () => {
 
             await navContext.gotoNext();
             expect(navContext.book).toBe('MRK');
-            expect(navContext.chapter).toBe('1');
+            expect(navContext.chapter).toBe('i');
         });
 
-        test('at end of collection do not advane', async () => {
+        test('at end of collection do not advance', async () => {
             const navContext = new TestNavigationContext(getTestCatalog, config);
             await navContext.gotoInitial();
             await navContext.goto('eng_C01', 'MRK', '3', '1');
@@ -583,11 +583,11 @@ describe('goTo', () => {
             const navContext = new TestNavigationContext(getTestCatalog, config);
             await navContext.gotoInitial();
             await navContext.goto('eng_C01', 'MAT', '3', '1');
-            await navContext.goto('eng_C01', 'MAT', '1', '1');
+            await navContext.goto('eng_C01', 'MAT', 'i', '1');
 
             await navContext.gotoPrev();
             expect(navContext.book).toBe('MAT');
-            expect(navContext.chapter).toBe('1');
+            expect(navContext.chapter).toBe('i');
         });
 
         test('previous chapter of same book', async () => {
@@ -603,7 +603,7 @@ describe('goTo', () => {
         test('last chapter of previous book', async () => {
             const navContext = new TestNavigationContext(getTestCatalog, config);
             await navContext.gotoInitial();
-            await navContext.goto('eng_C01', 'MRK', '1', '1');
+            await navContext.goto('eng_C01', 'MRK', 'i', '1');
 
             await navContext.gotoPrev();
             expect(navContext.book).toBe('MAT');

--- a/src/lib/data/navigation.ts
+++ b/src/lib/data/navigation.ts
@@ -264,7 +264,10 @@ export class NavigationContext {
         } else if (bookNum + 1 < this.books.length) {
             const nextDocument = this.catalog.documents[bookNum + 1];
             const nextChapters = Object.keys(nextDocument.versesByChapters);
-            this.next = { book: nextDocument.bookCode, chapter: nextChapters[0] };
+            this.next = {
+                book: nextDocument.bookCode,
+                chapter: nextDocument.hasIntroduction ? 'i' : nextChapters[0]
+            };
         } else {
             this.next = { book: null, chapter: null };
         }
@@ -273,15 +276,20 @@ export class NavigationContext {
     private updatePrev(bookNum: number, chapterNum: number, chapters: string[]) {
         if (chapterNum - 1 >= 0) {
             this.prev = { book: this.book, chapter: chapters[chapterNum - 1] };
-        } else if (bookNum - 1 >= 0) {
-            const prevDocument = this.catalog.documents[bookNum - 1];
-            const prevChapters = Object.keys(prevDocument.versesByChapters);
-            this.prev = {
-                book: prevDocument.bookCode,
-                chapter: prevChapters[prevChapters.length - 1]
-            };
         } else {
-            this.prev = { book: null, chapter: null };
+            const book = this.catalog.documents.find((b) => this.book === b.bookCode);
+            if (chapterNum === 0 && book?.hasIntroduction) {
+                this.prev = { book: this.book, chapter: 'i' };
+            } else if (bookNum - 1 >= 0) {
+                const prevDocument = this.catalog.documents[bookNum - 1];
+                const prevChapters = Object.keys(prevDocument.versesByChapters);
+                this.prev = {
+                    book: prevDocument.bookCode,
+                    chapter: prevChapters[prevChapters.length - 1]
+                };
+            } else {
+                this.prev = { book: null, chapter: null };
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #1083. In the native app, you could access a book's introduction by navigating left when on chapter 1, but in the PWA, this is not possible, and if 'Allow swiping between books' is set, the introductions will be skipped when swiping between books. To fix this, I made $refs.next and $refs.prev get set to book introductions if an intro should be the next or previous chapter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved next/previous navigation across book boundaries when a book has an introduction.
  * Navigation now opens the introduction when it’s available, including correct handling at the first and last chapter edge cases.
  * Prevented invalid “previous” navigation when there is no earlier content to go back to.
  * Updated navigation tests to reflect introduction chapter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->