### PR TITLE
Use system font or Roboto for UI headings

### DIFF
--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -140,6 +140,7 @@ The sidebar/drawer.
             style:background-color={drawerBackgroundColor}
             style:direction={$direction}
             style:font-size="{fontSize}%"
+            style:font-family="system-ui, roboto"
         >
             <!-- Sidebar content here -->
             <a class="fill" href={resolve('/')}>

--- a/src/lib/components/TabsMenu.svelte
+++ b/src/lib/components/TabsMenu.svelte
@@ -57,6 +57,7 @@ A component to display tabbed menus.
                     class="dy-tab normal-case {active === opt ? 'dy-tab-active font-bold' : ''}"
                     style:background="none"
                     style:color={$actionBarColor}
+                    style:font-family="system-ui, roboto"
                     role="button"
                 >
                     {#if options[opt].tab?.icon}


### PR DESCRIPTION
Resolves #1113. This PR uses system-ui (With a fallback to Roboto) for items in any TabsMenu or on the Sidebar. The TabsMenu change definitely improves it compared to what we had before, but I can't see a difference on the Sidebar. It might be that certain browsers rendered it in a different font, or I might have misunderstood what needed to be changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sidebar menus and tab links to use a consistent system UI and Roboto font stack.
  * Improved typography consistency across navigation elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->