### PR TITLE
Increase left and right margins on Scripture View

### DIFF
--- a/src/lib/components/HtmlBookView.svelte
+++ b/src/lib/components/HtmlBookView.svelte
@@ -45,7 +45,7 @@ Display an HTML Book.
     }
 </script>
 
-<div class="prose" style="line-height: {lineHeight}; font-size: {fontSize};">
+<div class="prose mx-2" style="line-height: {lineHeight}; font-size: {fontSize};">
     <!-- eslint-disable-next-line svelte/no-at-html-tags -->
     {@html htmlBody}
 </div>

--- a/src/lib/components/ScriptureViewSofria.svelte
+++ b/src/lib/components/ScriptureViewSofria.svelte
@@ -2817,7 +2817,7 @@ LOGGING:
         style:font-family={font}
         style:font-size={fontSize}
         style:line-height={lineHeight}
-        class="single"
+        class="single mx-2"
         style:direction
     ></div>
 </article>


### PR DESCRIPTION
Resolves #1116. This PR increases the left and right margins within ScriptureViewSofria and HTMLBookView, increasing the margin size while keeping it within borders, if any are defined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved horizontal spacing around HTML book content.
  * Added consistent side margins to scripture content for a more balanced reading layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->