### PR TITLE
Fix layout on first launch bug

### DIFF
--- a/src/lib/data/stores/collection.ts
+++ b/src/lib/data/stores/collection.ts
@@ -1,5 +1,6 @@
 import { scriptureConfig } from '$assets/config';
 import { get, writable } from 'svelte/store';
+import { setDefaultStorage } from './storage';
 import { Layout } from './view';
 
 export const testLayouts = false; // Set to true to show all layouts regardless of scriptureConfig
@@ -80,6 +81,10 @@ function createSelectedLayouts() {
     };
 }
 export const selectedLayouts = createSelectedLayouts();
+
+setDefaultStorage('layoutSelected', 'false');
+export const layoutSelected = writable(localStorage.layoutSelected === 'true');
+layoutSelected.subscribe((selected) => (localStorage.layoutSelected = selected ? 'true' : 'false'));
 
 export const moreThanOneCollection = (scriptureConfig.bookCollections?.length ?? 0) > 1;
 export const showCollection = {

--- a/src/routes/layout/+page.svelte
+++ b/src/routes/layout/+page.svelte
@@ -7,11 +7,14 @@
     import TabsMenu from '$lib/components/TabsMenu.svelte';
     import {
         actionBarColor,
+        isFirstLaunch,
         layout,
         Layout,
+        layoutSelected,
         monoIconColor,
         refs,
         selectedLayouts,
+        showCollection,
         t,
         testLayouts
     } from '$lib/data/stores';
@@ -47,6 +50,8 @@
         testLayouts ||
         !!scriptureConfig.layouts?.find((x) => x.mode === Layout.VerseByVerse)?.enabled; //Not yet implemented
 
+    const showingOnFirstLaunch = $isFirstLaunch && showCollection.onFirstLaunch && !$layoutSelected;
+
     // In the native app, if only showing the single pane, then don't show the title.
     // If showing one of the other two, then show the title.
     const showTitle = showSideBySide || showVerseByVerse;
@@ -65,6 +70,7 @@
         const selectedLayout = getSelectedLayout();
         $refs.docSet = selectedLayout.primaryDocSet;
         $layout = selectedLayout;
+        $layoutSelected = true;
         goto(resolve(`/`));
     }
 
@@ -89,7 +95,7 @@
 {/snippet}
 <div class="grid grid-rows-[auto_1fr]" style="height:100vh;height:100dvh;">
     <div class="navbar h-16">
-        <Navbar {backNavigation}>
+        <Navbar {backNavigation} showBackButton={!showingOnFirstLaunch}>
             {#snippet center()}
                 <label for="sidebar">
                     <div class="dy-btn dy-btn-ghost normal-case text-xl">

--- a/src/routes/text/+page.svelte
+++ b/src/routes/text/+page.svelte
@@ -40,6 +40,7 @@
         glossary,
         highlights,
         isFirstLaunch,
+        layoutSelected,
         modal,
         ModalType,
         moreThanOneCollection,
@@ -418,7 +419,7 @@
     onMount(() => {
         if ($isFirstLaunch) {
             analytics.log('ab_first_run');
-            if (showCollection.onFirstLaunch && moreThanOneCollection) {
+            if (showCollection.onFirstLaunch && moreThanOneCollection && !$layoutSelected) {
                 goto(resolve(`/layout`));
             }
         }


### PR DESCRIPTION
`/text` was rerouting to `/layout` when "Show the layout configuration screen when app is first launched" is configured, even once a layout has been selected. This PR fixes that by tracking when a layout has been selected and using that as an additional factor in the decision to reroute or not. The backnavigation button on `/layout` is also hidden under these circumstances.

Original bug report: https://community.scripture.software.sil.org/t/pwa-bug-layout-screen-on-first-launch/7250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent layout selection, preserving the chosen layout between sessions.
  * Introduced a first-launch layout setup flow when multiple collections are available.
  * Improved navigation during initial setup by hiding the back button and directing users to layout selection when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->