### PR TITLE
Fix settings styling

### DIFF
--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -2,7 +2,6 @@
     import config from '$assets/config';
     import {
         language,
-        s,
         SettingsCategory,
         t,
         theme,
@@ -27,7 +26,6 @@
         config.interfaceLanguages?.writingSystems[$language]?.fontRelativeSize
     );
     const fontSize = $derived(fontRelativeSize ? fontRelativeSize : '100');
-    console.log($s);
 </script>
 
 <!-- loops through the different settings types -->

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -2,6 +2,7 @@
     import config from '$assets/config';
     import {
         language,
+        s,
         SettingsCategory,
         t,
         theme,
@@ -26,6 +27,7 @@
         config.interfaceLanguages?.writingSystems[$language]?.fontRelativeSize
     );
     const fontSize = $derived(fontRelativeSize ? fontRelativeSize : '100');
+    console.log($s);
 </script>
 
 <!-- loops through the different settings types -->
@@ -72,15 +74,20 @@
                         {$t[setting.title] || setting.title}
                     </div>
                 </div>
-                <select
-                    class="dy-select dy-select-ghost dy-select-sm appearance-none px-0 w-full"
-                    style:font-size="{fontSize}%"
-                    bind:value={$userSettings[setting.key]}
-                >
-                    {#each setting.entries ?? [] as entry, i}
-                        <option value={setting.values![i]}>{$t[entry] || entry}</option>
-                    {/each}
-                </select>
+                <div class="settings-summary">
+                    <select
+                        class="dy-select dy-select-ghost dy-select-sm appearance-none px-0 w-full outline-none settings-select"
+                        style:font-size="{fontSize}%"
+                        bind:value={$userSettings[setting.key]}
+                    >
+                        {#each setting.entries ?? [] as entry, i}
+                            <option
+                                style="background: var(--DialogBackgroundColor); color: var(--SettingsTitleColor);"
+                                value={setting.values![i]}>{$t[entry] || entry}</option
+                            >
+                        {/each}
+                    </select>
+                </div>
                 {#if setting.summary}
                     <div class="settings-summary py-0">
                         <div style:font-size="{fontSize}%">
@@ -112,3 +119,13 @@
         {/if}
     {/each}
 {/each}
+
+<style>
+    .settings-select {
+        &:focus,
+        &:focus-within {
+            background-color: var(--DialogBackgroundColor);
+            color: var(--SettingsSummaryColor);
+        }
+    }
+</style>

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -5,6 +5,7 @@
         SettingsCategory,
         t,
         theme,
+        themeColors,
         themeIsDark,
         userSettings
     } from '$lib/data/stores';
@@ -80,7 +81,8 @@
                     >
                         {#each setting.entries ?? [] as entry, i}
                             <option
-                                style="background: var(--DialogBackgroundColor); color: var(--SettingsTitleColor);"
+                                style:background-color={$themeColors['DialogBackgroundColor']}
+                                style:color={$themeColors['SettingsTitleColor']}
                                 value={setting.values![i]}>{$t[entry] || entry}</option
                             >
                         {/each}

--- a/src/lib/components/Settings.svelte
+++ b/src/lib/components/Settings.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
     import config from '$assets/config';
-    import { language, SettingsCategory, t, userSettings } from '$lib/data/stores';
+    import {
+        language,
+        SettingsCategory,
+        t,
+        theme,
+        themeIsDark,
+        userSettings
+    } from '$lib/data/stores';
 
     interface Props {
         settings: App.UserPreferenceSetting[];
@@ -40,7 +47,9 @@
                     </div>
                     <input
                         type="checkbox"
-                        class="dy-checkbox dy-checkbox-neutral"
+                        class="dy-checkbox dy-checkbox-neutral appearance-none bg-white border-black
+         checked:bg-black text-white"
+                        class:invert={themeIsDark($theme)}
                         bind:checked={$userSettings[setting.key] as boolean}
                     />
                 </label>


### PR DESCRIPTION
Resolves #1091. This PR replaces the remaining DaisyUI color styling in Settings.ts with styling that better matches the native app. `<select>` components are difficult to style and some of the styling is simultaneously div-only and not in $s, so I had to just use the default SAB colors (As in, the ones that are in the correct style in the SAB Test PWA, which I assume is at least used in the vast majority of SAB projects because of the specificity of the color names) for part of it rather than using the SAB classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved settings controls with theme-aware checkbox colors and selector styling.
  * Updated list selectors with clearer focus states and themed menus for improved readability.
  * Enhanced settings control presentation across light and dark themes for a more consistent visual experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->