### PR TITLE
Add more deprecated colors to the list of colors to ignore

### DIFF
--- a/convert/convertConfig.ts
+++ b/convert/convertConfig.ts
@@ -486,7 +486,13 @@ function hackColorValue(
     return value;
 }
 
-const deprecatedColors = ['StatusBarColor', 'VerseBlock1Color', 'VerseBlock2Color'];
+const deprecatedColors = [
+    'StatusBarColor',
+    'VerseBlock1Color',
+    'VerseBlock2Color',
+    'AudioBarTopLine1Color',
+    'AudioBarTopLine2Color'
+];
 
 export function parseColorThemes(document: Document, verbose: number) {
     const colorThemeTags = document


### PR DESCRIPTION
- There are projects that have these colors without values. They are safe to ignore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated color-theme parsing to correctly exclude additional deprecated audio bar colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->