### PR TITLE
Fix various download/sharing related issues

### DIFF
--- a/src/lib/components/AudioAlertModal.svelte
+++ b/src/lib/components/AudioAlertModal.svelte
@@ -2,6 +2,12 @@
 @component
 No Connection Modal Dialog component.
 -->
+<script lang="ts" module>
+    export interface AudioAlertModalProps {
+        messageKey: string;
+        details?: string;
+    }
+</script>
 
 <script lang="ts">
     import { t } from '$lib/data/stores';
@@ -10,10 +16,10 @@ No Connection Modal Dialog component.
     const modalId = 'audioAlertModal';
     let modal: Modal | undefined = $state(undefined);
 
-    let messageKey = $state('');
+    let props: AudioAlertModalProps = $state({ messageKey: '' });
 
-    export function showModal(_messageKey: string) {
-        messageKey = _messageKey;
+    export function showModal(_props: AudioAlertModalProps) {
+        props = _props;
         modal?.showModal();
     }
 </script>
@@ -23,7 +29,12 @@ No Connection Modal Dialog component.
         <div class="message-body" id="message-body">
             <div class="message-header"></div>
             <div class="message-text">
-                {$t[messageKey]}
+                {#if props.messageKey}
+                    {$t[props.messageKey]}
+                {/if}
+                {#if props.details}
+                    <br />{props.details}
+                {/if}
             </div>
         </div>
 

--- a/src/lib/components/AudioDownloadModal.svelte
+++ b/src/lib/components/AudioDownloadModal.svelte
@@ -22,14 +22,14 @@ Audio Download Modal Dialog component.
         afterDownload = options?.afterDownload;
         modal?.showModal();
     }
-    export async function downloadAudio(url: string) {
+    export async function downloadAudio(url: string): ReturnType<typeof addAudioFile> {
         try {
             if (downloadAutomatically) {
                 $userSettings['audio-auto-download'] = 'auto';
             }
             downloadProgress = 1;
             abortController = new AbortController();
-            let addedAudioFile = await addAudioFile(
+            const addedAudioFile = await addAudioFile(
                 {
                     docSet: $refs.docSet,
                     collection: $refs.collection,
@@ -44,8 +44,8 @@ Audio Download Modal Dialog component.
             );
             downloadProgress = 0;
 
-            if (!addedAudioFile) {
-                return false;
+            if (!addedAudioFile.success) {
+                return addedAudioFile;
             }
             updateAudioPlayer($refs, { autoplay: true });
             if (afterDownload) {
@@ -54,14 +54,17 @@ Audio Download Modal Dialog component.
             return addedAudioFile;
         } catch (err) {
             console.error('Error downloading audio: ', err);
-            return false;
+            return { success: false, error: err instanceof Error ? err.message : String(err) };
         }
     }
     async function finishModal() {
         const addedAudioFile = await downloadAudio(audioUrl);
-        if (!addedAudioFile && !abortController?.signal.aborted) {
+        if (!addedAudioFile.success && !abortController?.signal.aborted) {
             modal?.close();
-            alert.open(ModalType.AudioAlert, 'Audio_Download_Error');
+            alert.open(ModalType.AudioAlert, {
+                messageKey: 'Audio_Download_Error',
+                details: addedAudioFile.error
+            });
             return false;
         }
     }

--- a/src/lib/components/AudioDownloadModal.svelte
+++ b/src/lib/components/AudioDownloadModal.svelte
@@ -15,10 +15,11 @@ Audio Download Modal Dialog component.
     let modal: Modal | undefined = $state(undefined);
     let downloadAutomatically: boolean = $state(false);
     let audioUrl: string = '';
-    let error = $state('');
+    let afterDownload: (() => void) | undefined;
 
-    export function showModal(url: string) {
+    export function showModal(url: string, options?: { afterDownload?: () => void }) {
         audioUrl = url;
+        afterDownload = options?.afterDownload;
         modal?.showModal();
     }
     export async function downloadAudio(url: string) {
@@ -47,6 +48,9 @@ Audio Download Modal Dialog component.
                 return false;
             }
             updateAudioPlayer($refs, { autoplay: true });
+            if (afterDownload) {
+                afterDownload();
+            }
             return addedAudioFile;
         } catch (err) {
             console.error('Error downloading audio: ', err);

--- a/src/lib/components/AudioDownloadModal.svelte
+++ b/src/lib/components/AudioDownloadModal.svelte
@@ -5,7 +5,7 @@ Audio Download Modal Dialog component.
 
 <script lang="ts">
     import { updateAudioPlayer } from '$lib/data/audio';
-    import { addAudioClip } from '$lib/data/audioclipsDB';
+    import { addAudioFile } from '$lib/data/audioFilesDB';
     import { modal as alert, ModalType, refs, t, userSettings } from '$lib/data/stores';
     import { CheckboxIcon, CheckboxOutlineIcon } from '$lib/icons';
     import { tick } from 'svelte';
@@ -28,7 +28,7 @@ Audio Download Modal Dialog component.
             }
             downloadProgress = 1;
             abortController = new AbortController();
-            let addedAudioClip = await addAudioClip(
+            let addedAudioFile = await addAudioFile(
                 {
                     docSet: $refs.docSet,
                     collection: $refs.collection,
@@ -43,19 +43,19 @@ Audio Download Modal Dialog component.
             );
             downloadProgress = 0;
 
-            if (!addedAudioClip) {
+            if (!addedAudioFile) {
                 return false;
             }
             updateAudioPlayer($refs, { autoplay: true });
-            return addedAudioClip;
+            return addedAudioFile;
         } catch (err) {
             console.error('Error downloading audio: ', err);
             return false;
         }
     }
     async function finishModal() {
-        const addedAudioClip = await downloadAudio(audioUrl);
-        if (!addedAudioClip && !abortController?.signal.aborted) {
+        const addedAudioFile = await downloadAudio(audioUrl);
+        if (!addedAudioFile && !abortController?.signal.aborted) {
             modal?.close();
             alert.open(ModalType.AudioAlert, 'Audio_Download_Error');
             return false;

--- a/src/lib/components/AudioDownloadModal.svelte
+++ b/src/lib/components/AudioDownloadModal.svelte
@@ -48,9 +48,7 @@ Audio Download Modal Dialog component.
                 return addedAudioFile;
             }
             updateAudioPlayer($refs, { autoplay: true });
-            if (afterDownload) {
-                afterDownload();
-            }
+            afterDownload?.();
             return addedAudioFile;
         } catch (err) {
             console.error('Error downloading audio: ', err);

--- a/src/lib/components/ShareSelector.svelte
+++ b/src/lib/components/ShareSelector.svelte
@@ -76,7 +76,7 @@ A component providing a dropdown where you can choose to download audio or video
                 throw new Error('No audio source available for this chapter');
             }
             if (audioSourceInfo?.isRemoteFile && !$appOnline) {
-                modal.open(ModalType.AudioAlert, 'Audio_Download_Connect');
+                modal.open(ModalType.AudioAlert, { messageKey: 'Audio_Download_Connect' });
                 return;
             }
 
@@ -136,7 +136,10 @@ A component providing a dropdown where you can choose to download audio or video
                 outputFormat.mimeType
             );
         } catch (error) {
-            modal.open(ModalType.AudioAlert, 'Audio_Download_Error');
+            modal.open(ModalType.AudioAlert, {
+                messageKey: 'Audio_Download_Error',
+                details: error instanceof Error ? error.message : String(error)
+            });
             console.error('Error generating audio export:', error);
         } finally {
             await audioCtx?.close();

--- a/src/lib/components/ShareSelector.svelte
+++ b/src/lib/components/ShareSelector.svelte
@@ -9,6 +9,7 @@ A component providing a dropdown where you can choose to download audio or video
     import { getAudioSourceInfo } from '$lib/data/audio';
     import { shareAudio, shareText } from '$lib/data/share';
     import {
+        appOnline,
         convertStyle,
         getPositioningCSS,
         modal,
@@ -73,6 +74,10 @@ A component providing a dropdown where you can choose to download audio or video
             });
             if (!audioSourceInfo?.source) {
                 throw new Error('No audio source available for this chapter');
+            }
+            if (audioSourceInfo?.isRemoteFile && !$appOnline) {
+                modal.open(ModalType.AudioAlert, 'Audio_Download_Connect');
+                return;
             }
 
             const audioSource = new AudioBufferSource(audioConfig);

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -6,7 +6,7 @@ Enables users to copy, highlight, bookmark, share, and annotate selected verses.
 <script lang="ts">
     import { goto } from '$app/navigation';
     import { scriptureConfig } from '$assets/config';
-    import { playVerses } from '$lib/data/audio';
+    import { checkAudioAvailability, playVerses } from '$lib/data/audio';
     import { addBookmark, findBookmark, removeBookmark } from '$lib/data/bookmarks';
     import { addHighlights, removeHighlights } from '$lib/data/highlights';
     import {
@@ -163,7 +163,14 @@ Enables users to copy, highlight, bookmark, share, and annotate selected verses.
                 {#if isAudioPlayable && $refs.hasAudio?.timingFile}
                     <button
                         class="dy-btn dy-btn-sm dy-btn-ghost"
-                        onclick={() => playSelectedVerseAudio({ repeat: false })}
+                        onclick={() =>
+                            checkAudioAvailability({
+                                afterDownload: () => playSelectedVerseAudio({ repeat: false })
+                            }).then((audioAvailable) => {
+                                if (audioAvailable) {
+                                    playSelectedVerseAudio({ repeat: false });
+                                }
+                            })}
                     >
                         <AudioIcon.Play color={iconColor} />
                     </button>

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -136,8 +136,8 @@ Enables users to copy, highlight, bookmark, share, and annotate selected verses.
         }
     }
 
-    const backgroundColor = $derived($s['ui.bar.text-select']['background-color']);
-    const iconColor = $derived($s['ui.bar.text-select.icon']['color']);
+    const backgroundColor = $derived($s?.['ui.bar.text-select']['background-color']);
+    const iconColor = $derived($s?.['ui.bar.text-select.icon']['color']);
 </script>
 
 <div

--- a/src/lib/components/TextSelectionToolbar.svelte
+++ b/src/lib/components/TextSelectionToolbar.svelte
@@ -178,7 +178,14 @@ Enables users to copy, highlight, bookmark, share, and annotate selected verses.
                 {#if isRepeatableAudio && $refs.hasAudio?.timingFile}
                     <button
                         class="dy-btn dy-btn-sm dy-btn-ghost"
-                        onclick={() => playSelectedVerseAudio({ repeat: true })}
+                        onclick={() =>
+                            checkAudioAvailability({
+                                afterDownload: () => playSelectedVerseAudio({ repeat: true })
+                            }).then((audioAvailable) => {
+                                if (audioAvailable) {
+                                    playSelectedVerseAudio({ repeat: true });
+                                }
+                            })}
                     >
                         <AudioIcon.PlayRepeat color={iconColor} />
                     </button>

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -755,13 +755,14 @@ export async function getAudioSourceInfo(
             }
         }
     }
-
+    let isRemoteFile: Boolean = false;
     if (!audioPath) {
         if (audioSource?.type === 'fcbh') {
             const result = await getBibleBrainUrl(audioSource, item, getDamId);
             if (result.error) {
                 throw new Error(`Failed to connect to BibleBrain: ${result.error}`);
             }
+            isRemoteFile = true;
 
             audioPath = result.path || null;
         } else if (audioSource?.type === 'assets') {
@@ -771,6 +772,7 @@ export async function getAudioSourceInfo(
             }
             audioPath = audioSources[audioKey];
         } else if (audioSource?.type === 'download') {
+            isRemoteFile = true;
             audioPath = pathJoin([audioSource.address, audio.filename]);
         }
     }
@@ -813,7 +815,8 @@ export async function getAudioSourceInfo(
     return audioPath
         ? {
               source: audioPath,
-              timing: timing.length > 0 ? timing : null
+              timing: timing.length > 0 ? timing : null,
+              isRemoteFile
           }
         : undefined;
 }

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -893,50 +893,56 @@ export async function checkAudioAvailability() {
         ?.find((c) => curRefs.collection === c.id)
         ?.books?.find((b) => b.id === curRefs.book)
         ?.audio?.find((a) => curRefs.chapter === '' + a.num);
-    if (audio && get(userSettings)['audio-access-method'] === 'download') {
+    if (audio) {
         const audioSource = scriptureConfig.audio?.sources[audio.src];
-        const foundAudioClip = await findAudioClip({
-            collection: curRefs.collection || '',
-            book: curRefs.book || '',
-            chapter: curRefs.chapter || ''
-        });
-        curRefs = get(refs);
-        if (!foundAudioClip) {
-            let audioPath = '';
-            if (audioSource?.type === 'download') {
-                audioPath = pathJoin([audioSource.address, audio.filename]);
-            } else if (audioSource?.type === 'fcbh') {
-                if (!get(appOnline)) {
-                    modal.open(ModalType.AudioAlert, 'Audio_Download_Connect');
-                } else {
-                    const result = await getBibleBrainUrl(
-                        audioSource,
-                        {
-                            collection: curRefs.collection || '',
-                            book: curRefs.book || '',
-                            chapter: curRefs.chapter || ''
-                        },
-                        getDamId
-                    );
-                    if (result.error) {
-                        throw new Error(`Failed to connect to BibleBrain: ${result.error}`);
-                    }
-                    if (result.path) {
-                        audioPath = result.path;
-                    }
-                }
-            }
-            if (audioSource?.accessMethods?.includes('download')) {
-                if (!get(appOnline)) {
-                    modal.open(ModalType.AudioAlert, 'Audio_Download_Connect');
-                } else {
-                    if (get(userSettings)['audio-auto-download'] === 'auto') {
-                        modal.open(ModalType.DownloadAudio, { audioPath, show: false }); //Just download it without showing the modal
+        if (
+            get(userSettings)['audio-access-method'] === 'download' ||
+            (!audioSource?.accessMethods?.includes('stream') &&
+                audioSource?.accessMethods?.includes('download'))
+        ) {
+            const foundAudioClip = await findAudioClip({
+                collection: curRefs.collection || '',
+                book: curRefs.book || '',
+                chapter: curRefs.chapter || ''
+            });
+            curRefs = get(refs);
+            if (!foundAudioClip) {
+                let audioPath = '';
+                if (audioSource?.type === 'download') {
+                    audioPath = pathJoin([audioSource.address, audio.filename]);
+                } else if (audioSource?.type === 'fcbh') {
+                    if (!get(appOnline)) {
+                        modal.open(ModalType.AudioAlert, 'Audio_Download_Connect');
                     } else {
-                        modal.open(ModalType.DownloadAudio, { audioPath, show: true });
+                        const result = await getBibleBrainUrl(
+                            audioSource,
+                            {
+                                collection: curRefs.collection || '',
+                                book: curRefs.book || '',
+                                chapter: curRefs.chapter || ''
+                            },
+                            getDamId
+                        );
+                        if (result.error) {
+                            throw new Error(`Failed to connect to BibleBrain: ${result.error}`);
+                        }
+                        if (result.path) {
+                            audioPath = result.path;
+                        }
                     }
                 }
-                return false;
+                if (audioSource?.accessMethods?.includes('download')) {
+                    if (!get(appOnline)) {
+                        modal.open(ModalType.AudioAlert, 'Audio_Download_Connect');
+                    } else {
+                        if (get(userSettings)['audio-auto-download'] === 'auto') {
+                            modal.open(ModalType.DownloadAudio, { audioPath, show: false }); //Just download it without showing the modal
+                        } else {
+                            modal.open(ModalType.DownloadAudio, { audioPath, show: true });
+                        }
+                    }
+                    return false;
+                }
             }
         }
     }

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -916,6 +916,7 @@ export async function checkAudioAvailability() {
                 } else if (audioSource?.type === 'fcbh') {
                     if (!get(appOnline)) {
                         modal.open(ModalType.AudioAlert, 'Audio_Download_Connect');
+                        return false;
                     } else {
                         const result = await getBibleBrainUrl(
                             audioSource,

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -66,7 +66,7 @@ function cacheKey(collection: string, book: string, chapter: string) {
 // builds a collection of audio players which can be switched between
 export function updateAudioPlayer(
     item: { collection: string; book: string; chapter: string },
-    options?: { autoplay?: boolean }
+    options?: { autoplay?: boolean; autoplaySelectedVerses?: boolean }
 ) {
     const key = cacheKey(item.collection, item.book, item.chapter);
     let audioPlayer = cache.get(key);
@@ -92,7 +92,11 @@ export function updateAudioPlayer(
     audioPlayerStore.set(audioPlayer);
     if (options?.autoplay) {
         if (audioPlayer.loaded) {
-            play();
+            if (options?.autoplaySelectedVerses) {
+                playSelectedVerseAudio({ repeat: false });
+            } else {
+                play();
+            }
         } else {
             autoplayTarget = audioPlayer;
         }
@@ -755,7 +759,7 @@ export async function getAudioSourceInfo(
             }
         }
     }
-    let isRemoteFile: Boolean = false;
+    let isRemoteFile: boolean = false;
     if (!audioPath) {
         if (audioSource?.type === 'fcbh') {
             const result = await getBibleBrainUrl(audioSource, item, getDamId);
@@ -890,7 +894,7 @@ function getVerseTimingRange(startVerse: string, endVerse: string) {
     return { start, end } as PlayModeRange;
 }
 
-export async function checkAudioAvailability() {
+export async function checkAudioAvailability(options?: { afterDownload?: () => void }) {
     let curRefs = get(refs);
     const audio = scriptureConfig.bookCollections
         ?.find((c) => curRefs.collection === c.id)
@@ -940,9 +944,17 @@ export async function checkAudioAvailability() {
                         modal.open(ModalType.AudioAlert, 'Audio_Download_Connect');
                     } else {
                         if (get(userSettings)['audio-auto-download'] === 'auto') {
-                            modal.open(ModalType.DownloadAudio, { audioPath, show: false }); //Just download it without showing the modal
+                            modal.open(ModalType.DownloadAudio, {
+                                audioPath,
+                                show: false,
+                                afterDownload: options?.afterDownload
+                            }); //Just download it without showing the modal
                         } else {
-                            modal.open(ModalType.DownloadAudio, { audioPath, show: true });
+                            modal.open(ModalType.DownloadAudio, {
+                                audioPath,
+                                show: true,
+                                afterDownload: options?.afterDownload
+                            });
                         }
                     }
                     return false;
@@ -951,4 +963,7 @@ export async function checkAudioAvailability() {
         }
     }
     return true;
+}
+function playSelectedVerseAudio(arg0: { repeat: boolean }) {
+    throw new Error('Function not implemented.');
 }

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -919,7 +919,7 @@ export async function checkAudioAvailability(options?: { afterDownload?: () => v
                     audioPath = pathJoin([audioSource.address, audio.filename]);
                 } else if (audioSource?.type === 'fcbh') {
                     if (!get(appOnline)) {
-                        modal.open(ModalType.AudioAlert, 'Audio_Download_Connect');
+                        modal.open(ModalType.AudioAlert, { messageKey: 'Audio_Download_Connect' });
                         return false;
                     } else {
                         const result = await getBibleBrainUrl(
@@ -941,7 +941,7 @@ export async function checkAudioAvailability(options?: { afterDownload?: () => v
                 }
                 if (audioSource?.accessMethods?.includes('download')) {
                     if (!get(appOnline)) {
-                        modal.open(ModalType.AudioAlert, 'Audio_Download_Connect');
+                        modal.open(ModalType.AudioAlert, { messageKey: 'Audio_Download_Connect' });
                     } else {
                         if (get(userSettings)['audio-auto-download'] === 'auto') {
                             modal.open(ModalType.DownloadAudio, {

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -22,9 +22,9 @@ import { getBibleBrainUrl } from '$lib/scripts/mediaUtils';
 import { pathJoin } from '$lib/scripts/stringUtils';
 import { get } from 'svelte/store';
 import { logAudioDuration, logAudioPlay } from './analytics';
-import { findAudioClip } from './audioclipsDB';
+import { findAudioFile } from './audioFilesDB';
 
-export const audioClipUrls = new MRUCache<string, string>(10, (item, key) => {
+export const audioFileUrls = new MRUCache<string, string>(10, (item, key) => {
     URL.revokeObjectURL(item);
     cache.delete(key);
 });
@@ -739,19 +739,19 @@ export async function getAudioSourceInfo(
     let audioPath: string | null = null;
 
     if (audioSource?.accessMethods?.includes('download')) {
-        const clipKey = `${item.collection}-${item.book}-${item.chapter}`;
-        audioPath = audioClipUrls.get(clipKey);
+        const fileKey = `${item.collection}-${item.book}-${item.chapter}`;
+        audioPath = audioFileUrls.get(fileKey);
         if (!audioPath) {
-            const foundAudioClip = await findAudioClip({
+            const foundAudioFile = await findAudioFile({
                 collection: item.collection || '',
                 book: item.book || '',
                 chapter: item.chapter || ''
             }); //If the audio has been downloaded already, use that.
-            if (foundAudioClip) {
-                if (!audioClipUrls.get(clipKey)) {
-                    audioClipUrls.put(clipKey, URL.createObjectURL(foundAudioClip.blob));
+            if (foundAudioFile) {
+                if (!audioFileUrls.get(fileKey)) {
+                    audioFileUrls.put(fileKey, URL.createObjectURL(foundAudioFile.blob));
                 }
-                audioPath = audioClipUrls.get(clipKey)!;
+                audioPath = audioFileUrls.get(fileKey)!;
             }
         }
     }
@@ -900,13 +900,13 @@ export async function checkAudioAvailability() {
             (!audioSource?.accessMethods?.includes('stream') &&
                 audioSource?.accessMethods?.includes('download'))
         ) {
-            const foundAudioClip = await findAudioClip({
+            const foundAudioFile = await findAudioFile({
                 collection: curRefs.collection || '',
                 book: curRefs.book || '',
                 chapter: curRefs.chapter || ''
             });
             curRefs = get(refs);
-            if (!foundAudioClip) {
+            if (!foundAudioFile) {
                 let audioPath = '';
                 if (audioSource?.type === 'download') {
                     audioPath = pathJoin([audioSource.address, audio.filename]);

--- a/src/lib/data/audioFilesDB.test.ts
+++ b/src/lib/data/audioFilesDB.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import { fetchWithProtocolFallback, resetProtocolPreferences } from './audioclipsDB';
+import { fetchWithProtocolFallback, resetProtocolPreferences } from './audioFilesDB';
 
 describe('fetchWithProtocolFallback', () => {
     beforeEach(() => {

--- a/src/lib/data/audioFilesDB.ts
+++ b/src/lib/data/audioFilesDB.ts
@@ -9,8 +9,8 @@ export interface AudioItem {
     chapter: string;
     blob: Blob;
 }
-interface AudioClips extends DBSchema {
-    audioclips: {
+interface AudioFiles extends DBSchema {
+    audiofiles: {
         key: number;
         value: AudioItem;
         indexes: {
@@ -65,12 +65,12 @@ export function resetProtocolPreferences(): void {
     httpsPreferredOrigins.clear();
 }
 
-let audioDB: Awaited<ReturnType<typeof openDB<AudioClips>>> | null = null;
-async function openAudioClips() {
+let audioDB: Awaited<ReturnType<typeof openDB<AudioFiles>>> | null = null;
+async function openAudioFiles() {
     if (!audioDB) {
-        audioDB = await openDB<AudioClips>('audioclips', 1, {
+        audioDB = await openDB<AudioFiles>('audiofiles', 1, {
             upgrade(db) {
-                const audioStore = db.createObjectStore('audioclips', {
+                const audioStore = db.createObjectStore('audiofiles', {
                     keyPath: 'date'
                 });
                 audioStore.createIndex('collection, book, chapter', [
@@ -84,7 +84,7 @@ async function openAudioClips() {
     }
     return audioDB;
 }
-export async function addAudioClip(
+export async function addAudioFile(
     item: {
         docSet: string;
         collection: string;
@@ -129,14 +129,14 @@ export async function addAudioClip(
         }
 
         const blob = new Blob(chunks);
-        const audioClips = await openAudioClips();
+        const audioFiles = await openAudioFiles();
         const date = new Date().getTime();
         const bookIndex = scriptureConfig.bookCollections
             ?.find((x) => x.id === item.collection)
             ?.books.findIndex((x) => x.id === item.book);
         if (bookIndex !== undefined && bookIndex >= 0) {
             const nextItem = { ...item, date: date, blob: blob };
-            await audioClips.add('audioclips', nextItem);
+            await audioFiles.add('audiofiles', nextItem);
             return true;
         }
         return false;
@@ -145,9 +145,9 @@ export async function addAudioClip(
         return false;
     }
 }
-export async function findAudioClip(item: { collection: string; book: string; chapter: string }) {
-    const audioClips = await openAudioClips();
-    const tx = audioClips.transaction('audioclips', 'readonly');
+export async function findAudioFile(item: { collection: string; book: string; chapter: string }) {
+    const audioFiles = await openAudioFiles();
+    const tx = audioFiles.transaction('audiofiles', 'readonly');
     const index = tx.store.index('collection, book, chapter');
     const result = await index.getAll([item.collection, item.book, item.chapter]);
     await tx.done;

--- a/src/lib/data/audioFilesDB.ts
+++ b/src/lib/data/audioFilesDB.ts
@@ -94,16 +94,16 @@ export async function addAudioFile(
     url: string,
     abortController: AbortController,
     onProgress?: (percent: number) => void
-) {
+): Promise<{ success: true; error?: never } | { success: false; error: string }> {
     try {
         const response = await fetchWithProtocolFallback(url, { signal: abortController.signal });
         if (!response.ok) {
-            return false;
+            return { success: false, error: response.statusText };
         }
         const contentLength = response.headers.get('Content-Length');
         const total = contentLength ? parseInt(contentLength, 10) : 0;
         if (!response.body) {
-            return false;
+            return { success: false, error: 'No Content' };
         }
         const reader = response.body.getReader();
         const chunks: BlobPart[] = [];
@@ -111,7 +111,7 @@ export async function addAudioFile(
 
         while (true) {
             if (abortController.signal.aborted) {
-                return false;
+                return { success: false, error: 'Download Cancelled' };
             }
             const { done, value } = await reader.read();
             if (done) {
@@ -137,12 +137,15 @@ export async function addAudioFile(
         if (bookIndex !== undefined && bookIndex >= 0) {
             const nextItem = { ...item, date: date, blob: blob };
             await audioFiles.add('audiofiles', nextItem);
-            return true;
+            return { success: true };
         }
-        return false;
+        return {
+            success: false,
+            error: `Could not locate book ${item.collection}.${item.book} for downloaded audio.`
+        };
     } catch (error) {
         console.error('Error downloading audio:', error);
-        return false;
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
 }
 export async function findAudioFile(item: { collection: string; book: string; chapter: string }) {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -99,11 +99,20 @@
                         break;
                     case ModalType.DownloadAudio:
                         {
-                            const audioModalData = data as { audioPath: string; show: boolean };
+                            const audioModalData = data as {
+                                audioPath: string;
+                                show: boolean;
+                                afterDownload?: () => void;
+                            };
                             if (audioModalData.show) {
-                                audioDownloadModal?.showModal(audioModalData.audioPath);
+                                audioDownloadModal?.showModal(audioModalData.audioPath, {
+                                    afterDownload: audioModalData.afterDownload
+                                });
                             } else {
                                 audioDownloadModal?.downloadAudio(audioModalData.audioPath);
+                                if (audioModalData.afterDownload) {
+                                    audioModalData.afterDownload();
+                                }
                             }
                         }
                         break;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -5,7 +5,9 @@
     import '$lib/styles/app.css';
     import { dev } from '$app/environment';
     import config from '$assets/config';
-    import AudioAlertModal from '$lib/components/AudioAlertModal.svelte';
+    import AudioAlertModal, {
+        type AudioAlertModalProps
+    } from '$lib/components/AudioAlertModal.svelte';
     import AudioDownloadModal from '$lib/components/AudioDownloadModal.svelte';
     import AudioPlaybackSpeed from '$lib/components/AudioPlaybackSpeed.svelte';
     import CollectionModal from '$lib/components/CollectionModal.svelte';
@@ -110,9 +112,7 @@
                                 });
                             } else {
                                 audioDownloadModal?.downloadAudio(audioModalData.audioPath);
-                                if (audioModalData.afterDownload) {
-                                    audioModalData.afterDownload();
-                                }
+                                audioModalData.afterDownload?.();
                             }
                         }
                         break;
@@ -120,7 +120,7 @@
                         audioPlaybackSpeed?.showModal();
                         break;
                     case ModalType.AudioAlert:
-                        audioAlertModal?.showModal(data as string);
+                        audioAlertModal?.showModal(data as AudioAlertModalProps);
                         break;
                     case ModalType.Collection:
                         collectionModal?.showModal(


### PR DESCRIPTION
Takes work from #1094, but will include other fixes as well. Current fixes:

- If the audio access method is set to download without streaming being an option, it will now download the audio instead of relying on the user setting of whether to download or stream.
- If the user attempts to share remote audio while there is no network connection, display the Audio_Download_Connect error.
- Clicking the play button in the text selection toolbar triggers audio download functionality just like clicking the normal play button or the audio on/off button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved audio access for downloadable content.
  * Added support for offline audio access with appropriate alerts.
  * Added download prompts and automatic downloads when streaming is unavailable.
  * Downloaded audio is now stored and retrieved consistently for playback.

* **Bug Fixes**
  * Existing downloaded audio bypasses unnecessary download prompts.
  * Improved handling of unavailable audio and download links.
  * Download completion and playback updates now behave more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->