### PR TITLE
Add option to save downloaded audio files to the device filesystem

### DIFF
--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -20,7 +20,7 @@ import { getBibleBrainUrl } from '../src/lib/scripts/mediaUtils';
 import { pathJoin } from '../src/lib/scripts/stringUtils';
 import { convertMarkdownsToHTML } from './convertMarkdown';
 import { getHashedName } from './fileUtils';
-import { splitVersion } from './stringUtils';
+import { compareVersions, splitVersion } from './stringUtils';
 import { Task, type TaskOutput } from './Task';
 
 const fontFamilies: string[] = [];
@@ -1894,6 +1894,17 @@ function filterFeaturesNotReady(data: ScriptureConfig | DictionaryConfig) {
                 !Object.values(it.link ?? {}).some((l) => /android_asset\/keyboard/.test(l))
         );
     }
+
+    /** Resource strings for the downloads audio to file system were not added until 14.4 */
+    if (data.programVersion && compareVersions(data.programVersion, '14.4') < 0) {
+        // disable the AudioSource.folder for all audio sources (both download and folder types)
+        if (data.audio?.sources) {
+            for (const source of Object.values(data.audio.sources)) {
+                delete source.folder;
+            }
+        }
+    }
+
     return data;
 }
 

--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -20,7 +20,7 @@ import { getBibleBrainUrl } from '../src/lib/scripts/mediaUtils';
 import { pathJoin } from '../src/lib/scripts/stringUtils';
 import { convertMarkdownsToHTML } from './convertMarkdown';
 import { getHashedName } from './fileUtils';
-import { splitVersion } from './stringUtils';
+import { compareVersions, splitVersion } from './stringUtils';
 import { Task, type TaskOutput } from './Task';
 
 const fontFamilies: string[] = [];
@@ -1914,6 +1914,17 @@ function filterFeaturesNotReady(data: ScriptureConfig | DictionaryConfig) {
                 !Object.values(it.link ?? {}).some((l) => /android_asset\/keyboard/.test(l))
         );
     }
+
+    /** Resource strings for the downloads audio to file system were not added until 14.4 */
+    if (data.programVersion && compareVersions(data.programVersion, '14.4') < 0) {
+        // disable the AudioSource.folder for all audio sources (both download and folder types)
+        if (data.audio?.sources) {
+            for (const source of Object.values(data.audio.sources)) {
+                delete source.folder;
+            }
+        }
+    }
+
     return data;
 }
 

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -83,7 +83,7 @@ declare namespace App {
     }
 
     interface UserPreferenceSetting {
-        type: 'checkbox' | 'list' | 'time';
+        type: 'checkbox' | 'list' | 'time' | 'audio-storage';
         category: string;
         title: string;
         summary?: string;

--- a/src/lib/components/AudioDownloadModal.svelte
+++ b/src/lib/components/AudioDownloadModal.svelte
@@ -121,22 +121,18 @@ Audio Download Modal Dialog component.
                 <div class="message-text">
                     {$t['Audio_Download_Confirm']}
                 </div>
-                <!-- svelte-ignore a11y_click_events_have_key_events -->
-                <!-- svelte-ignore a11y_no_static_element_interactions -->
-                <div
-                    class="message-checkbox flex w-full"
-                    onclick={() => {
-                        downloadAutomatically = !downloadAutomatically;
-                    }}
-                >
-                    <div class="message-checkbox-left">
-                        {#if downloadAutomatically}
-                            <CheckboxIcon></CheckboxIcon>
-                        {:else}
-                            <CheckboxOutlineIcon></CheckboxOutlineIcon>
-                        {/if}
-                    </div>
-                    <div class="message-checkbox-caption">{$t['Audio_Download_Auto']}</div>
+                <div class="message-checkbox flex w-full">
+                    <label class="flex w-full cursor-pointer items-center">
+                        <input type="checkbox" class="sr-only" bind:checked={downloadAutomatically} />
+                        <div class="message-checkbox-left" aria-hidden="true">
+                            {#if downloadAutomatically}
+                                <CheckboxIcon></CheckboxIcon>
+                            {:else}
+                                <CheckboxOutlineIcon></CheckboxOutlineIcon>
+                            {/if}
+                        </div>
+                        <div class="message-checkbox-caption">{$t['Audio_Download_Auto']}</div>
+                    </label>
                 </div>
             {:else}
                 <div class="message-title">

--- a/src/lib/components/AudioDownloadModal.svelte
+++ b/src/lib/components/AudioDownloadModal.svelte
@@ -6,13 +6,23 @@ Audio Download Modal Dialog component.
 <script lang="ts">
     import { updateAudioPlayer } from '$lib/data/audio';
     import { addAudioFile } from '$lib/data/audioFilesDB';
+    import {
+        getStoredMusicDirHandle,
+        isFileSystemAccessSupported,
+        pickMusicDirectory
+    } from '$lib/data/audioFileSystem';
     import { modal as alert, ModalType, refs, t, userSettings } from '$lib/data/stores';
     import { CheckboxIcon, CheckboxOutlineIcon } from '$lib/icons';
     import { tick } from 'svelte';
     import Modal from './Modal.svelte';
 
+    // Tracks whether the user has already been asked (once, ever) whether
+    // downloaded audio should also be saved to the filesystem.
+    const STORAGE_CHOICE_KEY = 'audio-filesystem-storage-choice';
+
     const modalId = 'audioDownloadModal';
     let modal: Modal | undefined = $state(undefined);
+    let modalStep: 'confirm' | 'storage-offer' = $state('confirm');
     let downloadAutomatically: boolean = $state(false);
     let audioUrl: string = '';
     let afterDownload: (() => void) | undefined;
@@ -20,7 +30,32 @@ Audio Download Modal Dialog component.
     export function showModal(url: string, options?: { afterDownload?: () => void }) {
         audioUrl = url;
         afterDownload = options?.afterDownload;
+        modalStep = 'confirm';
         modal?.showModal();
+    }
+
+    async function shouldOfferFilesystemStorage(): Promise<boolean> {
+        if (!isFileSystemAccessSupported() || localStorage.getItem(STORAGE_CHOICE_KEY)) {
+            return false;
+        }
+        return !(await getStoredMusicDirHandle());
+    }
+
+    async function onConfirmYes() {
+        if (await shouldOfferFilesystemStorage()) {
+            modalStep = 'storage-offer';
+            return;
+        }
+        modal?.close();
+        await proceedWithDownload();
+    }
+
+    async function onStorageOfferChoice(saveToFilesystem: boolean) {
+        modal?.close();
+        modalStep = 'confirm';
+        const handle = saveToFilesystem ? await pickMusicDirectory() : undefined;
+        localStorage.setItem(STORAGE_CHOICE_KEY, handle ? 'enabled' : 'declined');
+        await proceedWithDownload();
     }
     export async function downloadAudio(url: string): ReturnType<typeof addAudioFile> {
         try {
@@ -55,7 +90,7 @@ Audio Download Modal Dialog component.
             return { success: false, error: err instanceof Error ? err.message : String(err) };
         }
     }
-    async function finishModal() {
+    async function proceedWithDownload() {
         const addedAudioFile = await downloadAudio(audioUrl);
         if (!addedAudioFile.success && !abortController?.signal.aborted) {
             modal?.close();
@@ -79,43 +114,77 @@ Audio Download Modal Dialog component.
     <div id="container" class="message">
         <div class="message-body" id="message-body">
             <div class="message-header"></div>
-            <div class="message-title">
-                {$t['Audio_Download_Title']}
-            </div>
-            <div class="message-text">
-                {$t['Audio_Download_Confirm']}
-            </div>
-            <!-- svelte-ignore a11y_click_events_have_key_events -->
-            <!-- svelte-ignore a11y_no_static_element_interactions -->
-            <div
-                class="message-checkbox flex w-full"
-                onclick={() => {
-                    downloadAutomatically = !downloadAutomatically;
-                }}
-            >
-                <div class="message-checkbox-left">
-                    {#if downloadAutomatically}
-                        <CheckboxIcon></CheckboxIcon>
-                    {:else}
-                        <CheckboxOutlineIcon></CheckboxOutlineIcon>
-                    {/if}
+            {#if modalStep === 'confirm'}
+                <div class="message-title">
+                    {$t['Audio_Download_Title']}
                 </div>
-                <div class="message-checkbox-caption">{$t['Audio_Download_Auto']}</div>
-            </div>
+                <div class="message-text">
+                    {$t['Audio_Download_Confirm']}
+                </div>
+                <!-- svelte-ignore a11y_click_events_have_key_events -->
+                <!-- svelte-ignore a11y_no_static_element_interactions -->
+                <div
+                    class="message-checkbox flex w-full"
+                    onclick={() => {
+                        downloadAutomatically = !downloadAutomatically;
+                    }}
+                >
+                    <div class="message-checkbox-left">
+                        {#if downloadAutomatically}
+                            <CheckboxIcon></CheckboxIcon>
+                        {:else}
+                            <CheckboxOutlineIcon></CheckboxOutlineIcon>
+                        {/if}
+                    </div>
+                    <div class="message-checkbox-caption">{$t['Audio_Download_Auto']}</div>
+                </div>
+            {:else}
+                <div class="message-title">
+                    {$t['Audio_Download_Title']}
+                </div>
+                <div class="message-text">
+                    {$t['Audio_Storage_Offer']}
+                </div>
+            {/if}
         </div>
 
         <div class="left-0 dy-modal-action message-footer pointer-events-none">
             <div class="message-buttons">
-                <button class="dy-btn message-button pointer-events-auto" id="no">
-                    {$t['Button_No']}
-                </button>
-                <button
-                    class="dy-btn message-button pointer-events-auto"
-                    id="yes"
-                    onclick={() => finishModal()}
-                >
-                    {$t['Button_Yes']}
-                </button>
+                {#if modalStep === 'confirm'}
+                    <button
+                        class="dy-btn message-button pointer-events-auto"
+                        id="no"
+                        type="button"
+                        onclick={() => modal?.close()}
+                    >
+                        {$t['Button_No']}
+                    </button>
+                    <button
+                        class="dy-btn message-button pointer-events-auto"
+                        id="yes"
+                        type="button"
+                        onclick={() => onConfirmYes()}
+                    >
+                        {$t['Button_Yes']}
+                    </button>
+                {:else}
+                    <button
+                        class="dy-btn message-button pointer-events-auto"
+                        id="no"
+                        type="button"
+                        onclick={() => onStorageOfferChoice(false)}
+                    >
+                        {$t['Button_No']}
+                    </button>
+                    <button
+                        class="dy-btn message-button pointer-events-auto"
+                        id="yes"
+                        type="button"
+                        onclick={() => onStorageOfferChoice(true)}
+                    >
+                        {$t['Button_Yes']}
+                    </button>
+                {/if}
             </div>
         </div>
     </div>

--- a/src/lib/components/AudioDownloadModal.svelte
+++ b/src/lib/components/AudioDownloadModal.svelte
@@ -7,6 +7,7 @@ Audio Download Modal Dialog component.
     import { updateAudioPlayer } from '$lib/data/audio';
     import { addAudioFile } from '$lib/data/audioFilesDB';
     import {
+        ensureWritableMusicDirHandle,
         getStoredMusicDirHandle,
         isFileSystemAccessSupported,
         pickMusicDirectory,
@@ -61,6 +62,15 @@ Audio Download Modal Dialog component.
             }
             downloadProgress = 1;
             abortController = new AbortController();
+            // Resolve (and if needed, request) filesystem permission here, right
+            // at the top of the call, so it happens as close as possible to the
+            // user gesture that triggered the download - the fetch below can take
+            // a while, and by the time it finishes the click's transient
+            // activation needed for a permission prompt is likely gone.
+            const musicDirHandle = await ensureWritableMusicDirHandle();
+            console.debug('[audio-fs] downloadAudio: musicDirHandle resolved', {
+                hasHandle: !!musicDirHandle
+            });
             const addedAudioFile = await addAudioFile(
                 {
                     docSet: $refs.docSet,
@@ -72,7 +82,8 @@ Audio Download Modal Dialog component.
                 abortController,
                 (percent) => {
                     tick().then(() => (downloadProgress = percent));
-                }
+                },
+                musicDirHandle
             );
             downloadProgress = 0;
 

--- a/src/lib/components/AudioDownloadModal.svelte
+++ b/src/lib/components/AudioDownloadModal.svelte
@@ -9,16 +9,13 @@ Audio Download Modal Dialog component.
     import {
         getStoredMusicDirHandle,
         isFileSystemAccessSupported,
-        pickMusicDirectory
+        pickMusicDirectory,
+        STORAGE_CHOICE_KEY
     } from '$lib/data/audioFileSystem';
     import { modal as alert, ModalType, refs, t, userSettings } from '$lib/data/stores';
     import { CheckboxIcon, CheckboxOutlineIcon } from '$lib/icons';
     import { tick } from 'svelte';
     import Modal from './Modal.svelte';
-
-    // Tracks whether the user has already been asked (once, ever) whether
-    // downloaded audio should also be saved to the filesystem.
-    const STORAGE_CHOICE_KEY = 'audio-filesystem-storage-choice';
 
     const modalId = 'audioDownloadModal';
     let modal: Modal | undefined = $state(undefined);

--- a/src/lib/components/AudioDownloadModal.svelte
+++ b/src/lib/components/AudioDownloadModal.svelte
@@ -120,7 +120,11 @@ Audio Download Modal Dialog component.
                 </div>
                 <div class="message-checkbox flex w-full">
                     <label class="flex w-full cursor-pointer items-center">
-                        <input type="checkbox" class="sr-only" bind:checked={downloadAutomatically} />
+                        <input
+                            type="checkbox"
+                            class="sr-only"
+                            bind:checked={downloadAutomatically}
+                        />
                         <div class="message-checkbox-left" aria-hidden="true">
                             {#if downloadAutomatically}
                                 <CheckboxIcon></CheckboxIcon>

--- a/src/lib/components/AudioStorageSetting.svelte
+++ b/src/lib/components/AudioStorageSetting.svelte
@@ -11,12 +11,11 @@ API), falling back to IndexedDB storage when disconnected.
         getMusicDirStatus,
         getStoredMusicDirHandle,
         pickMusicDirectory,
-        requestMusicDirPermission
+        requestMusicDirPermission,
+        STORAGE_CHOICE_KEY
     } from '$lib/data/audioFileSystem';
     import { t } from '$lib/data/stores';
     import { onMount } from 'svelte';
-
-    const STORAGE_CHOICE_KEY = 'audio-filesystem-storage-choice';
 
     // The AudioSource.folder subdirectory name(s) audio is actually written
     // into, under whichever root folder the user picks. `audio.sources` also

--- a/src/lib/components/AudioStorageSetting.svelte
+++ b/src/lib/components/AudioStorageSetting.svelte
@@ -1,0 +1,130 @@
+<!--
+@component
+Settings row that lets the user connect, change, or disconnect the on-device
+music folder that downloaded audio is saved to (via the File System Access
+API), falling back to IndexedDB storage when disconnected.
+-->
+<script lang="ts">
+    import { scriptureConfig } from '$assets/config';
+    import {
+        clearStoredMusicDirHandle,
+        getMusicDirStatus,
+        getStoredMusicDirHandle,
+        pickMusicDirectory,
+        requestMusicDirPermission
+    } from '$lib/data/audioFileSystem';
+    import { t } from '$lib/data/stores';
+    import { onMount } from 'svelte';
+
+    const STORAGE_CHOICE_KEY = 'audio-filesystem-storage-choice';
+
+    // The AudioSource.folder subdirectory name(s) audio is actually written
+    // into, under whichever root folder the user picks. `audio.sources` also
+    // holds non-audio (e.g. video) entries that happen to have a `folder`,
+    // so this must match the same "downloadable audio" filter addAudioFile
+    // and setting.ts use, not just "has a folder".
+    const audioSubfolders = Array.from(
+        new Set(
+            Object.values(scriptureConfig.audio?.sources ?? {})
+                .filter((source) => source.accessMethods?.includes('download'))
+                .map((source) => source.folder)
+                .filter((folder): folder is string => !!folder)
+        )
+    );
+
+    interface Props {
+        setting: App.UserPreferenceSetting;
+        fontSize: string;
+    }
+    let { setting, fontSize }: Props = $props();
+
+    let status: {
+        connected: boolean;
+        folderName?: string;
+        needsPermission?: boolean;
+    } = $state({ connected: false });
+
+    // The path shown to the user for the connected state: the chosen root
+    // folder's name plus the subfolder(s) audio is actually saved into -
+    // never just the root folder name, which wouldn't tell them where their
+    // files actually end up.
+    let connectedPath = $derived(
+        status.folderName
+            ? audioSubfolders.length
+                ? audioSubfolders.map((folder) => `${status.folderName}/${folder}`).join(', ')
+                : status.folderName
+            : ''
+    );
+
+    async function refreshStatus() {
+        status = await getMusicDirStatus();
+    }
+
+    onMount(refreshStatus);
+
+    async function chooseFolder() {
+        const handle = await pickMusicDirectory();
+        if (handle) {
+            localStorage.setItem(STORAGE_CHOICE_KEY, 'enabled');
+        }
+        await refreshStatus();
+    }
+
+    async function reconnect() {
+        const handle = await getStoredMusicDirHandle();
+        if (handle) {
+            await requestMusicDirPermission(handle, 'readwrite');
+        }
+        await refreshStatus();
+    }
+
+    async function disconnect() {
+        await clearStoredMusicDirHandle();
+        localStorage.setItem(STORAGE_CHOICE_KEY, 'declined');
+        await refreshStatus();
+    }
+</script>
+
+<div class="dy-form-control settings-item w-full max-w-lg">
+    <div class="settings-title py-0">
+        <div style:font-size="{fontSize}%">
+            {$t[setting.title] || setting.title}
+        </div>
+    </div>
+    <div class="settings-summary py-0 flex items-center justify-between gap-2">
+        <div style:font-size="{fontSize}%">
+            {#if status.connected && status.needsPermission}
+                {$t['Settings_Audio_Storage_Needs_Permission'] || 'Permission needed'}
+            {:else if status.connected}
+                {connectedPath}
+            {:else}
+                {$t['Settings_Audio_Storage_Not_Connected'] || 'Not connected'}
+            {/if}
+        </div>
+        {#if !status.connected}
+            <button type="button" class="dy-btn dy-btn-sm" onclick={chooseFolder}>
+                {$t['Settings_Audio_Storage_Choose'] || 'Choose folder'}
+            </button>
+        {:else if status.needsPermission}
+            <button type="button" class="dy-btn dy-btn-sm" onclick={reconnect}>
+                {$t['Settings_Audio_Storage_Reconnect'] || 'Reconnect'}
+            </button>
+        {:else}
+            <div class="flex items-center gap-2">
+                <button type="button" class="dy-btn dy-btn-sm" onclick={chooseFolder}>
+                    {$t['Settings_Audio_Storage_Change'] || 'Change'}
+                </button>
+                <button type="button" class="dy-btn dy-btn-sm" onclick={disconnect}>
+                    {$t['Settings_Audio_Storage_Disconnect'] || 'Stop'}
+                </button>
+            </div>
+        {/if}
+    </div>
+    {#if setting.summary}
+        <div class="settings-summary py-0">
+            <div style:font-size="{fontSize}%">
+                {$t[setting.summary]}
+            </div>
+        </div>
+    {/if}
+</div>

--- a/src/lib/components/AudioStorageSetting.svelte
+++ b/src/lib/components/AudioStorageSetting.svelte
@@ -17,18 +17,39 @@ API), falling back to IndexedDB storage when disconnected.
     import { t } from '$lib/data/stores';
     import { onMount } from 'svelte';
 
-    // The AudioSource.folder subdirectory name(s) audio is actually written
-    // into, under whichever root folder the user picks. `audio.sources` also
-    // holds non-audio (e.g. video) entries that happen to have a `folder`,
-    // so this must match the same "downloadable audio" filter addAudioFile
-    // and setting.ts use, not just "has a folder".
-    const audioSubfolders = Array.from(
-        new Set(
-            Object.values(scriptureConfig.audio?.sources ?? {})
-                .filter((source) => source.accessMethods?.includes('download'))
-                .map((source) => source.folder)
-                .filter((folder): folder is string => !!folder)
+    // Every `src` key actually referenced by a chapter's audio entry, across
+    // all book collections/books and their book tabs. A source not used by
+    // any chapter shouldn't be shown here even if it's otherwise
+    // download-capable and has a folder configured.
+    const usedAudioSrcKeys = new Set(
+        (scriptureConfig.bookCollections ?? []).flatMap((collection) =>
+            collection.books.flatMap((book) => [
+                ...book.audio.map((audio) => audio.src),
+                ...(book.bookTabs?.tabs.flatMap((tab) => tab.audio.map((audio) => audio.src)) ?? [])
+            ])
         )
+    );
+
+    // The AudioSource(s) whose folder subdirectory audio is actually written
+    // into, under whichever root folder the user picks. `audio.sources` also
+    // holds non-audio (e.g. video) entries and sources no chapter references,
+    // so this must match download folders ('download' type) and pre-placed
+    // folders ('folder' type, not yet implemented elsewhere) - not
+    // accessMethods, which is about download-vs-stream choice, a separate
+    // concern from whether a source writes to an on-device folder. Deduped
+    // by name+folder since distinct source keys can otherwise describe the
+    // same folder.
+    const audioSources = Array.from(
+        new Map(
+            Object.entries(scriptureConfig.audio?.sources ?? {})
+                .filter(
+                    (entry): entry is [string, (typeof entry)[1] & { folder: string }] =>
+                        usedAudioSrcKeys.has(entry[0]) &&
+                        !!entry[1].folder &&
+                        (entry[1].type === 'download' || entry[1].type === 'folder')
+                )
+                .map(([, source]) => [JSON.stringify([source.name, source.folder]), source])
+        ).values()
     );
 
     interface Props {
@@ -43,16 +64,19 @@ API), falling back to IndexedDB storage when disconnected.
         needsPermission?: boolean;
     } = $state({ connected: false });
 
-    // The path shown to the user for the connected state: the chosen root
-    // folder's name plus the subfolder(s) audio is actually saved into -
-    // never just the root folder name, which wouldn't tell them where their
-    // files actually end up.
-    let connectedPath = $derived(
+    // The path(s) shown to the user for the connected state: the chosen root
+    // folder's name plus the subfolder audio is actually saved into for each
+    // AudioSource - never just the root folder name, which wouldn't tell them
+    // where their files actually end up, and never a bare comma-joined list,
+    // which doesn't say which folder belongs to which source.
+    let connectedLines = $derived(
         status.folderName
-            ? audioSubfolders.length
-                ? audioSubfolders.map((folder) => `${status.folderName}/${folder}`).join(', ')
-                : status.folderName
-            : ''
+            ? audioSources.length
+                ? audioSources.map(
+                      (source) => `${source.name}: ${status.folderName}/${source.folder}`
+                  )
+                : [status.folderName]
+            : []
     );
 
     async function refreshStatus() {
@@ -95,7 +119,9 @@ API), falling back to IndexedDB storage when disconnected.
             {#if status.connected && status.needsPermission}
                 {$t['Settings_Audio_Storage_Needs_Permission'] || 'Permission needed'}
             {:else if status.connected}
-                {connectedPath}
+                {#each connectedLines as line}
+                    <div>{line}</div>
+                {/each}
             {:else}
                 {$t['Settings_Audio_Storage_Not_Connected'] || 'Not connected'}
             {/if}

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import config from '$assets/config';
+    import AudioStorageSetting from '$lib/components/AudioStorageSetting.svelte';
     import { language, SettingsCategory, t, userSettings } from '$lib/data/stores';
 
     interface Props {
@@ -99,6 +100,10 @@
                         <div style:font-size="{fontSize}%">{$t[setting.summary]}</div>
                     </div>
                 {/if}
+            </div>
+        {:else if setting.type === 'audio-storage'}
+            <div class:settings-separator={i > 0}>
+                <AudioStorageSetting {setting} {fontSize} />
             </div>
         {/if}
     {/each}

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import config from '$assets/config';
+    import AudioStorageSetting from '$lib/components/AudioStorageSetting.svelte';
     import {
         language,
         SettingsCategory,
@@ -115,6 +116,10 @@
                         <div style:font-size="{fontSize}%">{$t[setting.summary]}</div>
                     </div>
                 {/if}
+            </div>
+        {:else if setting.type === 'audio-storage'}
+            <div class:settings-separator={i > 0}>
+                <AudioStorageSetting {setting} {fontSize} />
             </div>
         {/if}
     {/each}

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -22,7 +22,7 @@ import { getBibleBrainUrl } from '$lib/scripts/mediaUtils';
 import { pathJoin } from '$lib/scripts/stringUtils';
 import { get } from 'svelte/store';
 import { logAudioDuration, logAudioPlay } from './analytics';
-import { findAudioFile } from './audioFilesDB';
+import { findAudioFile, recoverAudioFileFromDisk } from './audioFilesDB';
 import { resolveFilesystemAudioFile } from './audioFileSystem';
 
 export const audioFileUrls = new MRUCache<string, string>(10, (item, key) => {
@@ -747,11 +747,22 @@ export async function getAudioSourceInfo(
         const fileKey = `${item.collection}-${item.book}-${item.chapter}`;
         audioPath = audioFileUrls.get(fileKey);
         if (!audioPath) {
-            const foundAudioFile = await findAudioFile({
+            let foundAudioFile = await findAudioFile({
                 collection: item.collection || '',
                 book: item.book || '',
                 chapter: item.chapter || ''
             }); //If the audio has been downloaded already, use that.
+            if (!foundAudioFile) {
+                foundAudioFile = await recoverAudioFileFromDisk(
+                    {
+                        docSet: get(refs).docSet || '',
+                        collection: item.collection || '',
+                        book: item.book || '',
+                        chapter: item.chapter || ''
+                    },
+                    audio
+                );
+            }
             if (foundAudioFile) {
                 if (!audioFileUrls.get(fileKey)) {
                     const source =
@@ -918,11 +929,22 @@ export async function checkAudioAvailability(options?: { afterDownload?: () => v
             (!audioSource?.accessMethods?.includes('stream') &&
                 audioSource?.accessMethods?.includes('download'))
         ) {
-            const foundAudioFile = await findAudioFile({
+            let foundAudioFile = await findAudioFile({
                 collection: curRefs.collection || '',
                 book: curRefs.book || '',
                 chapter: curRefs.chapter || ''
             });
+            if (!foundAudioFile) {
+                foundAudioFile = await recoverAudioFileFromDisk(
+                    {
+                        docSet: curRefs.docSet || '',
+                        collection: curRefs.collection || '',
+                        book: curRefs.book || '',
+                        chapter: curRefs.chapter || ''
+                    },
+                    audio
+                );
+            }
             curRefs = get(refs);
             if (!foundAudioFile) {
                 let audioPath = '';

--- a/src/lib/data/audio.ts
+++ b/src/lib/data/audio.ts
@@ -23,6 +23,7 @@ import { pathJoin } from '$lib/scripts/stringUtils';
 import { get } from 'svelte/store';
 import { logAudioDuration, logAudioPlay } from './analytics';
 import { findAudioFile } from './audioFilesDB';
+import { resolveFilesystemAudioFile } from './audioFileSystem';
 
 export const audioFileUrls = new MRUCache<string, string>(10, (item, key) => {
     URL.revokeObjectURL(item);
@@ -753,9 +754,19 @@ export async function getAudioSourceInfo(
             }); //If the audio has been downloaded already, use that.
             if (foundAudioFile) {
                 if (!audioFileUrls.get(fileKey)) {
-                    audioFileUrls.put(fileKey, URL.createObjectURL(foundAudioFile.blob));
+                    const source =
+                        foundAudioFile.blob ??
+                        (foundAudioFile.filename && foundAudioFile.folder
+                            ? await resolveFilesystemAudioFile({
+                                  folder: foundAudioFile.folder,
+                                  filename: foundAudioFile.filename
+                              })
+                            : undefined);
+                    if (source) {
+                        audioFileUrls.put(fileKey, URL.createObjectURL(source));
+                    }
                 }
-                audioPath = audioFileUrls.get(fileKey)!;
+                audioPath = audioFileUrls.get(fileKey) ?? null;
             }
         }
     }

--- a/src/lib/data/audioFileSystem.ts
+++ b/src/lib/data/audioFileSystem.ts
@@ -28,7 +28,9 @@ async function openHandleDB() {
 }
 
 export function isFileSystemAccessSupported(): boolean {
-    return typeof window !== 'undefined' && 'showDirectoryPicker' in window;
+    // Permissions isn't working correctly, so disable for now.
+    return false;
+    //return typeof window !== 'undefined' && 'showDirectoryPicker' in window;
 }
 
 export async function getStoredMusicDirHandle(): Promise<FileSystemDirectoryHandle | undefined> {

--- a/src/lib/data/audioFileSystem.ts
+++ b/src/lib/data/audioFileSystem.ts
@@ -148,6 +148,41 @@ async function readAudioFile(
 }
 
 /**
+ * Probes the stored music directory for a specific file, without reading its
+ * contents. Used to recognize audio that's still on disk after the
+ * `audiofiles` IndexedDB record tracking it was cleared (e.g. by the user
+ * clearing site data), so the app doesn't re-prompt for a download it doesn't
+ * need. Never requests permission (no user gesture available here) - if
+ * permission isn't already granted, this resolves to false.
+ */
+export async function fileExistsInMusicDir(folder: string, filename: string): Promise<boolean> {
+    if (!isFileSystemAccessSupported()) {
+        return false;
+    }
+    const musicDirHandle = await getStoredMusicDirHandle();
+    if (!musicDirHandle) {
+        return false;
+    }
+    if ((await queryMusicDirPermission(musicDirHandle, 'read')) !== 'granted') {
+        return false;
+    }
+    const subdirHandle = await getAudioSubdirHandle(musicDirHandle, folder);
+    if (!subdirHandle) {
+        return false;
+    }
+    try {
+        await subdirHandle.getFileHandle(filename);
+        return true;
+    } catch (error) {
+        if (error instanceof DOMException && error.name === 'NotFoundError') {
+            return false;
+        }
+        console.error(`Error checking for audio file "${filename}":`, error);
+        return false;
+    }
+}
+
+/**
  * Status for the Settings UI: whether a music folder is connected, its name,
  * and whether permission needs to be re-granted (e.g. revoked externally).
  */

--- a/src/lib/data/audioFileSystem.ts
+++ b/src/lib/data/audioFileSystem.ts
@@ -1,0 +1,192 @@
+import { openDB, type DBSchema } from 'idb';
+
+interface DirectoryHandles extends DBSchema {
+    directoryHandles: {
+        key: string;
+        value: { id: string; handle: FileSystemDirectoryHandle };
+    };
+}
+
+const MUSIC_DIR_ID = 'musicDir';
+
+let handleDB: Awaited<ReturnType<typeof openDB<DirectoryHandles>>> | null = null;
+async function openHandleDB() {
+    if (!handleDB) {
+        handleDB = await openDB<DirectoryHandles>('audioFileSystem', 1, {
+            upgrade(db) {
+                db.createObjectStore('directoryHandles', { keyPath: 'id' });
+            }
+        });
+    }
+    return handleDB;
+}
+
+export function isFileSystemAccessSupported(): boolean {
+    return typeof window !== 'undefined' && 'showDirectoryPicker' in window;
+}
+
+export async function getStoredMusicDirHandle(): Promise<FileSystemDirectoryHandle | undefined> {
+    const db = await openHandleDB();
+    const record = await db.get('directoryHandles', MUSIC_DIR_ID);
+    return record?.handle;
+}
+
+async function storeMusicDirHandle(handle: FileSystemDirectoryHandle): Promise<void> {
+    const db = await openHandleDB();
+    await db.put('directoryHandles', { id: MUSIC_DIR_ID, handle });
+}
+
+export async function clearStoredMusicDirHandle(): Promise<void> {
+    const db = await openHandleDB();
+    await db.delete('directoryHandles', MUSIC_DIR_ID);
+}
+
+/**
+ * Opens the OS directory picker. Must be called from a user-gesture handler
+ * (e.g. a click), or the browser will reject the call.
+ */
+export async function pickMusicDirectory(): Promise<FileSystemDirectoryHandle | undefined> {
+    if (!isFileSystemAccessSupported()) {
+        return undefined;
+    }
+    try {
+        const handle = await window.showDirectoryPicker({
+            id: 'scripture-audio',
+            startIn: 'music',
+            mode: 'readwrite'
+        });
+        await storeMusicDirHandle(handle);
+        return handle;
+    } catch (error) {
+        if (error instanceof DOMException && error.name === 'AbortError') {
+            return undefined;
+        }
+        console.error('Error picking music directory:', error);
+        return undefined;
+    }
+}
+
+export async function queryMusicDirPermission(
+    handle: FileSystemDirectoryHandle,
+    mode: FileSystemPermissionMode
+): Promise<PermissionState> {
+    try {
+        return await handle.queryPermission({ mode });
+    } catch (error) {
+        console.error('Error querying music directory permission:', error);
+        return 'denied';
+    }
+}
+
+/**
+ * Must be called from a user-gesture handler, or the browser may reject/no-op the call.
+ */
+export async function requestMusicDirPermission(
+    handle: FileSystemDirectoryHandle,
+    mode: FileSystemPermissionMode
+): Promise<PermissionState> {
+    try {
+        return await handle.requestPermission({ mode });
+    } catch (error) {
+        console.error('Error requesting music directory permission:', error);
+        return 'denied';
+    }
+}
+
+export async function getAudioSubdirHandle(
+    musicDirHandle: FileSystemDirectoryHandle,
+    folder: string,
+    options?: { create?: boolean }
+): Promise<FileSystemDirectoryHandle | undefined> {
+    try {
+        return await musicDirHandle.getDirectoryHandle(folder, {
+            create: options?.create ?? false
+        });
+    } catch (error) {
+        console.error(`Error opening audio subdirectory "${folder}":`, error);
+        return undefined;
+    }
+}
+
+export async function writeAudioFile(
+    subdirHandle: FileSystemDirectoryHandle,
+    filename: string,
+    blob: Blob
+): Promise<boolean> {
+    try {
+        const fileHandle = await subdirHandle.getFileHandle(filename, { create: true });
+        const writable = await fileHandle.createWritable();
+        await writable.write(blob);
+        await writable.close();
+        return true;
+    } catch (error) {
+        console.error(`Error writing audio file "${filename}":`, error);
+        return false;
+    }
+}
+
+async function readAudioFile(
+    subdirHandle: FileSystemDirectoryHandle,
+    filename: string
+): Promise<File | undefined> {
+    try {
+        const fileHandle = await subdirHandle.getFileHandle(filename);
+        return await fileHandle.getFile();
+    } catch (error) {
+        if (error instanceof DOMException && error.name === 'NotFoundError') {
+            return undefined;
+        }
+        console.error(`Error reading audio file "${filename}":`, error);
+        return undefined;
+    }
+}
+
+/**
+ * Status for the Settings UI: whether a music folder is connected, its name,
+ * and whether permission needs to be re-granted (e.g. revoked externally).
+ */
+export async function getMusicDirStatus(): Promise<{
+    connected: boolean;
+    folderName?: string;
+    needsPermission?: boolean;
+}> {
+    if (!isFileSystemAccessSupported()) {
+        return { connected: false };
+    }
+    const handle = await getStoredMusicDirHandle();
+    if (!handle) {
+        return { connected: false };
+    }
+    const permission = await queryMusicDirPermission(handle, 'read');
+    if (permission === 'granted') {
+        return { connected: true, folderName: handle.name };
+    }
+    return { connected: true, folderName: handle.name, needsPermission: true };
+}
+
+/**
+ * Read-path entry point used by playback. Never requests permission (there's
+ * no user gesture available here) - if permission isn't already granted, this
+ * resolves to undefined so the caller treats the chapter exactly like it was
+ * never downloaded.
+ */
+export async function resolveFilesystemAudioFile(item: {
+    folder: string;
+    filename: string;
+}): Promise<File | undefined> {
+    if (!isFileSystemAccessSupported()) {
+        return undefined;
+    }
+    const musicDirHandle = await getStoredMusicDirHandle();
+    if (!musicDirHandle) {
+        return undefined;
+    }
+    if ((await queryMusicDirPermission(musicDirHandle, 'read')) !== 'granted') {
+        return undefined;
+    }
+    const subdirHandle = await getAudioSubdirHandle(musicDirHandle, item.folder);
+    if (!subdirHandle) {
+        return undefined;
+    }
+    return readAudioFile(subdirHandle, item.filename);
+}

--- a/src/lib/data/audioFileSystem.ts
+++ b/src/lib/data/audioFileSystem.ts
@@ -9,6 +9,12 @@ interface DirectoryHandles extends DBSchema {
 
 const MUSIC_DIR_ID = 'musicDir';
 
+/**
+ * localStorage key tracking whether the user has already been asked (once,
+ * ever) whether downloaded audio should also be saved to the filesystem.
+ */
+export const STORAGE_CHOICE_KEY = 'audio-filesystem-storage-choice';
+
 let handleDB: Awaited<ReturnType<typeof openDB<DirectoryHandles>>> | null = null;
 async function openHandleDB() {
     if (!handleDB) {

--- a/src/lib/data/audioFileSystem.ts
+++ b/src/lib/data/audioFileSystem.ts
@@ -28,9 +28,7 @@ async function openHandleDB() {
 }
 
 export function isFileSystemAccessSupported(): boolean {
-    // Permissions isn't working correctly, so disable for now.
-    return false;
-    //return typeof window !== 'undefined' && 'showDirectoryPicker' in window;
+    return typeof window !== 'undefined' && 'showDirectoryPicker' in window;
 }
 
 export async function getStoredMusicDirHandle(): Promise<FileSystemDirectoryHandle | undefined> {
@@ -99,6 +97,28 @@ export async function requestMusicDirPermission(
         console.error('Error requesting music directory permission:', error);
         return 'denied';
     }
+}
+
+/**
+ * Resolves the stored music directory handle with readwrite permission
+ * confirmed, requesting it if necessary. Must be called from a user-gesture
+ * handler (e.g. a click), and as close to that gesture as possible - the
+ * transient activation a click grants is short-lived, so this should run
+ * before any lengthy async work (like a download fetch), not after.
+ */
+export async function ensureWritableMusicDirHandle(): Promise<
+    FileSystemDirectoryHandle | undefined
+> {
+    if (!isFileSystemAccessSupported()) {
+        return undefined;
+    }
+    const handle = await getStoredMusicDirHandle();
+    if (!handle) {
+        return undefined;
+    }
+    const permission = await requestMusicDirPermission(handle, 'readwrite');
+    console.debug(`[audio-fs] ensureWritableMusicDirHandle: permission=${permission}`);
+    return permission === 'granted' ? handle : undefined;
 }
 
 export async function getAudioSubdirHandle(
@@ -201,6 +221,7 @@ export async function getMusicDirStatus(): Promise<{
         return { connected: false };
     }
     const permission = await queryMusicDirPermission(handle, 'readwrite');
+    console.debug(`[audio-fs] getMusicDirStatus: permission=${permission}`);
     if (permission === 'granted') {
         return { connected: true, folderName: handle.name };
     }

--- a/src/lib/data/audioFileSystem.ts
+++ b/src/lib/data/audioFileSystem.ts
@@ -163,7 +163,7 @@ export async function getMusicDirStatus(): Promise<{
     if (!handle) {
         return { connected: false };
     }
-    const permission = await queryMusicDirPermission(handle, 'read');
+    const permission = await queryMusicDirPermission(handle, 'readwrite');
     if (permission === 'granted') {
         return { connected: true, folderName: handle.name };
     }

--- a/src/lib/data/audioFilesDB.ts
+++ b/src/lib/data/audioFilesDB.ts
@@ -1,5 +1,12 @@
 import { scriptureConfig } from '$assets/config';
 import { openDB, type DBSchema } from 'idb';
+import {
+    getAudioSubdirHandle,
+    getStoredMusicDirHandle,
+    isFileSystemAccessSupported,
+    queryMusicDirPermission,
+    writeAudioFile
+} from './audioFileSystem';
 
 export interface AudioItem {
     date: number;
@@ -7,7 +14,14 @@ export interface AudioItem {
     collection: string;
     book: string;
     chapter: string;
-    blob: Blob;
+    // Present when the audio is stored in IndexedDB. Absent when stored on the
+    // filesystem instead (see `filename`/`folder`).
+    blob?: Blob;
+    // Present when stored on the filesystem: the filename inside `folder`.
+    filename?: string;
+    // Present when stored on the filesystem: the AudioSource.folder subdirectory
+    // (under the user-selected music directory) the file was written into.
+    folder?: string;
 }
 interface AudioFiles extends DBSchema {
     audiofiles: {
@@ -131,10 +145,36 @@ export async function addAudioFile(
         const blob = new Blob(chunks);
         const audioFiles = await openAudioFiles();
         const date = new Date().getTime();
-        const bookIndex = scriptureConfig.bookCollections
+        const book = scriptureConfig.bookCollections
             ?.find((x) => x.id === item.collection)
-            ?.books.findIndex((x) => x.id === item.book);
-        if (bookIndex !== undefined && bookIndex >= 0) {
+            ?.books.find((x) => x.id === item.book);
+        if (book) {
+            const chapterAudio = book.audio?.find((a) => item.chapter === '' + a.num);
+            const folder = chapterAudio
+                ? scriptureConfig.audio?.sources[chapterAudio.src]?.folder
+                : undefined;
+            if (folder && chapterAudio?.filename && isFileSystemAccessSupported()) {
+                const musicDirHandle = await getStoredMusicDirHandle();
+                const permission =
+                    musicDirHandle && (await queryMusicDirPermission(musicDirHandle, 'readwrite'));
+                if (musicDirHandle && permission === 'granted') {
+                    const subdirHandle = await getAudioSubdirHandle(musicDirHandle, folder, {
+                        create: true
+                    });
+                    if (
+                        subdirHandle &&
+                        (await writeAudioFile(subdirHandle, chapterAudio.filename, blob))
+                    ) {
+                        await audioFiles.add('audiofiles', {
+                            ...item,
+                            date,
+                            filename: chapterAudio.filename,
+                            folder
+                        });
+                        return { success: true };
+                    }
+                }
+            }
             const nextItem = { ...item, date: date, blob: blob };
             await audioFiles.add('audiofiles', nextItem);
             return { success: true };

--- a/src/lib/data/audioFilesDB.ts
+++ b/src/lib/data/audioFilesDB.ts
@@ -1,6 +1,8 @@
 import { scriptureConfig } from '$assets/config';
+import type { BookCollectionAudioConfig } from '$config';
 import { openDB, type DBSchema } from 'idb';
 import {
+    fileExistsInMusicDir,
     getAudioSubdirHandle,
     getStoredMusicDirHandle,
     isFileSystemAccessSupported,
@@ -210,4 +212,37 @@ export async function addAudioFile(
 export async function findAudioFile(item: { collection: string; book: string; chapter: string }) {
     const audioFiles = await openAudioFiles();
     return audioFiles.get('audiofiles', [item.collection, item.book, item.chapter]);
+}
+
+/**
+ * Falls back to the filesystem when `findAudioFile` finds no record - the
+ * record is lost whenever the user clears site data, even though a
+ * previously-downloaded file written to their chosen music folder is
+ * untouched by that. If the file is still there, re-creates the IndexedDB
+ * record (so this probe only has to happen once per chapter) and returns it;
+ * otherwise returns undefined so the caller prompts to download as usual.
+ */
+export async function recoverAudioFileFromDisk(
+    item: { docSet: string; collection: string; book: string; chapter: string },
+    chapterAudio: BookCollectionAudioConfig
+): Promise<AudioItem | undefined> {
+    if (!isFileSystemAccessSupported()) {
+        return undefined;
+    }
+    const folder = scriptureConfig.audio?.sources[chapterAudio.src]?.folder;
+    if (!folder) {
+        return undefined;
+    }
+    if (!(await fileExistsInMusicDir(folder, chapterAudio.filename))) {
+        return undefined;
+    }
+    const record: AudioItem = {
+        ...item,
+        date: new Date().getTime(),
+        filename: chapterAudio.filename,
+        folder
+    };
+    const audioFiles = await openAudioFiles();
+    await audioFiles.put('audiofiles', record);
+    return record;
 }

--- a/src/lib/data/audioFilesDB.ts
+++ b/src/lib/data/audioFilesDB.ts
@@ -25,12 +25,12 @@ export interface AudioItem {
 }
 interface AudioFiles extends DBSchema {
     audiofiles: {
-        key: number;
+        // [collection, book, chapter] identifies the one record kept per
+        // chapter; docSet doesn't distinguish audio content (scriptureConfig
+        // resolves audio by collection/book/chapter only), so it's stored on
+        // the record but left out of the key.
+        key: [string, string, string];
         value: AudioItem;
-        indexes: {
-            'collection, book, chapter': string[];
-            date: string;
-        };
     };
 }
 // Origins that are known to require HTTPS even though the configured URL uses
@@ -82,17 +82,36 @@ export function resetProtocolPreferences(): void {
 let audioDB: Awaited<ReturnType<typeof openDB<AudioFiles>>> | null = null;
 async function openAudioFiles() {
     if (!audioDB) {
-        audioDB = await openDB<AudioFiles>('audiofiles', 1, {
-            upgrade(db) {
-                const audioStore = db.createObjectStore('audiofiles', {
-                    keyPath: 'date'
+        audioDB = await openDB<AudioFiles>('audiofiles', 2, {
+            async upgrade(db, oldVersion, newVersion, transaction) {
+                if (oldVersion < 1) {
+                    db.createObjectStore('audiofiles', {
+                        keyPath: ['collection', 'book', 'chapter']
+                    });
+                    return;
+                }
+                // v1 keyed records by download date, so re-downloading a
+                // chapter (e.g. after filesystem storage was enabled) added a
+                // second record rather than replacing the first. Migrate the
+                // existing records to a compound key, keeping only the
+                // newest record per chapter so no downloaded audio is lost.
+                const oldStore = transaction.objectStore('audiofiles');
+                const existing = await oldStore.getAll();
+                const newestByChapter = new Map<string, AudioItem>();
+                for (const record of existing) {
+                    const key = JSON.stringify([record.collection, record.book, record.chapter]);
+                    const current = newestByChapter.get(key);
+                    if (!current || record.date > current.date) {
+                        newestByChapter.set(key, record);
+                    }
+                }
+                db.deleteObjectStore('audiofiles');
+                const newStore = db.createObjectStore('audiofiles', {
+                    keyPath: ['collection', 'book', 'chapter']
                 });
-                audioStore.createIndex('collection, book, chapter', [
-                    'collection',
-                    'book',
-                    'chapter'
-                ]);
-                audioStore.createIndex('date', ['date']);
+                await Promise.all(
+                    Array.from(newestByChapter.values(), (record) => newStore.put(record))
+                );
             }
         });
     }
@@ -165,7 +184,7 @@ export async function addAudioFile(
                         subdirHandle &&
                         (await writeAudioFile(subdirHandle, chapterAudio.filename, blob))
                     ) {
-                        await audioFiles.add('audiofiles', {
+                        await audioFiles.put('audiofiles', {
                             ...item,
                             date,
                             filename: chapterAudio.filename,
@@ -176,7 +195,7 @@ export async function addAudioFile(
                 }
             }
             const nextItem = { ...item, date: date, blob: blob };
-            await audioFiles.add('audiofiles', nextItem);
+            await audioFiles.put('audiofiles', nextItem);
             return { success: true };
         }
         return {
@@ -190,9 +209,5 @@ export async function addAudioFile(
 }
 export async function findAudioFile(item: { collection: string; book: string; chapter: string }) {
     const audioFiles = await openAudioFiles();
-    const tx = audioFiles.transaction('audiofiles', 'readonly');
-    const index = tx.store.index('collection, book, chapter');
-    const result = await index.getAll([item.collection, item.book, item.chapter]);
-    await tx.done;
-    return result[0];
+    return audioFiles.get('audiofiles', [item.collection, item.book, item.chapter]);
 }

--- a/src/lib/data/audioFilesDB.ts
+++ b/src/lib/data/audioFilesDB.ts
@@ -4,9 +4,7 @@ import { openDB, type DBSchema } from 'idb';
 import {
     fileExistsInMusicDir,
     getAudioSubdirHandle,
-    getStoredMusicDirHandle,
     isFileSystemAccessSupported,
-    queryMusicDirPermission,
     writeAudioFile
 } from './audioFileSystem';
 
@@ -128,7 +126,8 @@ export async function addAudioFile(
     },
     url: string,
     abortController: AbortController,
-    onProgress?: (percent: number) => void
+    onProgress?: (percent: number) => void,
+    musicDirHandle?: FileSystemDirectoryHandle
 ): Promise<{ success: true; error?: never } | { success: false; error: string }> {
     try {
         const response = await fetchWithProtocolFallback(url, { signal: abortController.signal });
@@ -174,27 +173,34 @@ export async function addAudioFile(
             const folder = chapterAudio
                 ? scriptureConfig.audio?.sources[chapterAudio.src]?.folder
                 : undefined;
-            if (folder && chapterAudio?.filename && isFileSystemAccessSupported()) {
-                const musicDirHandle = await getStoredMusicDirHandle();
-                const permission =
-                    musicDirHandle && (await queryMusicDirPermission(musicDirHandle, 'readwrite'));
-                if (musicDirHandle && permission === 'granted') {
-                    const subdirHandle = await getAudioSubdirHandle(musicDirHandle, folder, {
-                        create: true
+            console.debug('[audio-fs] addAudioFile: write check', {
+                folder,
+                filename: chapterAudio?.filename,
+                hasHandle: !!musicDirHandle
+            });
+            if (folder && chapterAudio?.filename && musicDirHandle) {
+                const subdirHandle = await getAudioSubdirHandle(musicDirHandle, folder, {
+                    create: true
+                });
+                if (
+                    subdirHandle &&
+                    (await writeAudioFile(subdirHandle, chapterAudio.filename, blob))
+                ) {
+                    await audioFiles.put('audiofiles', {
+                        ...item,
+                        date,
+                        filename: chapterAudio.filename,
+                        folder
                     });
-                    if (
-                        subdirHandle &&
-                        (await writeAudioFile(subdirHandle, chapterAudio.filename, blob))
-                    ) {
-                        await audioFiles.put('audiofiles', {
-                            ...item,
-                            date,
-                            filename: chapterAudio.filename,
-                            folder
-                        });
-                        return { success: true };
-                    }
+                    console.debug('[audio-fs] addAudioFile: wrote to filesystem', {
+                        folder,
+                        filename: chapterAudio.filename
+                    });
+                    return { success: true };
                 }
+                console.debug(
+                    '[audio-fs] addAudioFile: filesystem write failed, falling back to blob'
+                );
             }
             const nextItem = { ...item, date: date, blob: blob };
             await audioFiles.put('audiofiles', nextItem);

--- a/src/lib/data/fileSystemAccess.d.ts
+++ b/src/lib/data/fileSystemAccess.d.ts
@@ -1,0 +1,27 @@
+// TypeScript's bundled lib.dom.d.ts models FileSystemHandle/FileSystemDirectoryHandle
+// per the File System Entries spec, but not the newer File System Access API
+// (showDirectoryPicker, queryPermission/requestPermission), which is Chromium-only.
+// These augmentations add just enough of that surface for audioFileSystem.ts.
+
+type FileSystemPermissionMode = 'read' | 'readwrite';
+
+interface FileSystemHandlePermissionDescriptor {
+    mode?: FileSystemPermissionMode;
+}
+
+interface FileSystemHandle {
+    queryPermission(descriptor?: FileSystemHandlePermissionDescriptor): Promise<PermissionState>;
+    requestPermission(descriptor?: FileSystemHandlePermissionDescriptor): Promise<PermissionState>;
+}
+
+type WellKnownDirectory = 'desktop' | 'documents' | 'downloads' | 'music' | 'pictures' | 'videos';
+
+interface DirectoryPickerOptions {
+    id?: string;
+    mode?: FileSystemPermissionMode;
+    startIn?: FileSystemHandle | WellKnownDirectory;
+}
+
+interface Window {
+    showDirectoryPicker(options?: DirectoryPickerOptions): Promise<FileSystemDirectoryHandle>;
+}

--- a/src/lib/data/stores/setting.ts
+++ b/src/lib/data/stores/setting.ts
@@ -1,5 +1,6 @@
 import config, { scriptureConfig } from '$assets/config';
 import type { FeatureConfig } from '$config';
+import { isFileSystemAccessSupported } from '$lib/data/audioFileSystem';
 import { getDefaultLanguage } from '$lib/data/language';
 import { mergeDefaultStorage, setDefaultStorage } from '$lib/data/stores/storage';
 import { isSAB } from '$lib/scripts/configUtils';
@@ -228,6 +229,19 @@ export const userPreferenceSettings = ((): Array<App.UserPreferenceSetting> => {
                 'Settings_Audio_Download_Automatic_Wifi'
             ],
             values: ['prompt', 'auto', 'auto-wifi']
+        });
+    }
+
+    const hasAudioSourceWithFolder = Object.keys(config.audio?.sources ?? {}).some(
+        (key) => !!config.audio?.sources[key].folder
+    );
+    if (hasAudioSourceWitbDownload && hasAudioSourceWithFolder && isFileSystemAccessSupported()) {
+        settings.push({
+            type: 'audio-storage',
+            category: SettingsCategory.Audio,
+            title: 'Settings_Audio_Storage',
+            summary: 'Settings_Audio_Storage_Summary',
+            key: 'audio-storage'
         });
     }
 


### PR DESCRIPTION
This is dependent on SAB 14.4.

Windows 14.4 with the new string resources
https://drive.google.com/file/d/1kdcd_aa88Ew3f_WoDKU2ffbFJTugZ3ws/view?usp=drive_link

## Description

Downloaded chapter audio was stored as a Blob in IndexedDB, which is invisible to the OS and can't be shared between apps/devices. This adds an opt-in flow (via the File System Access API) to instead save audio as real files under a user-picked folder, in a subfolder named from the audio source's configured `folder` value, mirroring the existing native-app convention. IndexedDB remains the fallback for unsupported browsers, declined/cancelled folder selection, or any write/permission failure.

- New audioFileSystem.ts module wraps showDirectoryPicker/permission APIs and persists the chosen directory handle in IndexedDB.
- addAudioFile writes to the filesystem when a folder is configured and permission is already granted, otherwise falls back to a Blob as before.
- AudioDownloadModal offers the filesystem option once, the first time a user downloads audio.
- New Settings > Audio row (AudioStorageSetting.svelte) to connect, change, reconnect, or stop using a device folder.

## Settings

### Not Connected

<img width="641" height="190" alt="image" src="https://github.com/user-attachments/assets/243c185d-9fab-451b-8dd1-64453f02fa97" />

## Connected

<img width="510" height="167" alt="image" src="https://github.com/user-attachments/assets/8daf6d56-37e6-45dd-8944-6bd7427418e5" />

## Reconnect

<img width="642" height="186" alt="image" src="https://github.com/user-attachments/assets/d9c98077-535e-4126-a7b4-6c7cbe0249d6" />


## Dialogs

<img width="771" height="296" alt="image" src="https://github.com/user-attachments/assets/d5d427ae-3166-4c12-a5ec-fd539ced63e1" />

<img width="682" height="212" alt="image" src="https://github.com/user-attachments/assets/d272d76f-4858-47b5-8327-9710c7448960" />

### Browser permission prompt

<img width="523" height="176" alt="image" src="https://github.com/user-attachments/assets/07bf3414-cc2a-473b-a8c3-e8dabd74d1c1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional on-device audio storage using a selected music folder.
  - Added settings to choose, reconnect, change, or disconnect the storage folder.
  - Audio downloads can be saved directly to the selected folder, with automatic fallback to in-app storage.
  - Added support for locating and playing audio stored on the device.
  - Users can choose whether to enable automatic downloads to on-device storage.

- **Compatibility**
  - Storage options appear only when supported by the browser and audio configuration.
  - Older configurations automatically remove unsupported audio folder settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->