### PR TITLE
Handle missing colors in a way that will allow the app to build with warnings

### DIFF
--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -493,7 +493,7 @@ export function parseColorThemes(document: Document, verbose: number) {
         .getElementsByTagName('color-themes')[0]
         .getElementsByTagName('color-theme');
     const colorSetTags = document.getElementsByTagName('colors');
-    const themes = [];
+    const themes: { name: string; enabled: boolean; colorSets: any[] }[] = [];
     let defaultTheme = '';
     let defaultColors: { [key: string]: string } = {};
 
@@ -523,13 +523,24 @@ export function parseColorThemes(document: Document, verbose: number) {
                         }
                         continue;
                     } else if (name && !value) {
-                        const colorMissingError = new Error(
-                            `No color value found for "${name}" in the "${theme}" theme.` +
-                                `\nIt is possible that the project was last saved with a version of the App Builder that didn't correctly save the color values.` +
-                                `\nPlease select a different color theme in the App Builder and save the project, then change it back to the desired theme and save the project again.`
-                        );
-                        colorMissingError.stack = `Error in ${__filename}:parseColorThemes(): ${colorMissingError.message}`;
-                        throw colorMissingError;
+                        // Try to fallback to the Normal theme value if available
+                        const normalCm = color.querySelector(`cm[theme="Normal"]`);
+                        const normalValue = normalCm?.getAttribute('value');
+                        if (normalValue) {
+                            console.log(
+                                `⚠️ no value for "${name}" in "${theme}" theme, using "Normal" theme value "${normalValue}" instead.`
+                            );
+
+                            colors[name] = normalValue;
+                        } else {
+                            const colorMissingError = new Error(
+                                `No color value found for "${name}" in the "${theme}" theme.` +
+                                    `\nIt is possible that the project was last saved with a version of the App Builder that didn't correctly save the color values.` +
+                                    `\nPlease select a different color theme in the App Builder and save the project, then change it back to the desired theme and save the project again.`
+                            );
+                            colorMissingError.stack = `Error in ${__filename}:parseColorThemes(): ${colorMissingError.message}`;
+                            throw colorMissingError;
+                        }
                     }
                     if (verbose >= 3) {
                         console.log(`.. colors[${name}]=${colors[name]}`);

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -486,7 +486,7 @@ function hackColorValue(
     return value;
 }
 
-const deprecatedColors = ['StatusBarColor'];
+const deprecatedColors = ['StatusBarColor', 'VerseBlock1Color', 'VerseBlock2Color'];
 
 export function parseColorThemes(document: Document, verbose: number) {
     const colorThemeTags = document

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -496,6 +496,7 @@ export function parseColorThemes(document: Document, verbose: number) {
     const themes: { name: string; enabled: boolean; colorSets: any[] }[] = [];
     let defaultTheme = '';
     let defaultColors: { [key: string]: string } = {};
+    let replacedMissingColor = false;
 
     for (const tag of colorThemeTags) {
         const theme = tag.attributes.getNamedItem('name')!.value;
@@ -531,6 +532,7 @@ export function parseColorThemes(document: Document, verbose: number) {
                                 `⚠️ no value for "${name}" in "${theme}" theme, using "Normal" theme value "${normalValue}" instead.`
                             );
 
+                            replacedMissingColor = true;
                             colors[name] = normalValue;
                         } else {
                             const colorMissingError = new Error(
@@ -586,6 +588,14 @@ export function parseColorThemes(document: Document, verbose: number) {
             defaultColors =
                 themes[themes.length - 1].colorSets.find((c) => c.type === 'main')?.colors || {};
         }
+    }
+
+    if (replacedMissingColor) {
+        console.log(
+            "⚠️ Some colors were missing in the theme and were replaced with the 'Normal' theme values.\n" +
+                `   It is possible that the project was last saved with a version of the App Builder that didn't correctly save the color values.\n` +
+                `   Please select a different color theme in the App Builder and save the project, then change it back to the desired theme and save the project again.`
+        );
     }
 
     if (verbose) {


### PR DESCRIPTION
In #1092, we chose to fail the build when a color value is missing. In SAB in the desktop and the native app, it will use the value of the Normal theme with a color value is missing. Implement that strategy and give a warning when this happens so that the user know how to fix the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of deprecated theme colors.
  * Missing colors now fall back to the `Normal` theme when available.
  * Added clearer warnings when fallback values are used.
  * Errors are reported only when no suitable theme value exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->