### PR TITLE
fix: fall back to HTTPS when HTTP audio downloads fail

### DIFF
--- a/src/lib/data/audioclipsDB.test.ts
+++ b/src/lib/data/audioclipsDB.test.ts
@@ -38,10 +38,7 @@ describe('fetchWithProtocolFallback', () => {
         // Subsequent request to the same origin should go straight to HTTPS.
         const secondHttpsResponse = new Response('ok');
         (fetch as any).mockResolvedValueOnce(secondHttpsResponse);
-        const secondResponse = await fetchWithProtocolFallback(
-            'http://example.com/other.mp3',
-            {}
-        );
+        const secondResponse = await fetchWithProtocolFallback('http://example.com/other.mp3', {});
 
         expect(secondResponse).toBe(secondHttpsResponse);
         expect(fetch).toHaveBeenCalledTimes(3);
@@ -65,9 +62,9 @@ describe('fetchWithProtocolFallback', () => {
             .mockRejectedValueOnce(new TypeError('Failed to fetch'))
             .mockRejectedValueOnce(httpsError);
 
-        await expect(
-            fetchWithProtocolFallback('http://example.com/audio.mp3', {})
-        ).rejects.toBe(httpsError);
+        await expect(fetchWithProtocolFallback('http://example.com/audio.mp3', {})).rejects.toBe(
+            httpsError
+        );
         expect(fetch).toHaveBeenCalledTimes(2);
     });
 
@@ -92,10 +89,7 @@ describe('fetchWithProtocolFallback', () => {
         // origin-a should still be requested directly over HTTP afterwards.
         const secondHttpResponseA = new Response('ok');
         (fetch as any).mockResolvedValueOnce(secondHttpResponseA);
-        const responseA2 = await fetchWithProtocolFallback(
-            'http://origin-a.example/other.mp3',
-            {}
-        );
+        const responseA2 = await fetchWithProtocolFallback('http://origin-a.example/other.mp3', {});
         expect(responseA2).toBe(secondHttpResponseA);
         expect(fetch).toHaveBeenLastCalledWith('http://origin-a.example/other.mp3', {});
     });

--- a/src/lib/data/audioclipsDB.test.ts
+++ b/src/lib/data/audioclipsDB.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { fetchWithProtocolFallback, resetProtocolPreferences } from './audioclipsDB';
+
+describe('fetchWithProtocolFallback', () => {
+    beforeEach(() => {
+        resetProtocolPreferences();
+        vi.stubGlobal('fetch', vi.fn());
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    test('HTTP URL succeeds -> only HTTP is used', async () => {
+        const okResponse = new Response('ok');
+        (fetch as any).mockResolvedValueOnce(okResponse);
+
+        const response = await fetchWithProtocolFallback('http://example.com/audio.mp3', {});
+
+        expect(response).toBe(okResponse);
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(fetch).toHaveBeenCalledWith('http://example.com/audio.mp3', {});
+    });
+
+    test('HTTP fails and HTTPS succeeds -> HTTPS is subsequently used for that origin', async () => {
+        const httpsResponse = new Response('ok');
+        (fetch as any)
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockResolvedValueOnce(httpsResponse);
+
+        const response = await fetchWithProtocolFallback('http://example.com/audio.mp3', {});
+
+        expect(response).toBe(httpsResponse);
+        expect(fetch).toHaveBeenCalledTimes(2);
+        expect(fetch).toHaveBeenNthCalledWith(1, 'http://example.com/audio.mp3', {});
+        expect(fetch).toHaveBeenNthCalledWith(2, 'https://example.com/audio.mp3', {});
+
+        // Subsequent request to the same origin should go straight to HTTPS.
+        const secondHttpsResponse = new Response('ok');
+        (fetch as any).mockResolvedValueOnce(secondHttpsResponse);
+        const secondResponse = await fetchWithProtocolFallback(
+            'http://example.com/other.mp3',
+            {}
+        );
+
+        expect(secondResponse).toBe(secondHttpsResponse);
+        expect(fetch).toHaveBeenCalledTimes(3);
+        expect(fetch).toHaveBeenNthCalledWith(3, 'https://example.com/other.mp3', {});
+    });
+
+    test('HTTPS URL succeeds -> no HTTP attempt', async () => {
+        const httpsResponse = new Response('ok');
+        (fetch as any).mockResolvedValueOnce(httpsResponse);
+
+        const response = await fetchWithProtocolFallback('https://example.com/audio.mp3', {});
+
+        expect(response).toBe(httpsResponse);
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(fetch).toHaveBeenCalledWith('https://example.com/audio.mp3', {});
+    });
+
+    test('HTTP and HTTPS both fail -> the failure is propagated', async () => {
+        const httpsError = new TypeError('Failed to fetch');
+        (fetch as any)
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockRejectedValueOnce(httpsError);
+
+        await expect(
+            fetchWithProtocolFallback('http://example.com/audio.mp3', {})
+        ).rejects.toBe(httpsError);
+        expect(fetch).toHaveBeenCalledTimes(2);
+    });
+
+    test('different origins independently have different protocol preferences', async () => {
+        const workingHttpResponse = new Response('ok');
+        (fetch as any).mockResolvedValueOnce(workingHttpResponse);
+
+        // origin-a works fine over plain HTTP (e.g. a MicroPi server).
+        const responseA = await fetchWithProtocolFallback('http://origin-a.example/audio.mp3', {});
+        expect(responseA).toBe(workingHttpResponse);
+        expect(fetch).toHaveBeenLastCalledWith('http://origin-a.example/audio.mp3', {});
+
+        // origin-b requires HTTPS.
+        const httpsResponseB = new Response('ok');
+        (fetch as any)
+            .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+            .mockResolvedValueOnce(httpsResponseB);
+        const responseB = await fetchWithProtocolFallback('http://origin-b.example/audio.mp3', {});
+        expect(responseB).toBe(httpsResponseB);
+        expect(fetch).toHaveBeenLastCalledWith('https://origin-b.example/audio.mp3', {});
+
+        // origin-a should still be requested directly over HTTP afterwards.
+        const secondHttpResponseA = new Response('ok');
+        (fetch as any).mockResolvedValueOnce(secondHttpResponseA);
+        const responseA2 = await fetchWithProtocolFallback(
+            'http://origin-a.example/other.mp3',
+            {}
+        );
+        expect(responseA2).toBe(secondHttpResponseA);
+        expect(fetch).toHaveBeenLastCalledWith('http://origin-a.example/other.mp3', {});
+    });
+});

--- a/src/lib/data/audioclipsDB.ts
+++ b/src/lib/data/audioclipsDB.ts
@@ -33,10 +33,6 @@ const httpsPreferredOrigins = new Set<string>();
  * response itself and never rewrites https:// URLs or URLs whose origin is
  * already known to work over plain http.
  */
-export function resetProtocolPreferences(): void {
-    httpsPreferredOrigins.clear();
-}
-
 export async function fetchWithProtocolFallback(url: string, init: RequestInit): Promise<Response> {
     let parsed: URL;
     try {
@@ -63,6 +59,10 @@ export async function fetchWithProtocolFallback(url: string, init: RequestInit):
         httpsPreferredOrigins.add(parsed.origin);
         return response;
     }
+}
+
+export function resetProtocolPreferences(): void {
+    httpsPreferredOrigins.clear();
 }
 
 let audioDB: Awaited<ReturnType<typeof openDB<AudioClips>>> | null = null;

--- a/src/lib/data/audioclipsDB.ts
+++ b/src/lib/data/audioclipsDB.ts
@@ -37,10 +37,7 @@ export function resetProtocolPreferences(): void {
     httpsPreferredOrigins.clear();
 }
 
-export async function fetchWithProtocolFallback(
-    url: string,
-    init: RequestInit
-): Promise<Response> {
+export async function fetchWithProtocolFallback(url: string, init: RequestInit): Promise<Response> {
     let parsed: URL;
     try {
         parsed = new URL(url);

--- a/src/lib/data/audioclipsDB.ts
+++ b/src/lib/data/audioclipsDB.ts
@@ -19,6 +19,55 @@ interface AudioClips extends DBSchema {
         };
     };
 }
+// Origins that are known to require HTTPS even though the configured URL uses
+// http://. Populated at runtime; kept in memory only (not persisted) so a
+// fresh page load re-checks the environment rather than getting stuck on a
+// stale determination, and so it never blocks a working MicroPi/offline
+// server whose http:// URLs work directly.
+const httpsPreferredOrigins = new Set<string>();
+
+/**
+ * Fetches a URL, transparently retrying over https:// if an http:// request
+ * fails outright (e.g. a http->https redirect whose response lacks the CORS
+ * headers needed for fetch() to follow it). Never inspects the redirect
+ * response itself and never rewrites https:// URLs or URLs whose origin is
+ * already known to work over plain http.
+ */
+export function resetProtocolPreferences(): void {
+    httpsPreferredOrigins.clear();
+}
+
+export async function fetchWithProtocolFallback(
+    url: string,
+    init: RequestInit
+): Promise<Response> {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        return fetch(url, init);
+    }
+    if (parsed.protocol !== 'http:') {
+        return fetch(url, init);
+    }
+    if (httpsPreferredOrigins.has(parsed.origin)) {
+        parsed.protocol = 'https:';
+        return fetch(parsed.toString(), init);
+    }
+    try {
+        return await fetch(url, init);
+    } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+            throw error;
+        }
+        const httpsUrl = new URL(url);
+        httpsUrl.protocol = 'https:';
+        const response = await fetch(httpsUrl.toString(), init);
+        httpsPreferredOrigins.add(parsed.origin);
+        return response;
+    }
+}
+
 let audioDB: Awaited<ReturnType<typeof openDB<AudioClips>>> | null = null;
 async function openAudioClips() {
     if (!audioDB) {
@@ -50,7 +99,7 @@ export async function addAudioClip(
     onProgress?: (percent: number) => void
 ) {
     try {
-        const response = await fetch(url, { signal: abortController.signal });
+        const response = await fetchWithProtocolFallback(url, { signal: abortController.signal });
         if (!response.ok) {
             return false;
         }


### PR DESCRIPTION
Public deployments configure http:// audio URLs that get redirected to https://, but the redirect response lacks CORS headers, causing fetch() to fail outright. MicroPi/offline deployments serve audio over plain HTTP and must keep working unchanged, so URLs can't be unconditionally rewritten to https://.

addAudioClip() now goes through fetchWithProtocolFallback(), which tries the configured HTTP URL first and only retries over HTTPS if the request fails before producing a response. A successful HTTPS origin is remembered in memory for the rest of the session so later downloads skip straight to HTTPS, without persisting a determination that could go stale across environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Audio clip requests now automatically retry over HTTPS when an HTTP request fails.
  - Successful HTTPS fallback preferences are remembered for each origin.
  - Abort errors and other request failures continue to be handled correctly.

- **Tests**
  - Added coverage for fallback behavior, HTTPS requests, error propagation, and independent origin preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->