### PR TITLE
Update bottom navbar icon color and font

### DIFF
--- a/src/lib/components/BottomNavigationBar.svelte
+++ b/src/lib/components/BottomNavigationBar.svelte
@@ -135,19 +135,17 @@
                             class="dy-btn dy-btn-ghost flex-col gap-1 my-2"
                             onclick={() => handleClick(item.type, item.link?.['default'])}
                         >
-                            <picture>
-                                <!-- Image Icon -->
-                                <div
-                                    style={`width:24px; height:24px; background: ${
-                                        selectedLink(item.type, item.link?.['default'])
-                                            ? barTextSelectedColor
-                                            : barTextColor
-                                    }; mask: url(${menuIcons[`./${item.images?.[0]?.file}`]}); -webkit-mask: url(${menuIcons[`./${item.images?.[0]?.file}`]});`}
-                                    class={selectedLink(item.type, item.link?.['default'])
-                                        ? 'opacity-100'
-                                        : 'opacity-50'}
-                                ></div>
-                            </picture>
+                            <!-- Image Icon -->
+                            <div
+                                style={`width:24px; height:24px; background: ${
+                                    selectedLink(item.type, item.link?.['default'])
+                                        ? barTextSelectedColor
+                                        : barTextColor
+                                }; mask: url(${menuIcons[`./${item.images?.[0]?.file}`]}); -webkit-mask: url(${menuIcons[`./${item.images?.[0]?.file}`]});`}
+                                class={selectedLink(item.type, item.link?.['default'])
+                                    ? 'opacity-100'
+                                    : 'opacity-50'}
+                            ></div>
                             <!-- Text -->
                             <span
                                 class="text-center"

--- a/src/lib/components/BottomNavigationBar.svelte
+++ b/src/lib/components/BottomNavigationBar.svelte
@@ -5,7 +5,7 @@
     import { goto } from '$app/navigation';
     import config, { scriptureConfig } from '$assets/config';
     import contents from '$assets/contents';
-    import { language, languageDefault, refs, s, theme, themeIsDark } from '$lib/data/stores';
+    import { language, languageDefault, refs, s } from '$lib/data/stores';
     import { resolve } from '$lib/utils/paths';
 
     const menuIcons = import.meta.glob('./*', {
@@ -149,7 +149,9 @@
                             <!-- Text -->
                             <span
                                 class="text-center"
-                                style="font-family: system-ui; color: {selectedLink(
+                                style="font-family: {$s?.['ui.bottom-navigation.item.text'][
+                                    'font-family'
+                                ] ?? 'system-ui'}; color: {selectedLink(
                                     item.type,
                                     item.link?.['default']
                                 )

--- a/src/lib/components/BottomNavigationBar.svelte
+++ b/src/lib/components/BottomNavigationBar.svelte
@@ -137,18 +137,24 @@
                         >
                             <picture class:invert={themeIsDark($theme)}>
                                 <!-- Image Icon -->
-                                <img
-                                    src={menuIcons[`./${item.images?.[0]?.file}`]}
-                                    alt=""
+                                <div
+                                    style={`width:24px; height:24px; background: ${
+                                        selectedLink(item.type, item.link?.['default'])
+                                            ? barTextSelectedColor
+                                            : barTextColor
+                                    }; mask: url(${menuIcons[`./${item.images?.[0]?.file}`]}); -webkit-mask: url(${menuIcons[`./${item.images?.[0]?.file}`]});`}
                                     class={selectedLink(item.type, item.link?.['default'])
                                         ? 'opacity-100'
                                         : 'opacity-50'}
-                                />
+                                ></div>
                             </picture>
                             <!-- Text -->
                             <span
                                 class="text-center"
-                                style="color: {selectedLink(item.type, item.link?.['default'])
+                                style="font-family: system-ui; color: {selectedLink(
+                                    item.type,
+                                    item.link?.['default']
+                                )
                                     ? barTextSelectedColor
                                     : barTextColor}"
                             >

--- a/src/lib/components/BottomNavigationBar.svelte
+++ b/src/lib/components/BottomNavigationBar.svelte
@@ -5,7 +5,7 @@
     import { goto } from '$app/navigation';
     import config, { scriptureConfig } from '$assets/config';
     import contents from '$assets/contents';
-    import { language, languageDefault, refs, s } from '$lib/data/stores';
+    import { convertStyle, language, languageDefault, refs, s } from '$lib/data/stores';
     import { resolve } from '$lib/utils/paths';
 
     const menuIcons = import.meta.glob('./*', {
@@ -22,8 +22,8 @@
     const barBackgroundColor = $derived(
         ($s?.['ui.bottom-navigation.bar'] ?? $s?.['ui.bottom-navigation.'])?.['background-color']
     );
-    const barTextColor = $derived($s?.['ui.bottom-navigation.item.text']['color']);
-    const barTextSelectedColor = $derived($s?.['ui.bottom-navigation.item.text.selected']['color']);
+    const barTextColor = $derived($s?.['ui.bottom-navigation.item.icon']['color']);
+    const barTextSelectedColor = $derived($s?.['ui.bottom-navigation.item.icon.selected']['color']);
 
     const showContents = (contents.screens?.length ?? 0) > 0;
     const showSearch = config.mainFeatures['search'] as boolean;
@@ -142,21 +142,21 @@
                                         ? barTextSelectedColor
                                         : barTextColor
                                 }; mask: url(${menuIcons[`./${item.images?.[0]?.file}`]}); -webkit-mask: url(${menuIcons[`./${item.images?.[0]?.file}`]});`}
-                                class={selectedLink(item.type, item.link?.['default'])
-                                    ? 'opacity-100'
-                                    : 'opacity-50'}
                             ></div>
                             <!-- Text -->
                             <span
                                 class="text-center"
                                 style="font-family: {$s?.['ui.bottom-navigation.item.text'][
                                     'font-family'
-                                ] ?? 'system-ui'}; color: {selectedLink(
-                                    item.type,
-                                    item.link?.['default']
-                                )
-                                    ? barTextSelectedColor
-                                    : barTextColor}"
+                                ]
+                                    ? ''
+                                    : 'system-ui'}; {convertStyle(
+                                    $s?.[
+                                        selectedLink(item.type, item.link?.['default'])
+                                            ? 'ui.bottom-navigation.item.text.selected'
+                                            : 'ui.bottom-navigation.item.text'
+                                    ]
+                                )}"
                             >
                                 {item.title[$language] || item.title[languageDefault]}
                             </span>

--- a/src/lib/components/BottomNavigationBar.svelte
+++ b/src/lib/components/BottomNavigationBar.svelte
@@ -22,8 +22,8 @@
     const barBackgroundColor = $derived(
         ($s?.['ui.bottom-navigation.bar'] ?? $s?.['ui.bottom-navigation.'])?.['background-color']
     );
-    const barTextColor = $derived($s?.['ui.bottom-navigation.item.icon']['color']);
-    const barTextSelectedColor = $derived($s?.['ui.bottom-navigation.item.icon.selected']['color']);
+    const barIconColor = $derived($s?.['ui.bottom-navigation.item.icon']['color']);
+    const barIconSelectedColor = $derived($s?.['ui.bottom-navigation.item.icon.selected']['color']);
 
     const showContents = (contents.screens?.length ?? 0) > 0;
     const showSearch = config.mainFeatures['search'] as boolean;
@@ -139,18 +139,14 @@
                             <div
                                 style={`width:24px; height:24px; background: ${
                                     selectedLink(item.type, item.link?.['default'])
-                                        ? barTextSelectedColor
-                                        : barTextColor
+                                        ? barIconSelectedColor
+                                        : barIconColor
                                 }; mask: url(${menuIcons[`./${item.images?.[0]?.file}`]}); -webkit-mask: url(${menuIcons[`./${item.images?.[0]?.file}`]});`}
                             ></div>
                             <!-- Text -->
                             <span
                                 class="text-center"
-                                style="font-family: {$s?.['ui.bottom-navigation.item.text'][
-                                    'font-family'
-                                ]
-                                    ? ''
-                                    : 'system-ui'}; {convertStyle(
+                                style="font-family: 'system-ui'; {convertStyle(
                                     $s?.[
                                         selectedLink(item.type, item.link?.['default'])
                                             ? 'ui.bottom-navigation.item.text.selected'

--- a/src/lib/components/BottomNavigationBar.svelte
+++ b/src/lib/components/BottomNavigationBar.svelte
@@ -135,7 +135,7 @@
                             class="dy-btn dy-btn-ghost flex-col gap-1 my-2"
                             onclick={() => handleClick(item.type, item.link?.['default'])}
                         >
-                            <picture class:invert={themeIsDark($theme)}>
+                            <picture>
                                 <!-- Image Icon -->
                                 <div
                                     style={`width:24px; height:24px; background: ${


### PR DESCRIPTION
Fixes #1064. This PR updates the bottom navigation bar icons to be colored based on the color the app defines. It also updates the bottom navbar item text to use the system font like the default for the PWA. Right now, it doesn't directly use the ui.bottom-navigation.item.text class; it just gets the color from the defined classes, so this'll need to be updated if we want to support arbitrary styles or changing the font. Is that within the scope of this issue?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the bottom navigation bar icons to use CSS mask-based rendering for more consistent visuals across themes.
  - Improved the selected-state look by adjusting icon/background emphasis and refining how the label styling switches between active and inactive states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->