### PR TITLE
Use 15% width for layout icons (like native app)

### DIFF
--- a/src/lib/components/CollectionList.svelte
+++ b/src/lib/components/CollectionList.svelte
@@ -42,11 +42,11 @@ Custom list of collections for the LayoutOptions menu
                 style:background-color={selectedLayouts?.id === d.id
                     ? $themeColors['LayoutItemSelectedBackgroundColor']
                     : ''}
-                class="flex justify-between layout-item-block rounded-none"
+                class="flex layout-item-block rounded-none"
                 role="button"
             >
                 {#if d.image}
-                    <div class="layout-image-block self-start">
+                    <div class="layout-image-block self-start w-[15%]!">
                         <img class="layout-image" src={illustrations['./' + d.image]} />
                     </div>
                 {/if}


### PR DESCRIPTION
Also, don't want `justify-between` for text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved collection list item layout by adjusting image sizing and spacing for a more balanced appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->